### PR TITLE
fix: Fix the parameter passing problem of setDefaultCredentials to ma…

### DIFF
--- a/app/server/app.js
+++ b/app/server/app.js
@@ -23,7 +23,7 @@ const { setDefaultCredentials, basicAuth } = require('./util');
 const { webssh2debug } = require('./logging');
 const { reauth, connect, notfound, handleErrors } = require('./routes');
 
-setDefaultCredentials(config);
+setDefaultCredentials(config.user);
 
 // safe shutdown
 let remainingSeconds = config.safeShutdownDuration;


### PR DESCRIPTION
According to the parameter definition of the "setDefaultCredentials" method, "config.user" should be passed in instead of "config"