### PR TITLE
fix missing value in the config.json sample

### DIFF
--- a/app/config.json.sample
+++ b/app/config.json.sample
@@ -71,6 +71,6 @@
     "server": false
   },
   "accesslog": false,
-  "verify": ,
+  "verify": false,
   "safeShutdownDuration": 300
 }


### PR DESCRIPTION
The value for 'verify' in config.json.sample was missing. I changed the file by adding false as it is the default value.
fix #191 