### PR TITLE
fix: rename AuthMethod to SSHAuthMethod to avoid type naming conflict

### DIFF
--- a/app/utils/credential-extractor.ts
+++ b/app/utils/credential-extractor.ts
@@ -24,9 +24,9 @@ interface RequiredFields {
 }
 
 /**
- * Authentication method type
+ * SSH Authentication method type
  */
-export type AuthMethod = 'password' | 'privateKey' | 'both' | 'none'
+export type SSHAuthMethod = 'password' | 'privateKey' | 'both' | 'none'
 
 /**
  * Credential validation error
@@ -78,7 +78,7 @@ export function validateRequiredFields(raw: Record<string, unknown>): Result<Req
  * @returns Authentication method
  * @pure
  */
-export function extractAuthMethod(raw: Record<string, unknown>): AuthMethod {
+export function extractAuthMethod(raw: Record<string, unknown>): SSHAuthMethod {
   const password = raw['password']
   const privateKey = raw['privateKey']
 

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -107,7 +107,7 @@ export {
   convertToAuthCredentials,
   CredentialError,
   type TerminalSettings,
-  type AuthMethod
+  type SSHAuthMethod
 } from './credential-extractor.js'
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Renamed `AuthMethod` type to `SSHAuthMethod` in `credential-extractor.ts` to avoid naming conflict with auth provider's `AuthMethod` type
- Updated export in `utils/index.ts` to use the new type name
- This prevents confusion between SSH authentication methods (`password`/`privateKey`/`both`/`none`) and web authentication methods (`manual`/`basicAuth`/`post`)

## Test plan
- [x] All existing tests pass without modification
- [x] `npm run check` passes (lint, typecheck, and tests)
- [x] No breaking changes as the type was not imported anywhere in production code