### PR TITLE
fix: update misleading config.json missing message

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -123,7 +123,7 @@ export async function loadConfigAsync(): Promise<Config> {
   } catch (err: unknown) {
     const e = err as { code?: string; message?: string }
     if (e.code === 'ENOENT') {
-      debug('Missing config.json for webssh. Using default config')
+      debug('No config.json found, using environment variables and defaults')
     } else {
       debug('Error loading config.json: %s', e.message)
       const error = new ConfigError(


### PR DESCRIPTION
## Summary
- Updates the misleading error message when config.json is not found
- Changes from "Missing config.json for webssh. Using default config" to "No config.json found, using environment variables and defaults"
- Accurately reflects that environment variables are the preferred configuration method

## Resolves
Fixes #404

## Changes
- Updated debug message in `app/config.ts:126` to better reflect the configuration hierarchy

## Test Plan
- [x] All existing tests pass
- [x] Lint passes with no warnings
- [x] TypeScript type checking passes
- [x] Message only appears at debug level (normal operation)