### PR TITLE
Bugfix for config.json not being read.

### DIFF
--- a/app/server/app.js
+++ b/app/server/app.js
@@ -2,6 +2,7 @@
 /* jshint esversion: 6, asi: true, node: true */
 // app.js
 
+var fs = require('fs')
 var path = require('path')
 var nodeRoot = path.dirname(require.main.filename)
 var configPath = path.join(nodeRoot, 'config.json')


### PR DESCRIPTION
Without this change config.json will not be loaded:
```
❯ docker build -t webssh2 .
...
❯ docker run -it -p 2222:2222 webssh2:latest
npm info it worked if it ends with ok
npm info using npm@5.3.0
npm info using node@v8.6.0
npm info lifecycle webssh2@0.2.8~prestart: webssh2@0.2.8
npm info lifecycle webssh2@0.2.8~start: webssh2@0.2.8

> webssh2@0.2.8 start /usr/src
> node index.js

WebSSH2 service reading config from: /usr/src/config.json


ERROR: Missing config.json for webssh. Current config: {"listen":{"ip":"0.0.0.0","port":2222},"user":{"name":null,"password":null},"ssh":{"host":null,"port":22,"term":"xterm-color","readyTimeout":20000,"keepaliveInterval":120000,"keepaliveCountMax":10},"terminal":{"cursorBlink":true,"scrollback":10000,"tabStopWidth":8,"bellStyle":"sound"},"header":{"text":null,"background":"green"},"session":{"name":"WebSSH2","secret":"mysecret"},"options":{"challengeButton":true,"allowreauth":true},"algorithms":{"kex":["ecdh-sha2-nistp256","ecdh-sha2-nistp384","ecdh-sha2-nistp521","diffie-hellman-group-exchange-sha256","diffie-hellman-group14-sha1"],"cipher":["aes128-ctr","aes192-ctr","aes256-ctr","aes128-gcm","aes128-gcm@openssh.com","aes256-gcm","aes256-gcm@openssh.com","aes256-cbc"],"hmac":["hmac-sha2-256","hmac-sha2-512","hmac-sha1"],"compress":["none","zlib@openssh.com","zlib"]},"serverlog":{"client":false,"server":false},"accesslog":false,"verify":false}

  See config.json.sample for details


ERROR:

  ReferenceError: fs is not defined
WebSSH2 service listening on 0.0.0.0:2222
```