### PR TITLE
Allow websocket server to take ssh host as query parameter…

### DIFF
--- a/app/server/app.js
+++ b/app/server/app.js
@@ -3,105 +3,18 @@
 // app.js
 
 var path = require('path')
-var fs = require('fs')
 var nodeRoot = path.dirname(require.main.filename)
-var configPath = path.join(nodeRoot, 'config.json')
 var publicPath = path.join(nodeRoot, 'client', 'public')
-console.log('WebSSH2 service reading config from: ' + configPath)
+var config = require('./config')
 var express = require('express')
 var logger = require('morgan')
-
-// sane defaults if config.json or parts are missing
-let config = {
-  listen: {
-    ip: '0.0.0.0',
-    port: 2222
-  },
-  user: {
-    name: null,
-    password: null,
-    privatekey: null
-  },
-  ssh: {
-    host: null,
-    port: 22,
-    term: 'xterm-color',
-    readyTimeout: 20000,
-    keepaliveInterval: 120000,
-    keepaliveCountMax: 10,
-    allowedSubnets: []
-  },
-  terminal: {
-    cursorBlink: true,
-    scrollback: 10000,
-    tabStopWidth: 8,
-    bellStyle: 'sound'
-  },
-  header: {
-    text: null,
-    background: 'green'
-  },
-  session: {
-    name: 'WebSSH2',
-    secret: 'mysecret'
-  },
-  options: {
-    challengeButton: true,
-    allowreauth: true
-  },
-  algorithms: {
-    kex: [
-      'ecdh-sha2-nistp256',
-      'ecdh-sha2-nistp384',
-      'ecdh-sha2-nistp521',
-      'diffie-hellman-group-exchange-sha256',
-      'diffie-hellman-group14-sha1'
-    ],
-    cipher: [
-      'aes128-ctr',
-      'aes192-ctr',
-      'aes256-ctr',
-      'aes128-gcm',
-      'aes128-gcm@openssh.com',
-      'aes256-gcm',
-      'aes256-gcm@openssh.com',
-      'aes256-cbc'
-    ],
-    hmac: [
-      'hmac-sha2-256',
-      'hmac-sha2-512',
-      'hmac-sha1'
-    ],
-    compress: [
-      'none',
-      'zlib@openssh.com',
-      'zlib'
-    ]
-  },
-  serverlog: {
-    client: false,
-    server: false
-  },
-  accesslog: false,
-  verify: false
-}
-
-// test if config.json exists, if not provide error message but try to run
-// anyway
-try {
-  if (fs.existsSync(configPath)) {
-    console.log('ephemeral_auth service reading config from: ' + configPath)
-    config = require('read-config')(configPath)
-  } else {
-    console.error('\n\nERROR: Missing config.json for webssh. Current config: ' + JSON.stringify(config))
-    console.error('\n  See config.json.sample for details\n\n')
-  }
-} catch (err) {
-  console.error('\n\nERROR: Missing config.json for webssh. Current config: ' + JSON.stringify(config))
-  console.error('\n  See config.json.sample for details\n\n')
-  console.error('ERROR:\n\n  ' + err)
-}
-
+var app = express()
+var compression = require('compression')
+var server = require('http').Server(app)
+var myutil = require('./util')
+var io = require('socket.io')(server, { serveClient: false })
+var socket = require('./socket')
+var expressOptions = require('./expressOptions')
 var session = require('express-session')({
   secret: config.session.secret,
   name: config.session.name,
@@ -109,15 +22,6 @@ var session = require('express-session')({
   saveUninitialized: false,
   unset: 'destroy'
 })
-var app = express()
-var compression = require('compression')
-var server = require('http').Server(app)
-var myutil = require('./util')
-myutil.setDefaultCredentials(config.user.name, config.user.password, config.user.privatekey);
-var validator = require('validator')
-var io = require('socket.io')(server, { serveClient: false })
-var socket = require('./socket')
-var expressOptions = require('./expressOptions')
 
 // express
 app.use(compression({ level: 9 }))
@@ -137,44 +41,6 @@ app.get('/reauth', function (req, res, next) {
 // eslint-disable-next-line complexity
 app.get('/ssh/host/:host?', function (req, res, next) {
   res.sendFile(path.join(path.join(publicPath, 'client.htm')))
-  // capture, assign, and validated variables
-  req.session.ssh = {
-    host: (validator.isIP(req.params.host + '') && req.params.host) ||
-      (validator.isFQDN(req.params.host) && req.params.host) ||
-      (/^(([a-z]|[A-Z]|[0-9]|[!^(){}\-_~])+)?\w$/.test(req.params.host) &&
-      req.params.host) || config.ssh.host,
-    port: (validator.isInt(req.query.port + '', { min: 1, max: 65535 }) &&
-      req.query.port) || config.ssh.port,
-    localAddress: config.ssh.localAddress,
-    localPort: config.ssh.localPort,
-    header: {
-      name: req.query.header || config.header.text,
-      background: req.query.headerBackground || config.header.background
-    },
-    algorithms: config.algorithms,
-    keepaliveInterval: config.ssh.keepaliveInterval,
-    keepaliveCountMax: config.ssh.keepaliveCountMax,
-    allowedSubnets: config.ssh.allowedSubnets,
-    term: (/^(([a-z]|[A-Z]|[0-9]|[!^(){}\-_~])+)?\w$/.test(req.query.sshterm) &&
-      req.query.sshterm) || config.ssh.term,
-    terminal: {
-      cursorBlink: (validator.isBoolean(req.query.cursorBlink + '') ? myutil.parseBool(req.query.cursorBlink) : config.terminal.cursorBlink),
-      scrollback: (validator.isInt(req.query.scrollback + '', { min: 1, max: 200000 }) && req.query.scrollback) ? req.query.scrollback : config.terminal.scrollback,
-      tabStopWidth: (validator.isInt(req.query.tabStopWidth + '', { min: 1, max: 100 }) && req.query.tabStopWidth) ? req.query.tabStopWidth : config.terminal.tabStopWidth,
-      bellStyle: ((req.query.bellStyle) && (['sound', 'none'].indexOf(req.query.bellStyle) > -1)) ? req.query.bellStyle : config.terminal.bellStyle
-    },
-    allowreplay: config.options.challengeButton || (validator.isBoolean(req.headers.allowreplay + '') ? myutil.parseBool(req.headers.allowreplay) : false),
-    allowreauth: config.options.allowreauth || false,
-    mrhsession: ((validator.isAlphanumeric(req.headers.mrhsession + '') && req.headers.mrhsession) ? req.headers.mrhsession : 'none'),
-    serverlog: {
-      client: config.serverlog.client || false,
-      server: config.serverlog.server || false
-    },
-    readyTimeout: (validator.isInt(req.query.readyTimeout + '', { min: 1, max: 300000 }) &&
-      req.query.readyTimeout) || config.ssh.readyTimeout
-  }
-  if (req.session.ssh.header.name) validator.escape(req.session.ssh.header.name)
-  if (req.session.ssh.header.background) validator.escape(req.session.ssh.header.background)
 })
 
 // express error handling

--- a/app/server/config.js
+++ b/app/server/config.js
@@ -1,0 +1,98 @@
+const fs = require('fs')
+const path = require('path')
+const nodeRoot = path.dirname(require.main.filename)
+const configPath = path.join(nodeRoot, 'config.json')
+
+console.log('WebSSH2 service reading config from: ' + configPath)
+
+// sane defaults if config.json or parts are missing
+let config = {
+  listen: {
+    ip: '0.0.0.0',
+    port: 2222
+  },
+  user: {
+    name: null,
+    password: null,
+    privatekey: null
+  },
+  ssh: {
+    host: null,
+    port: 22,
+    term: 'xterm-color',
+    readyTimeout: 20000,
+    keepaliveInterval: 120000,
+    keepaliveCountMax: 10,
+    allowedSubnets: []
+  },
+  terminal: {
+    cursorBlink: true,
+    scrollback: 10000,
+    tabStopWidth: 8,
+    bellStyle: 'sound'
+  },
+  header: {
+    text: null,
+    background: 'green'
+  },
+  session: {
+    name: 'WebSSH2',
+    secret: 'mysecret'
+  },
+  options: {
+    challengeButton: true,
+    allowreauth: true
+  },
+  algorithms: {
+    kex: [
+      'ecdh-sha2-nistp256',
+      'ecdh-sha2-nistp384',
+      'ecdh-sha2-nistp521',
+      'diffie-hellman-group-exchange-sha256',
+      'diffie-hellman-group14-sha1'
+    ],
+    cipher: [
+      'aes128-ctr',
+      'aes192-ctr',
+      'aes256-ctr',
+      'aes128-gcm',
+      'aes128-gcm@openssh.com',
+      'aes256-gcm',
+      'aes256-gcm@openssh.com',
+      'aes256-cbc'
+    ],
+    hmac: [
+      'hmac-sha2-256',
+      'hmac-sha2-512',
+      'hmac-sha1'
+    ],
+    compress: [
+      'none',
+      'zlib@openssh.com',
+      'zlib'
+    ]
+  },
+  serverlog: {
+    client: false,
+    server: false
+  },
+  accesslog: false,
+  verify: false
+}
+
+// test if config.json exists, if not provide error message but try to run anyway
+try {
+  if (fs.existsSync(configPath)) {
+    console.log('ephemeral_auth service reading config from: ' + configPath)
+    config = require('read-config')(configPath)
+  } else {
+    console.error('\n\nERROR: Missing config.json for webssh. Current config: ' + JSON.stringify(config))
+    console.error('\n  See config.json.sample for details\n\n')
+  }
+} catch (err) {
+  console.error('\n\nERROR: Missing config.json for webssh. Current config: ' + JSON.stringify(config))
+  console.error('\n  See config.json.sample for details\n\n')
+  console.error('ERROR:\n\n  ' + err)
+}
+
+module.exports = config

--- a/app/server/util.js
+++ b/app/server/util.js
@@ -4,37 +4,36 @@
 
 // private
 require('colors') // allow for color property extensions in log messages
+var config = require('./config')
 var debug = require('debug')('WebSSH2')
 var Auth = require('basic-auth')
 
-let defaultCredentials = {username: null, password: null, privatekey: null};
-
-exports.setDefaultCredentials = function (username, password, privatekey) {
-    defaultCredentials.username = username
-    defaultCredentials.password = password
-    defaultCredentials.privatekey = privatekey
+exports.defaultCredentials = {
+  username: config.user.name,
+  userpassword: config.user.password,
+  privatekey: config.user.privatekey,
 }
 
 exports.basicAuth = function basicAuth (req, res, next) {
   var myAuth = Auth(req)
+  let password = exports.defaultCredentials.userpassword
+
   if (myAuth && myAuth.pass !== '') {
     req.session.username = myAuth.name
-    req.session.userpassword = myAuth.pass
+    req.session.userpassword = password = myAuth.pass
     debug('myAuth.name: ' + myAuth.name.yellow.bold.underline +
       ' and password ' + ((myAuth.pass) ? 'exists'.yellow.bold.underline
       : 'is blank'.underline.red.bold))
-  } else {
-    req.session.username = defaultCredentials.username;
-    req.session.userpassword = defaultCredentials.password;
-    req.session.privatekey = defaultCredentials.privatekey;
   }
-  if ( (!req.session.userpassword) && (!req.session.privatekey) ) {
+
+  if (!(password || exports.defaultCredentials.privatekey)) {
     res.statusCode = 401
     debug('basicAuth credential request (401)')
     res.setHeader('WWW-Authenticate', 'Basic realm="WebSSH"')
     res.end('Username and password required for web SSH service.')
     return
   }
+
   next()
 }
 


### PR DESCRIPTION
This allows sockets to be opened without requiring the user to load the client page first to set up the session. This simplifies use when using WebSSH2 with an alternative client. 

Additionally cleaned up the derivation of configuration from defaults, static config file, request params & session. Some mild renaming and shuffling of code. If any of this is against the style sensibilities of the project I'd be glad to change it.

Note: This is a still a WIP, though I wanted a general review of it earlier rather than later. There's still a few unfinished TODOs to take care of in this before merging. A bit of previous functionality I commented out while making my changes that I have to reenable. Shouldn't be too difficult.