### PR TITLE
feat(auth): ssh private key auth implemented via config.json

### DIFF
--- a/app/config.json.sample
+++ b/app/config.json.sample
@@ -6,10 +6,13 @@
   "user": {
     "name": null,
     "password": null
+    "privatekey": null,
   },
   "ssh": {
     "host": null,
     "port": 22,
+    "localAddress": null,
+    "localPort": null,
     "term": "xterm-color",
     "readyTimeout": 20000,
     "keepaliveInterval": 120000,

--- a/app/server/app.js
+++ b/app/server/app.js
@@ -19,7 +19,8 @@ let config = {
   },
   user: {
     name: null,
-    password: null
+    password: null,
+    privatekey: null
   },
   ssh: {
     host: null,
@@ -111,7 +112,7 @@ var app = express()
 var compression = require('compression')
 var server = require('http').Server(app)
 var myutil = require('./util')
-myutil.setDefaultCredentials(config.user.name, config.user.password);
+myutil.setDefaultCredentials(config.user.name, config.user.password, config.user.privatekey);
 var validator = require('validator')
 var io = require('socket.io')(server, { serveClient: false })
 var socket = require('./socket')
@@ -132,6 +133,7 @@ app.get('/reauth', function (req, res, next) {
   res.status(401).send('<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=' + r + '"></head><body bgcolor="#000"></body></html>')
 })
 
+// eslint-disable-next-line complexity
 app.get('/ssh/host/:host?', function (req, res, next) {
   res.sendFile(path.join(path.join(publicPath, 'client.htm')))
   // capture, assign, and validated variables

--- a/app/server/socket.js
+++ b/app/server/socket.js
@@ -108,19 +108,22 @@ module.exports = function socket (socket) {
   })
 
   conn.on('end', function connOnEnd (err) { SSHerror('CONN END BY HOST', err) })
-  conn.on('close', function connOnClose (err) { SSHerror('CONN CLOSE', err) })
+  conn.on('close', function connOnClose (err) { SSHerror('CONN CLOSE', err) }) 
   conn.on('error', function connOnError (err) { SSHerror('CONN ERROR', err) })
   conn.on('keyboard-interactive', function connOnKeyboardInteractive (name, instructions, instructionsLang, prompts, finish) {
     debugWebSSH2('conn.on(\'keyboard-interactive\')')
     finish([socket.request.session.userpassword])
   })
-  if (socket.request.session.username && socket.request.session.userpassword && socket.request.session.ssh) {
+  if (socket.request.session.username && (socket.request.session.userpassword || socket.request.session.privatekey) && socket.request.session.ssh) {
     // console.log('hostkeys: ' + hostkeys[0].[0])
     conn.connect({
       host: socket.request.session.ssh.host,
       port: socket.request.session.ssh.port,
+      localAddress: socket.request.session.ssh.localAddress,
+      localPort: socket.request.session.ssh.localPort,
       username: socket.request.session.username,
       password: socket.request.session.userpassword,
+      privateKey: socket.request.session.privatekey,
       tryKeyboard: true,
       algorithms: socket.request.session.ssh.algorithms,
       readyTimeout: socket.request.session.ssh.readyTimeout,
@@ -141,6 +144,7 @@ module.exports = function socket (socket) {
   * @param {string} myFunc Function calling this function
   * @param {object} err    error object or error message
   */
+  // eslint-disable-next-line complexity
   function SSHerror (myFunc, err) {
     var theError
     if (socket.request.session) {

--- a/app/server/util.js
+++ b/app/server/util.js
@@ -7,11 +7,12 @@ require('colors') // allow for color property extensions in log messages
 var debug = require('debug')('WebSSH2')
 var Auth = require('basic-auth')
 
-let defaultCredentials = {username: null, password: null};
+let defaultCredentials = {username: null, password: null, privatekey: null};
 
-exports.setDefaultCredentials = function (username, password) {
-    defaultCredentials.username = username;
-    defaultCredentials.password = password;
+exports.setDefaultCredentials = function (username, password, privatekey) {
+    defaultCredentials.username = username
+    defaultCredentials.password = password
+    defaultCredentials.privatekey = privatekey
 }
 
 exports.basicAuth = function basicAuth (req, res, next) {
@@ -25,8 +26,9 @@ exports.basicAuth = function basicAuth (req, res, next) {
   } else {
     req.session.username = defaultCredentials.username;
     req.session.userpassword = defaultCredentials.password;
+    req.session.privatekey = defaultCredentials.privatekey;
   }
-  if (!req.session.userpassword) {
+  if ( (!req.session.userpassword) && (!req.session.privatekey) ) {
     res.statusCode = 401
     debug('basicAuth credential request (401)')
     res.setHeader('WWW-Authenticate', 'Basic realm="WebSSH"')


### PR DESCRIPTION
If config.json is present and user.privatekey has an ssh-rsa private key defined as well as a user.name, the SSH server will staticlly authenticate to whatever host is specified on the URL with those credentials.

The ssh-rsa private key must have is line returns replaced with the litaral \n

Example: "-----BEGIN RSA PRIVATE KEY-----\nblahblahblah\n"
fixes #160 #139