### PR TITLE
package.json: Support node.js versions greater than 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   ],
   "engines": {
-    "node": "6"
+    "node": ">= 6"
   },
   "bugs": {
     "url": "https://github.com/billchurch/WebSSH2/issues"


### PR DESCRIPTION
Thanks for an interesting project.

This fix is needed to be able to install the dependencies using `yarn install`, since `yarn` is stricter than `npm` in terms of handling engine versions:

```
$ yarn install
yarn install v1.12.1
info No lockfile found.
[1/5] Validating package.json...
error webssh2@0.2.5: The engine "node" is incompatible with this module. Expected version "6". Got "8.12.0"
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

With this change, installing the dependencies works fine on yarn with newer node.js versions.