### PR TITLE
Support to UTF-8 characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ io.on('connection', function (socket) {
 
       socket.on('error', function (error) { debugWebSSH2('SOCKET ERROR: ' + JSON.stringify(error)) })
 
-      stream.on('data', function (d) { socket.emit('data', d.toString('binary')) })
+      stream.on('data', function (d) { socket.emit('data', d.toString('utf-8')) })
 
       stream.on('close', function (code, signal) {
         err = { message: ((code || signal) ? (((code) ? 'CODE: ' + code : '') + ((code && signal) ? ' ' : '') + ((signal) ? 'SIGNAL: ' + signal : '')) : undefined) }


### PR DESCRIPTION
Hello, I found a problem with systems who are in UTF8. If the ssh2 connection show a UTF8 character the software show a two graphical characters. 