### PR TITLE
fix: removed comma from config.json.sample which caused json linting error

### DIFF
--- a/app/config.json.sample
+++ b/app/config.json.sample
@@ -6,7 +6,7 @@
   "socketio": {
     "serveClient": false,
     "path": "/ssh/socket.io",
-    "origins": ["localhost:2222"],
+    "origins": ["localhost:2222"]
   },
   "user": {
     "name": null,


### PR DESCRIPTION
In `app/config.json.sample` file there was a wrong comma.