### PR TITLE
Add configuration option to restrict connections to specified subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ docker run --name webssh2 -d -p 2222:2222 -v `pwd`/app/config.json:/usr/src/conf
 
 * **ssh.keepaliveCountMax** - _integer_ - How many consecutive, unanswered SSH-level keepalive packets that can be sent to the server before disconnection (similar to OpenSSH's ServerAliveCountMax config option). **Default:** 10.
 
+* **allowedSubnets** - _array_ - A list of subnets that the server is allowed to connect to via SSH. An empty array means all subnets are permitted; no restriction. **Default:** empty array.
+
 * **terminal.cursorBlink** - _boolean_ - Cursor blinks (true), does not (false) **Default:** true.
 
 * **terminal.scrollback** - _integer_ - Lines in the scrollback buffer. **Default:** 10000.

--- a/app/config.json.sample
+++ b/app/config.json.sample
@@ -16,7 +16,8 @@
     "term": "xterm-color",
     "readyTimeout": 20000,
     "keepaliveInterval": 120000,
-    "keepaliveCountMax": 10
+    "keepaliveCountMax": 10,
+    "allowedSubnets": []
   },
   "terminal": {
     "cursorBlink": true,

--- a/app/package.json
+++ b/app/package.json
@@ -42,7 +42,7 @@
     "xterm-addon-fit": "^0.3.0",
     "xterm-addon-search": "^0.3.0",
     "xterm-addon-web-links": "^0.2.1",
-    "netmask": "1.0.6"
+    "cidr-matcher": "2.1.1"
   },
   "scripts": {
     "start": "node index.js",

--- a/app/package.json
+++ b/app/package.json
@@ -41,7 +41,8 @@
     "validator": "~12.0.0",
     "xterm-addon-fit": "^0.3.0",
     "xterm-addon-search": "^0.3.0",
-    "xterm-addon-web-links": "^0.2.1"
+    "xterm-addon-web-links": "^0.2.1",
+    "netmask": "1.0.6"
   },
   "scripts": {
     "start": "node index.js",

--- a/app/server/app.js
+++ b/app/server/app.js
@@ -28,7 +28,8 @@ let config = {
     term: 'xterm-color',
     readyTimeout: 20000,
     keepaliveInterval: 120000,
-    keepaliveCountMax: 10
+    keepaliveCountMax: 10,
+    allowedSubnets: []
   },
   terminal: {
     cursorBlink: true,
@@ -153,6 +154,7 @@ app.get('/ssh/host/:host?', function (req, res, next) {
     algorithms: config.algorithms,
     keepaliveInterval: config.ssh.keepaliveInterval,
     keepaliveCountMax: config.ssh.keepaliveCountMax,
+    allowedSubnets: config.ssh.allowedSubnets,
     term: (/^(([a-z]|[A-Z]|[0-9]|[!^(){}\-_~])+)?\w$/.test(req.query.sshterm) &&
       req.query.sshterm) || config.ssh.term,
     terminal: {

--- a/app/server/socket.js
+++ b/app/server/socket.js
@@ -35,7 +35,6 @@ module.exports = function socket (socket) {
     }
     if (!permitted) {
         socket.emit('401 UNAUTHORIZED')
-        socket.emit('status', 'SSH CONNECTION ESTABLISHED')
         debugWebSSH2('SOCKET: Requested host outside configured subnets / REJECTED')
         socket.disconnect(true)
         return

--- a/app/server/socket.js
+++ b/app/server/socket.js
@@ -6,6 +6,7 @@
 var debug = require('debug')
 var debugWebSSH2 = require('debug')('WebSSH2')
 var SSH = require('ssh2').Client
+var Netmask = require('netmask').Netmask
 // var fs = require('fs')
 // var hostkeys = JSON.parse(fs.readFileSync('./hostkeyhashes.json', 'utf8'))
 var termCols, termRows
@@ -21,6 +22,26 @@ module.exports = function socket (socket) {
     socket.disconnect(true)
     return
   }
+
+  // If configured, check that requsted host is in a permitted subnet
+  if (socket.request.session.ssh.allowedSubnets.length > 0) {
+    var permitted = false;
+    for (const subnet of socket.request.session.ssh.allowedSubnets) {
+      var subnetBlock = new Netmask(subnet);
+      if (subnetBlock.contains(socket.request.session.ssh.host)) {
+        permitted = true;
+        break;
+      }
+    }
+    if (!permitted) {
+        socket.emit('401 UNAUTHORIZED')
+        socket.emit('status', 'SSH CONNECTION ESTABLISHED')
+        debugWebSSH2('SOCKET: Requested host outside configured subnets / REJECTED')
+        socket.disconnect(true)
+        return
+    }
+  }
+
   var conn = new SSH()
   socket.on('geometry', function socketOnGeometry (cols, rows) {
     termCols = cols


### PR DESCRIPTION
> Note, I've rarely worked with Node.js or Javascript in general. Beginner mistakes likely, and patience appreciated!

For security reasons, it's helpful to be able to provide a whitelist of subnets that the server is permitted to connect to via SSH. This PR introduces this functionality as an optional configuration option, defaulting to an empty array, which will result in all connections being permitted. An administrator can add CIDR blocks to this array, and this app will then treat it as a whitelist.

I'm using `cidr-matcher` which works on either IPv4 or IPv6 networks, though it should be noted that it doesn't seem this project (or perhaps the downstream ssh library) supports IPv6 at the moment, so I couldn't test v6 subnets.

# Connecting Via Hostname

One thing I haven't decided if I should do anything about is how to behave when a name (i.e. FQDN) is provided instead of an address. The current implementation isn't compatible with that scenario unless no subnets are provided (in which case no restrictions are in place). I'm guessing this is because the lookup doesn't happen until the actual connection is made in the SSH library. 

So, I could either do nothing about this and force users to connect via address if a whitelist is configured, or do my own lookup ahead of connection time and then make a decision once the address is known. I'm not crazy about the former option, but I feel like the latter option will open a whole different can of worms. Guidance welcome here.
