### PR TITLE
re-authentication support

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -35,6 +35,19 @@ app.disable('x-powered-by')
 // static files
 app.use(express.static(publicPath, expressOptions))
 
+app.get('/logout', function (req, res, next) {
+    var r = req.headers.referer || '/';
+    res.status(401).send(
+        '<html>' +
+        '    <head>' +
+        '        <meta http-equiv="refresh" content="1; url=' + r + '" />' +
+        '    </head>' +
+        '    <body>' +
+        '        <a href="' + r + '">Go Back</a>' +
+        '    </body>' +
+        '</html>');
+})
+
 app.get('/ssh/host/:host?', function (req, res, next) {
   res.sendFile(path.join(path.join(publicPath, 'client.htm')))
   // capture, assign, and validated variables

--- a/server/app.js
+++ b/server/app.js
@@ -35,7 +35,7 @@ app.disable('x-powered-by')
 // static files
 app.use(express.static(publicPath, expressOptions))
 
-app.get('/logout', function (req, res, next) {
+app.get('/reauth', function (req, res, next) {
     var r = req.headers.referer || '/';
     res.status(401).send(
         '<html>' +

--- a/server/socket.js
+++ b/server/socket.js
@@ -9,7 +9,7 @@ var SSH = require('ssh2').Client
 var termCols, termRows
 var menuData = '<a id="logBtn"><i class="fas fa-clipboard fa-fw"></i> Start Log</a>' +
   '<a id="downloadLogBtn"><i class="fas fa-download fa-fw"></i> Download Log</a>' +
-  '<a style="color:black" href="/logout"><i class="fas fa-key fa-fw"></i> Switch User</a>';
+  '<a style="color:black" href="/reauth"><i class="fas fa-key fa-fw"></i> Switch User</a>';
 
 // public
 module.exports = function socket (socket) {

--- a/server/socket.js
+++ b/server/socket.js
@@ -7,7 +7,9 @@ var SSH = require('ssh2').Client
 // var fs = require('fs')
 // var hostkeys = JSON.parse(fs.readFileSync('./hostkeyhashes.json', 'utf8'))
 var termCols, termRows
-var menuData = '<a id="logBtn"><i class="fas fa-clipboard fa-fw"></i> Start Log</a><a id="downloadLogBtn"><i class="fas fa-download fa-fw"></i> Download Log</a>'
+var menuData = '<a id="logBtn"><i class="fas fa-clipboard fa-fw"></i> Start Log</a>' +
+  '<a id="downloadLogBtn"><i class="fas fa-download fa-fw"></i> Download Log</a>' +
+  '<a style="color:black" href="/logout"><i class="fas fa-key fa-fw"></i> Switch User</a>';
 
 // public
 module.exports = function socket (socket) {


### PR DESCRIPTION
The provided patch, will add a /logout URL, which will re-request the authentication and then redirect you back to the referrer (e.g like http://localhost:2222/ssh/host/myhost.com).

It also adds a menu entry "Switch User" that opens /logout and forces re-authentication.

This probably fixes issue #51 and outdates #75 