### PR TITLE
Fix header url param to not render html

### DIFF
--- a/app/client/src/js/index.ts
+++ b/app/client/src/js/index.ts
@@ -208,7 +208,7 @@ socket.on('headerBackground', (data: string) => {
 
 socket.on('header', (data: string) => {
   if (data) {
-    header.innerHTML = data;
+    header.textContent = data;
     header.style.display = 'block';
     // header is 19px and footer is 19px, recaculate new terminal-container and resize
     terminalContainer.style.height = 'calc(100% - 38px)';


### PR DESCRIPTION
Fixes xss in header via:
`http://localhost:2222/ssh/host/mydevice.local?header=<img src=x onerror=alert('XSS')>`

Before:
![image](https://github.com/billchurch/webssh2/assets/2525601/ab3ad052-30c3-4fd9-93c4-3581cac57d6d)

After:
<img width="276" alt="image" src="https://github.com/billchurch/webssh2/assets/2525601/20b6f2e6-5d25-48bf-836c-44a3a00da80b">

Note - This could be breaking if someone is using the header for HTML rendering, however, i would say this is still justified.