### PR TITLE
Properly ignore node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 .git
 .cache
-node_modules
+app/node_modules


### PR DESCRIPTION
It wasn't properly ignoring the node_modules and thus the produced image was quite big.
It contained everything needed for webpack if you did an `npm install` on your machine before.