### PR TITLE
Add env overrides for logging runtime controls

### DIFF
--- a/DOCS/configuration/ENVIRONMENT-VARIABLES.md
+++ b/DOCS/configuration/ENVIRONMENT-VARIABLES.md
@@ -186,6 +186,35 @@ WEBSSH2_SSH_ALGORITHMS_KEX="ecdh-sha2-nistp256,ecdh-sha2-nistp384"
 | `WEBSSH2_HEADER_TEXT` | string | `null` | Header text in web interface |
 | `WEBSSH2_HEADER_BACKGROUND` | string | `green` | Header background color |
 
+### Logging
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `WEBSSH2_LOGGING_FORMAT` | string | `json` | Structured log output format (`json` only at present) |
+| `WEBSSH2_LOGGING_LEVEL` | string | `info` | Global minimum log level (`debug`, `info`, `warn`, `error`) |
+| `WEBSSH2_LOGGING_STDOUT_ENABLED` | boolean | `true` | Enables stdout transport when `true` |
+| `WEBSSH2_LOGGING_STDOUT_MIN_LEVEL` | string | `info` | Per-transport minimum level for stdout delivery |
+| `WEBSSH2_LOGGING_SYSLOG_ENABLED` | boolean | `false` | Enables RFC 5424/TLS syslog forwarding |
+| `WEBSSH2_LOGGING_SYSLOG_HOST` | string | `null` | Syslog collector hostname or IP |
+| `WEBSSH2_LOGGING_SYSLOG_PORT` | number | `6514` | Syslog collector port (TLS default) |
+| `WEBSSH2_LOGGING_SYSLOG_APP_NAME` | string | `webssh2` | Syslog `APP-NAME` field |
+| `WEBSSH2_LOGGING_SYSLOG_ENTERPRISE_ID` | number | `32473` | Enterprise ID for structured data (`webssh2@<ID>`) |
+| `WEBSSH2_LOGGING_SYSLOG_TLS_ENABLED` | boolean | `true` | Enables TLS transport as per RFC 5425 |
+| `WEBSSH2_LOGGING_SYSLOG_TLS_CA_FILE` | string | `null` | Path to CA bundle when TLS is enabled |
+| `WEBSSH2_LOGGING_SYSLOG_TLS_CERT_FILE` | string | `null` | Path to client certificate for mutual TLS |
+| `WEBSSH2_LOGGING_SYSLOG_TLS_KEY_FILE` | string | `null` | Path to private key paired with client cert |
+| `WEBSSH2_LOGGING_SYSLOG_TLS_REJECT_UNAUTHORIZED` | boolean | `true` | Reject syslog server certificates failing validation |
+| `WEBSSH2_LOGGING_SYSLOG_BUFFER_SIZE` | number | `1000` | Maximum in-memory message backlog before drop |
+| `WEBSSH2_LOGGING_SYSLOG_FLUSH_INTERVAL_MS` | number | `1000` | Flush cadence for buffered syslog messages |
+| `WEBSSH2_LOGGING_SYSLOG_INCLUDE_JSON` | boolean | `false` | Attach JSON payload after syslog structured data |
+| `WEBSSH2_LOGGING_SAMPLING_DEFAULT_RATE` | number | `1` | Default probability (0-1) for emitting sampled events |
+| `WEBSSH2_LOGGING_SAMPLING_RULES` | string | `null` | JSON array of sampling overrides (`[{"target":"*","sampleRate":0.25}]`) |
+| `WEBSSH2_LOGGING_RATE_LIMIT_RULES` | string | `null` | JSON describing token-bucket rules (`[{"target":"ssh_command","limit":5,"intervalMs":1000,"burst":5}]`) |
+| `WEBSSH2_LOGGING_RELOAD_ENABLED` | boolean | `false` | Enables runtime polling for logging control reload |
+| `WEBSSH2_LOGGING_RELOAD_INTERVAL_MS` | number | `null` | Optional reload interval override in milliseconds |
+
+> **Note:** Syslog variables are part of the roadmap and are documented for planning only; the transport implementation ships in a later phase. When providing complex JSON values (such as `WEBSSH2_LOGGING_RATE_LIMIT_RULES` or `WEBSSH2_LOGGING_SAMPLING_RULES`), wrap the payload in single quotes to prevent shell interpolation. Sampling rules can be supplied via `config.json` for richer targeting (per-event overrides).
+
 ## Quick Start Examples
 
 Set common settings using environment variables (preferred):

--- a/app/app.ts
+++ b/app/app.ts
@@ -8,7 +8,7 @@ import { applyMiddleware } from './middleware.js'
 import { createServer, startServer } from './server.js'
 import { configureSocketIO } from './io.js'
 import { handleError, ConfigError } from './errors.js'
-import { createNamespacedDebug } from './logger.js'
+import { createNamespacedDebug, applyLoggingConfiguration } from './logger.js'
 import { MESSAGES } from './constants.js'
 import { getClientPublicPath } from './client-path.js'
 import type { Config } from './types/config.js'
@@ -49,6 +49,8 @@ export async function initializeServerAsync(): Promise<{
   try {
     const appConfig = await getConfig()
     debug('Configuration loaded asynchronously')
+
+    applyLoggingConfiguration(appConfig.logging)
 
     // Initialize DI container and services
     const container = initializeGlobalContainer(appConfig)

--- a/app/auth/auth-pipeline.ts
+++ b/app/auth/auth-pipeline.ts
@@ -3,22 +3,27 @@
 
 import type { IncomingMessage } from 'node:http'
 import { createNamespacedDebug } from '../logger.js'
-import { isValidCredentials } from '../validation/index.js'
+import { isValidCredentials, type Credentials } from '../validation/index.js'
 import { maskSensitive } from '../utils/data-masker.js'
-import type { Credentials } from '../validation/index.js'
 import type { Config } from '../types/config.js'
 import type { AuthSession } from './auth-utils.js'
 import {
-  type AuthProvider,
-  type AuthMethod,
   BasicAuthProvider,
   PostAuthProvider,
+  type AuthProvider as InternalAuthProvider,
+  type AuthMethod as InternalAuthMethod
 } from './providers/index.js'
+
+type AuthProvider = InternalAuthProvider
+type AuthMethod = InternalAuthMethod
 
 const debug = createNamespacedDebug('auth-pipeline')
 
 // Re-export types for backward compatibility
-export type { AuthMethod, AuthProvider } from './providers/index.js'
+export type {
+  InternalAuthMethod as AuthMethod,
+  InternalAuthProvider as AuthProvider
+}
 
 type ExtendedRequest = IncomingMessage & {
   session?: AuthSession

--- a/app/auth/auth-utils.ts
+++ b/app/auth/auth-utils.ts
@@ -7,27 +7,11 @@ import { DEFAULTS } from '../constants.js'
 import { createNamespacedDebug } from '../logger.js'
 import type { Config } from '../types/config.js'
 
-// Re-export types from pure modules
-export type { 
-  HeaderOverride, 
-  HeaderValues, 
-  SourceType 
-} from './header-processor.js'
-
-export type {
-  SshCredentials,
-  ConnectionParams,
-  ValidatedConnection
-} from './credential-processor.js'
-
-export type {
-  RecordingParams
-} from './session-processor.js'
-
-// Import pure functions
 import {
   processHeaderParams,
-  type HeaderOverride
+  type HeaderOverride,
+  type HeaderValues,
+  type SourceType
 } from './header-processor.js'
 
 import {
@@ -36,13 +20,20 @@ import {
   createSshCredentials,
   maskCredentials,
   extractReadyTimeout,
-  type SshCredentials
+  type SshCredentials,
+  type ConnectionParams,
+  type ValidatedConnection
 } from './credential-processor.js'
 
 import {
   extractEnvironmentVars,
-  extractRecordingParams
+  extractRecordingParams,
+  type RecordingParams
 } from './session-processor.js'
+
+export type { HeaderOverride, HeaderValues, SourceType }
+export type { SshCredentials, ConnectionParams, ValidatedConnection }
+export type { RecordingParams }
 
 const debug = createNamespacedDebug('auth-utils')
 

--- a/app/config/env-mapper.ts
+++ b/app/config/env-mapper.ts
@@ -1,8 +1,7 @@
 // app/config/env-mapper.ts
 // Pure functions for mapping environment variables to configuration
 
-import type { EnvValueType } from './env-parser.js'
-import { parseEnvValue } from './env-parser.js'
+import { parseEnvValue, type EnvValueType } from './env-parser.js'
 import { getAlgorithmPreset } from './algorithm-presets.js'
 import { createSafeKey, safeGet, safePathToKeys, safeSetNested } from '../utils/index.js'
 

--- a/app/config/env-mapper.ts
+++ b/app/config/env-mapper.ts
@@ -61,6 +61,24 @@ export const ENV_VAR_MAPPING: Record<string, EnvVarMap> = {
   WEBSSH2_SSO_HEADER_USERNAME: { path: 'sso.headerMapping.username', type: 'string' },
   WEBSSH2_SSO_HEADER_PASSWORD: { path: 'sso.headerMapping.password', type: 'string' },
   WEBSSH2_SSO_HEADER_SESSION: { path: 'sso.headerMapping.session', type: 'string' },
+  WEBSSH2_LOGGING_LEVEL: { path: 'logging.minimumLevel', type: 'string' },
+  WEBSSH2_LOGGING_SAMPLING_DEFAULT_RATE: {
+    path: 'logging.controls.sampling.defaultSampleRate',
+    type: 'number'
+  },
+  WEBSSH2_LOGGING_SAMPLING_RULES: {
+    path: 'logging.controls.sampling.rules',
+    type: 'json'
+  },
+  WEBSSH2_LOGGING_RATE_LIMIT_RULES: {
+    path: 'logging.controls.rateLimit.rules',
+    type: 'json'
+  },
+  WEBSSH2_LOGGING_RELOAD_ENABLED: { path: 'logging.reload.enabled', type: 'boolean' },
+  WEBSSH2_LOGGING_RELOAD_INTERVAL_MS: {
+    path: 'logging.reload.intervalMs',
+    type: 'number'
+  },
 }
 
 /**

--- a/app/config/env-parser.ts
+++ b/app/config/env-parser.ts
@@ -1,7 +1,16 @@
 // app/config/env-parser.ts
 // Pure functions for parsing environment variable values
 
-export type EnvValueType = 'string' | 'number' | 'boolean' | 'array' | 'preset'
+export type EnvValueType = 'string' | 'number' | 'boolean' | 'array' | 'preset' | 'json'
+
+export type ParsedEnvValue =
+  | string
+  | number
+  | boolean
+  | string[]
+  | Record<string, unknown>
+  | unknown[]
+  | null
 
 /**
  * Parse a comma-separated or JSON array string into array
@@ -41,7 +50,7 @@ export function parseArrayValue(value: string): string[] {
 export function parseEnvValue(
   value: string,
   type: EnvValueType
-): string | number | boolean | string[] | null {
+): ParsedEnvValue {
   if (value === 'null') {
     return null
   }
@@ -54,7 +63,7 @@ export function parseEnvValue(
     case 'boolean':
       return value === 'true' || value === '1'
     case 'number':
-      return Number.parseInt(value, 10)
+      return Number.parseFloat(value)
     case 'array':
       return parseArrayValue(value)
     case 'string':
@@ -62,7 +71,24 @@ export function parseEnvValue(
     case 'preset':
       // Presets are handled upstream; return raw value
       return value
+    case 'json':
+      return parseJsonValue(value)
   }
+}
+
+function parseJsonValue(value: string): Record<string, unknown> | unknown[] | null {
+  try {
+    const parsed = JSON.parse(value) as unknown
+    if (Array.isArray(parsed)) {
+      return parsed
+    }
+    if (parsed !== null && typeof parsed === 'object') {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    return null
+  }
+  return null
 }
 
 /**

--- a/app/config/env-parser.ts
+++ b/app/config/env-parser.ts
@@ -80,10 +80,12 @@ function parseJsonValue(value: string): Record<string, unknown> | unknown[] | nu
   try {
     const parsed = JSON.parse(value) as unknown
     if (Array.isArray(parsed)) {
-      return parsed
+      const arrayValue = parsed as unknown[]
+      return arrayValue
     }
     if (parsed !== null && typeof parsed === 'object') {
-      return parsed as Record<string, unknown>
+      const objectValue = parsed as Record<string, unknown>
+      return objectValue
     }
   } catch {
     return null

--- a/app/errors.ts
+++ b/app/errors.ts
@@ -5,7 +5,7 @@ import { logError, createNamespacedDebug } from './logger.js'
 import { HTTP, MESSAGES } from './constants.js'
 import { WebSSH2Error } from './errors/webssh2-error.js'
 
-export { WebSSH2Error } from './errors/webssh2-error.js'
+export { WebSSH2Error }
 export { ConfigError } from './errors/config-error.js'
 export { SSHConnectionError } from './errors/ssh-connection-error.js'
 

--- a/app/logger.ts
+++ b/app/logger.ts
@@ -4,9 +4,9 @@
 import createDebug, { type Debugger } from 'debug'
 import {
   createStructuredLogger,
-  type StructuredLoggerOptions
+  type StructuredLoggerOptions,
+  type StructuredLogger
 } from './logging/structured-logger.js'
-import type { StructuredLogger } from './logging/structured-logger.js'
 import type { LogContext } from './logging/log-context.js'
 import type { Config, LoggingConfig } from './types/config.js'
 
@@ -74,8 +74,4 @@ export function applyLoggingConfiguration(logging?: LoggingConfig): void {
 }
 
 export { createStructuredLogger } from './logging/structured-logger.js'
-export type {
-  StructuredLogger,
-  StructuredLoggerOptions,
-  StructuredLoggerMetrics
-} from './logging/structured-logger.js'
+export type { StructuredLogger, StructuredLoggerOptions, StructuredLoggerMetrics } from './logging/structured-logger.js'

--- a/app/logger.ts
+++ b/app/logger.ts
@@ -4,28 +4,41 @@
 import createDebug, { type Debugger } from 'debug'
 import {
   createStructuredLogger,
-  type StructuredLogger,
   type StructuredLoggerOptions
 } from './logging/structured-logger.js'
+import type { StructuredLogger } from './logging/structured-logger.js'
 import type { LogContext } from './logging/log-context.js'
+import type { Config, LoggingConfig } from './types/config.js'
 
-const defaultStructuredLogger = createStructuredLogger({
+let defaultStructuredLogger = createStructuredLogger({
   namespace: 'webssh2:app',
   minimumLevel: 'info'
 })
+
+export interface AppStructuredLoggerOptions extends StructuredLoggerOptions {
+  readonly config?: Config
+}
 
 export function createNamespacedDebug(namespace: string): Debugger {
   return createDebug(`webssh2:${namespace}`)
 }
 
 export function createAppStructuredLogger(
-  options: StructuredLoggerOptions = {}
+  options: AppStructuredLoggerOptions = {}
 ): StructuredLogger {
+  const { config, ...rest } = options
+  const loggingConfig = config?.logging
+
+  const namespace =
+    rest.namespace ?? loggingConfig?.namespace ?? 'webssh2:app'
+  const minimumLevel = rest.minimumLevel ?? loggingConfig?.minimumLevel
+  const controls = rest.controls ?? loggingConfig?.controls
+
   return createStructuredLogger({
-    namespace: options.namespace ?? 'webssh2:app',
-    ...(options.minimumLevel === undefined ? {} : { minimumLevel: options.minimumLevel }),
-    ...(options.transport === undefined ? {} : { transport: options.transport }),
-    ...(options.clock === undefined ? {} : { clock: options.clock })
+    ...rest,
+    namespace,
+    ...(minimumLevel === undefined ? {} : { minimumLevel }),
+    ...(controls === undefined ? {} : { controls })
   })
 }
 
@@ -52,5 +65,17 @@ export function logError(message: string, error?: Error, context?: Partial<LogCo
   }
 }
 
-export { createStructuredLogger, type StructuredLogger, type StructuredLoggerOptions } from './logging/structured-logger.js'
+export function applyLoggingConfiguration(logging?: LoggingConfig): void {
+  defaultStructuredLogger = createStructuredLogger({
+    namespace: logging?.namespace ?? 'webssh2:app',
+    minimumLevel: logging?.minimumLevel ?? 'info',
+    ...(logging?.controls === undefined ? {} : { controls: logging.controls })
+  })
+}
 
+export { createStructuredLogger } from './logging/structured-logger.js'
+export type {
+  StructuredLogger,
+  StructuredLoggerOptions,
+  StructuredLoggerMetrics
+} from './logging/structured-logger.js'

--- a/app/logging/structured-logger.ts
+++ b/app/logging/structured-logger.ts
@@ -7,13 +7,33 @@ import type { LogLevel } from './levels.js'
 import { shouldLog } from './levels.js'
 import type { Result } from '../types/result.js'
 import { err, ok } from '../utils/result.js'
-import { createStdoutTransport, type LogTransport } from './stdout-transport.js'
+import {
+  createStdoutTransport,
+  type LogTransport,
+  TransportBackpressureError
+} from './stdout-transport.js'
+import type { LoggingControlsConfig } from '../types/config.js'
+import {
+  createLoggingControlState,
+  evaluateLoggingControls,
+  type LoggingControlState
+} from '../services/logging/controls.js'
 
 export interface StructuredLoggerOptions {
   readonly minimumLevel?: LogLevel
   readonly namespace?: string
   readonly transport?: LogTransport
   readonly clock?: () => Date
+  readonly controls?: LoggingControlsConfig
+  readonly random?: () => number
+}
+
+export interface StructuredLoggerMetrics {
+  readonly published: number
+  readonly droppedBySampling: number
+  readonly droppedByRateLimit: number
+  readonly droppedByQueue: number
+  readonly lastError?: Error
 }
 
 export interface StructuredLogger {
@@ -23,6 +43,8 @@ export interface StructuredLogger {
   warn(entry: Omit<StructuredLogInput, 'level'>): Result<void>
   error(entry: Omit<StructuredLogInput, 'level'>): Result<void>
   flush(): Result<void>
+  updateControls(config: LoggingControlsConfig | undefined): void
+  snapshotMetrics(): StructuredLoggerMetrics
 }
 
 const DEFAULT_MINIMUM_LEVEL: LogLevel = 'info'
@@ -30,27 +52,69 @@ const DEFAULT_MINIMUM_LEVEL: LogLevel = 'info'
 export function createStructuredLogger(options: StructuredLoggerOptions = {}): StructuredLogger {
   const minimumLevel = options.minimumLevel ?? DEFAULT_MINIMUM_LEVEL
   const transport = options.transport ?? createStdoutTransport()
+  const randomFn = options.random ?? Math.random
+  let controlsConfig = options.controls
+  let controlState: LoggingControlState = createLoggingControlState()
+  let queueDropCount = 0
+  let lastPublishError: Error | undefined
+
+  const baseClock = options.clock ?? (() => new Date())
 
   const log = (entry: StructuredLogInput): Result<void> => {
-    if (!shouldLog(entry.level, minimumLevel)) {
+    if (shouldLog(entry.level, minimumLevel) === false) {
       return ok(undefined)
     }
 
-    const formatOptions: FormatStructuredLogOptions = {
-      ...(options.clock === undefined ? {} : { clock: options.clock }),
+    const preparation = prepareLogEntry({
+      entry,
+      controls: controlsConfig,
+      state: controlState,
+      random: randomFn,
+      clock: baseClock,
       ...(options.namespace === undefined ? {} : { namespace: options.namespace })
+    })
+
+    if (preparation.ok === false) {
+      return err(preparation.error)
     }
 
-    const formatted = formatStructuredLog(entry, formatOptions)
+    const prepared = preparation.value
+    controlState = prepared.state
 
-    if (!formatted.ok) {
-      return err(formatted.error)
+    if (prepared.skip === true || prepared.payload === undefined) {
+      return ok(undefined)
     }
 
-    return transport.publish(formatted.value)
+    const publishResult = transport.publish(prepared.payload)
+    if (publishResult.ok === false) {
+      if (publishResult.error instanceof TransportBackpressureError) {
+        queueDropCount += 1
+        controlState = rollbackPublished(controlState)
+        lastPublishError = publishResult.error
+        return ok(undefined)
+      }
+      lastPublishError = publishResult.error
+      return err(publishResult.error)
+    }
+
+    lastPublishError = undefined
+    return ok(undefined)
   }
 
   const flush = (): Result<void> => transport.flush()
+
+  const updateControls = (config: LoggingControlsConfig | undefined): void => {
+    controlsConfig = config
+    controlState = createLoggingControlState()
+  }
+
+  const snapshotMetrics = (): StructuredLoggerMetrics => ({
+    published: controlState.metrics.published,
+    droppedBySampling: controlState.metrics.droppedBySampling,
+    droppedByRateLimit: controlState.metrics.droppedByRateLimit,
+    droppedByQueue: queueDropCount,
+    ...(lastPublishError === undefined ? {} : { lastError: lastPublishError })
+  })
 
   return {
     log,
@@ -58,6 +122,70 @@ export function createStructuredLogger(options: StructuredLoggerOptions = {}): S
     info: (entry) => log({ ...entry, level: 'info' }),
     warn: (entry) => log({ ...entry, level: 'warn' }),
     error: (entry) => log({ ...entry, level: 'error' }),
-    flush
+    flush,
+    updateControls,
+    snapshotMetrics
   }
+}
+
+function rollbackPublished(state: LoggingControlState): LoggingControlState {
+  const metrics = state.metrics
+  const published = metrics.published > 0 ? metrics.published - 1 : 0
+
+  return {
+    rateLimitBuckets: state.rateLimitBuckets,
+    metrics: {
+      published,
+      droppedBySampling: metrics.droppedBySampling,
+      droppedByRateLimit: metrics.droppedByRateLimit
+    }
+  }
+}
+
+interface PreparedLogEntry {
+  readonly skip: boolean
+  readonly payload?: string
+  readonly state: LoggingControlState
+}
+
+interface PrepareLogEntryOptions {
+  readonly entry: StructuredLogInput
+  readonly controls: LoggingControlsConfig | undefined
+  readonly state: LoggingControlState
+  readonly random: () => number
+  readonly clock: () => Date
+  readonly namespace?: string
+}
+
+function prepareLogEntry(options: PrepareLogEntryOptions): Result<PreparedLogEntry> {
+  const now = options.clock()
+  const timestamp = now.getTime()
+  if (Number.isNaN(timestamp)) {
+    return err(new Error('Clock produced invalid date'))
+  }
+
+  const decision = evaluateLoggingControls({
+    event: options.entry.event,
+    nowMs: timestamp,
+    ...(options.controls === undefined ? {} : { config: options.controls }),
+    state: options.state,
+    random: options.random
+  })
+
+  const updatedState = decision.updatedState
+  if (decision.allow === false) {
+    return ok({ skip: true, state: updatedState })
+  }
+
+  const formatOptions: FormatStructuredLogOptions = {
+    clock: () => now,
+    ...(options.namespace === undefined ? {} : { namespace: options.namespace })
+  }
+
+  const formatted = formatStructuredLog(options.entry, formatOptions)
+  if (formatted.ok === false) {
+    return err(formatted.error)
+  }
+
+  return ok({ skip: false, payload: formatted.value, state: updatedState })
 }

--- a/app/logging/structured-logger.ts
+++ b/app/logging/structured-logger.ts
@@ -3,8 +3,7 @@
 
 import { formatStructuredLog, type FormatStructuredLogOptions } from './formatter.js'
 import type { StructuredLogInput } from './structured-log.js'
-import type { LogLevel } from './levels.js'
-import { shouldLog } from './levels.js'
+import { shouldLog, type LogLevel } from './levels.js'
 import type { Result } from '../types/result.js'
 import { err, ok } from '../utils/result.js'
 import {

--- a/app/middleware/index.ts
+++ b/app/middleware/index.ts
@@ -12,11 +12,13 @@ import type { Config } from '../types/config.js'
 
 // Re-export individual middleware creators
 export { createAuthMiddleware } from './auth.middleware.js'
-export { createSessionMiddleware } from './session.middleware.js'
-export { createBodyParserMiddleware } from './body-parser.middleware.js'
-export { createCookieMiddleware } from './cookie.middleware.js'
-export { createSSOAuthMiddleware } from './sso.middleware.js'
-export { createCSRFMiddleware } from './csrf.middleware.js'
+export {
+  createSessionMiddleware,
+  createBodyParserMiddleware,
+  createCookieMiddleware,
+  createSSOAuthMiddleware,
+  createCSRFMiddleware
+}
 
 /**
  * Apply all middleware to the Express application

--- a/app/routes/routes-v2.ts
+++ b/app/routes/routes-v2.ts
@@ -5,11 +5,10 @@ import express, { type Router, type Request, type Response } from 'express'
 import handleConnection from '../connectionHandler.js'
 import { createNamespacedDebug } from '../logger.js'
 import { createAuthMiddleware } from '../middleware.js'
-import { processAuthParameters } from '../auth/auth-utils.js'
+import { processAuthParameters, type AuthSession } from '../auth/auth-utils.js'
 import { validateSshCredentials } from '../connection/index.js'
 import { HTTP } from '../constants.js'
 import type { Config } from '../types/config.js'
-import type { AuthSession } from '../auth/auth-utils.js'
 import { createSafeKey, safeGet } from '../utils/safe-property-access.js'
 
 // Import pure handlers

--- a/app/server.ts
+++ b/app/server.ts
@@ -1,7 +1,6 @@
 import type { Application } from 'express'
-import type { Server as HttpServer } from 'node:http'
+import http, { type Server as HttpServer } from 'node:http'
 import type { Config } from './types/config.js'
-import http from 'node:http'
 import debug from 'debug'
 
 const serverDebug = debug('webssh:server')

--- a/app/services/auth/auth-service.ts
+++ b/app/services/auth/auth-service.ts
@@ -9,10 +9,13 @@ import type {
   Credentials,
   ServiceDependencies
 } from '../interfaces.js'
-import type { SessionId, UserId } from '../../types/branded.js'
-import type { Result } from '../../state/types.js'
-import { ok, err } from '../../state/types.js'
-import { createSessionId, createUserId } from '../../types/branded.js'
+import {
+  createSessionId,
+  createUserId,
+  type SessionId,
+  type UserId
+} from '../../types/branded.js'
+import { ok, err, type Result } from '../../state/types.js'
 import type { SessionStore } from '../../state/store.js'
 import { DEFAULTS } from '../../constants.js'
 // import { UnifiedAuthPipeline } from '../../auth/auth-pipeline.js' // Not used yet

--- a/app/services/factory.ts
+++ b/app/services/factory.ts
@@ -119,12 +119,14 @@ export function createLogger(
 }
 
 export function createServiceStructuredLogger(
+  config: Config,
   options: StructuredLoggerOptions = {}
 ): StructuredLogger {
   const namespace = options.namespace ?? 'webssh2:services'
   return createAppStructuredLogger({
     ...options,
-    namespace
+    namespace,
+    config
   })
 }
 
@@ -155,7 +157,7 @@ export function bootstrapServices(config: Config): {
     config,
     logger,
     store,
-    createStructuredLogger: createServiceStructuredLogger
+    createStructuredLogger: (options) => createServiceStructuredLogger(config, options)
   }
 
   // Create services

--- a/app/services/logging/controls.ts
+++ b/app/services/logging/controls.ts
@@ -1,0 +1,358 @@
+// app/services/logging/controls.ts
+// Pure utilities for evaluating logging sampling and rate limit controls
+
+import type {
+  LoggingControlsConfig,
+  LoggingRateLimitRule,
+  LoggingSamplingRule
+} from '../../types/config.js'
+
+export interface LoggingControlMetrics {
+  readonly published: number
+  readonly droppedBySampling: number
+  readonly droppedByRateLimit: number
+}
+
+export interface LoggingControlState {
+  readonly rateLimitBuckets: ReadonlyMap<string, RateLimitBucketState>
+  readonly metrics: LoggingControlMetrics
+}
+
+export interface LoggingControlDecisionDetails {
+  readonly samplingRate?: number
+  readonly rateLimit?: {
+    readonly target: string
+    readonly remainingTokens: number
+  }
+}
+
+export interface LoggingControlDecision {
+  readonly allow: boolean
+  readonly reason?: 'sampling' | 'rate_limit'
+  readonly details?: LoggingControlDecisionDetails
+  readonly updatedState: LoggingControlState
+}
+
+export interface EvaluateLoggingControlsOptions {
+  readonly event: string
+  readonly nowMs: number
+  readonly config?: LoggingControlsConfig
+  readonly state?: LoggingControlState
+  readonly random?: () => number
+}
+
+interface RateLimitEvaluationResult {
+  readonly allow: boolean
+  readonly buckets: ReadonlyMap<string, RateLimitBucketState>
+  readonly appliedRule?: LoggingRateLimitRule
+  readonly remainingTokens?: number
+}
+
+interface SamplingEvaluationResult {
+  readonly allow: boolean
+  readonly appliedRate: number
+}
+
+interface RateLimitBucketState {
+  readonly tokens: number
+  readonly lastRefillMs: number
+}
+
+const INITIAL_METRICS: LoggingControlMetrics = {
+  published: 0,
+  droppedBySampling: 0,
+  droppedByRateLimit: 0
+}
+
+export function createLoggingControlState(): LoggingControlState {
+  return {
+    rateLimitBuckets: new Map<string, RateLimitBucketState>(),
+    metrics: { ...INITIAL_METRICS }
+  }
+}
+
+export function evaluateLoggingControls(
+  options: EvaluateLoggingControlsOptions
+): LoggingControlDecision {
+  const baseState = options.state ?? createLoggingControlState()
+  const randomFn = options.random ?? Math.random
+
+  if (options.config === undefined) {
+    return permit(baseState, baseState.rateLimitBuckets)
+  }
+
+  const samplingResult = evaluateSampling(options.event, options.config.sampling, randomFn)
+  if (samplingResult.allow === false) {
+    return dropForSampling(baseState, samplingResult.appliedRate)
+  }
+
+  const rateResult = evaluateRateLimit(
+    options.event,
+    options.nowMs,
+    options.config.rateLimit,
+    baseState.rateLimitBuckets
+  )
+
+  if (rateResult.allow === false) {
+    return dropForRateLimit(baseState, rateResult)
+  }
+
+  const details = createSuccessDetails(samplingResult, rateResult)
+  return permit(baseState, rateResult.buckets, details)
+}
+
+function evaluateSampling(
+  event: string,
+  config: LoggingControlsConfig['sampling'],
+  random: () => number
+): SamplingEvaluationResult {
+  if (config === undefined) {
+    return { allow: true, appliedRate: 1 }
+  }
+
+  const rule = selectSamplingRule(config.rules, event)
+  const rate = rule?.sampleRate ?? config.defaultSampleRate ?? 1
+
+  if (rate >= 1) {
+    return { allow: true, appliedRate: 1 }
+  }
+
+  if (rate <= 0) {
+    return { allow: false, appliedRate: 0 }
+  }
+
+  const decision = random() < rate
+  return { allow: decision, appliedRate: rate }
+}
+
+function selectSamplingRule(
+  rules: readonly LoggingSamplingRule[] | undefined,
+  event: string
+): LoggingSamplingRule | undefined {
+  if (rules === undefined) {
+    return undefined
+  }
+
+  let wildcard: LoggingSamplingRule | undefined
+  for (const rule of rules) {
+    if (rule.target === event) {
+      return rule
+    }
+    if (rule.target === '*' && wildcard === undefined) {
+      wildcard = rule
+    }
+  }
+  return wildcard
+}
+
+function evaluateRateLimit(
+  event: string,
+  nowMs: number,
+  config: LoggingControlsConfig['rateLimit'],
+  buckets: ReadonlyMap<string, RateLimitBucketState>
+): RateLimitEvaluationResult {
+  if (config?.rules === undefined || config.rules.length === 0) {
+    return { allow: true, buckets }
+  }
+
+  const rule = selectRateLimitRule(config.rules, event)
+  if (rule === undefined) {
+    return { allow: true, buckets }
+  }
+
+  const bucketKey = rule.target === '*' ? '*' : event
+  const capacity = rule.limit + (rule.burst ?? 0)
+
+  if (capacity <= 0) {
+    return {
+      allow: false,
+      appliedRule: rule,
+      buckets: upsertBucket(buckets, bucketKey, { tokens: 0, lastRefillMs: nowMs }),
+      remainingTokens: 0
+    }
+  }
+
+  const previous = buckets.get(bucketKey)
+  const refilled = refillBucket(previous, rule, nowMs, capacity)
+
+  if (refilled.tokens <= 0) {
+    return {
+      allow: false,
+      appliedRule: rule,
+      buckets: upsertBucket(buckets, bucketKey, refilled),
+      remainingTokens: refilled.tokens
+    }
+  }
+
+  const updated: RateLimitBucketState = {
+    tokens: refilled.tokens - 1,
+    lastRefillMs: refilled.lastRefillMs
+  }
+
+  return {
+    allow: true,
+    appliedRule: rule,
+    buckets: upsertBucket(buckets, bucketKey, updated),
+    remainingTokens: updated.tokens
+  }
+}
+
+function selectRateLimitRule(
+  rules: readonly LoggingRateLimitRule[],
+  event: string
+): LoggingRateLimitRule | undefined {
+  let wildcard: LoggingRateLimitRule | undefined
+  for (const rule of rules) {
+    if (rule.target === event) {
+      return rule
+    }
+    if (rule.target === '*' && wildcard === undefined) {
+      wildcard = rule
+    }
+  }
+  return wildcard
+}
+
+function refillBucket(
+  previous: RateLimitBucketState | undefined,
+  rule: LoggingRateLimitRule,
+  nowMs: number,
+  capacity: number
+): RateLimitBucketState {
+  if (previous === undefined) {
+    return { tokens: capacity, lastRefillMs: nowMs }
+  }
+
+  if (nowMs <= previous.lastRefillMs) {
+    return previous
+  }
+
+  const elapsed = nowMs - previous.lastRefillMs
+  const intervals = Math.floor(elapsed / rule.intervalMs)
+
+  if (intervals <= 0) {
+    return previous
+  }
+
+  const replenished = Math.min(previous.tokens + intervals * rule.limit, capacity)
+  const lastRefillMs = previous.lastRefillMs + intervals * rule.intervalMs
+
+  return {
+    tokens: replenished,
+    lastRefillMs
+  }
+}
+
+function upsertBucket(
+  buckets: ReadonlyMap<string, RateLimitBucketState>,
+  key: string,
+  value: RateLimitBucketState
+): ReadonlyMap<string, RateLimitBucketState> {
+  const next = new Map(buckets)
+  next.set(key, value)
+  return next
+}
+
+function permit(
+  state: LoggingControlState,
+  buckets: ReadonlyMap<string, RateLimitBucketState>,
+  details?: LoggingControlDecisionDetails
+): LoggingControlDecision {
+  return {
+    allow: true,
+    ...(details === undefined ? {} : { details }),
+    updatedState: {
+      rateLimitBuckets: buckets,
+      metrics: incrementPublished(state.metrics)
+    }
+  }
+}
+
+function dropForSampling(
+  state: LoggingControlState,
+  appliedRate: number
+): LoggingControlDecision {
+  return {
+    allow: false,
+    reason: 'sampling',
+    details: { samplingRate: appliedRate },
+    updatedState: {
+      rateLimitBuckets: state.rateLimitBuckets,
+      metrics: incrementDroppedBySampling(state.metrics)
+    }
+  }
+}
+
+function dropForRateLimit(
+  state: LoggingControlState,
+  result: RateLimitEvaluationResult
+): LoggingControlDecision {
+  const details =
+    result.appliedRule === undefined
+      ? undefined
+      : {
+          rateLimit: {
+            target: result.appliedRule.target,
+            remainingTokens: result.remainingTokens ?? 0
+          }
+        }
+
+  return {
+    allow: false,
+    reason: 'rate_limit',
+    ...(details === undefined ? {} : { details }),
+    updatedState: {
+      rateLimitBuckets: result.buckets,
+      metrics: incrementDroppedByRateLimit(state.metrics)
+    }
+  }
+}
+
+function incrementPublished(metrics: LoggingControlMetrics): LoggingControlMetrics {
+  return {
+    published: metrics.published + 1,
+    droppedBySampling: metrics.droppedBySampling,
+    droppedByRateLimit: metrics.droppedByRateLimit
+  }
+}
+
+function incrementDroppedBySampling(metrics: LoggingControlMetrics): LoggingControlMetrics {
+  return {
+    published: metrics.published,
+    droppedBySampling: metrics.droppedBySampling + 1,
+    droppedByRateLimit: metrics.droppedByRateLimit
+  }
+}
+
+function incrementDroppedByRateLimit(metrics: LoggingControlMetrics): LoggingControlMetrics {
+  return {
+    published: metrics.published,
+    droppedBySampling: metrics.droppedBySampling,
+    droppedByRateLimit: metrics.droppedByRateLimit + 1
+  }
+}
+
+function createSuccessDetails(
+  sampling: SamplingEvaluationResult,
+  rate: RateLimitEvaluationResult
+): LoggingControlDecisionDetails | undefined {
+  const includeSampling = sampling.appliedRate > 0 && sampling.appliedRate < 1
+  const rule = rate.appliedRule
+  const includeRate = rule !== undefined
+
+  if (!includeSampling && !includeRate) {
+    return undefined
+  }
+
+  return {
+    ...(includeSampling ? { samplingRate: sampling.appliedRate } : {}),
+    ...(includeRate
+      ? {
+          rateLimit: {
+            target: rule.target,
+            remainingTokens: rate.remainingTokens ?? 0
+          }
+        }
+      : {})
+  }
+}

--- a/app/services/session/session-service.ts
+++ b/app/services/session/session-service.ts
@@ -9,10 +9,8 @@ import type {
   SessionParams,
   ServiceDependencies
 } from '../interfaces.js'
-import type { SessionId } from '../../types/branded.js'
-import type { SessionState, Result } from '../../state/types.js'
-import { ok, err } from '../../state/types.js'
-import { createSessionId } from '../../types/branded.js'
+import { createSessionId, type SessionId } from '../../types/branded.js'
+import { ok, err, type SessionState, type Result } from '../../state/types.js'
 import type { SessionStore } from '../../state/store.js'
 import debug from 'debug'
 

--- a/app/services/setup.ts
+++ b/app/services/setup.ts
@@ -78,11 +78,12 @@ export function setupContainer(config: Config): Container {
  * Helper to create service dependencies from container
  */
 function createDependencies(container: Container): ExtendedServiceDependencies {
+  const config = container.resolve(TOKENS.Config)
   return {
-    config: container.resolve(TOKENS.Config),
+    config,
     logger: container.resolve(TOKENS.Logger),
     store: container.resolve(TOKENS.SessionStore),
-    createStructuredLogger: createServiceStructuredLogger
+    createStructuredLogger: (options) => createServiceStructuredLogger(config, options)
   }
 }
 

--- a/app/services/setup.ts
+++ b/app/services/setup.ts
@@ -8,9 +8,9 @@ import {
   createLogger,
   createSessionStore,
   createServices,
-  createServiceStructuredLogger
+  createServiceStructuredLogger,
+  type ExtendedServiceDependencies
 } from './factory.js'
-import type { ExtendedServiceDependencies } from './factory.js'
 import debug from 'debug'
 
 const logger = debug('webssh2:services:setup')

--- a/app/services/ssh/exec-command.ts
+++ b/app/services/ssh/exec-command.ts
@@ -1,7 +1,6 @@
 import type { ClientChannel } from 'ssh2'
 import type { ConnectionId } from '../../types/branded.js'
-import type { Result } from '../../state/types.js'
-import { ok, err } from '../../state/types.js'
+import { ok, err, type Result } from '../../state/types.js'
 import type { ExecResult, SSHConnection } from '../interfaces.js'
 import type { ConnectionPool } from './connection-pool.js'
 import type { ConnectionLogger, ConnectionLogBase } from './connection-logger.js'

--- a/app/services/ssh/ssh-service.ts
+++ b/app/services/ssh/ssh-service.ts
@@ -11,15 +11,16 @@ import type {
   ExecResult,
   ServiceDependencies
 } from '../interfaces.js'
-import type { ConnectionId, SessionId } from '../../types/branded.js'
-import type { Result } from '../../state/types.js'
-import { ok, err } from '../../state/types.js'
-import { createConnectionId } from '../../types/branded.js'
-import { Client as SSH2Client } from 'ssh2'
+import {
+  createConnectionId,
+  type ConnectionId,
+  type SessionId
+} from '../../types/branded.js'
+import { ok, err, type Result } from '../../state/types.js'
+import { Client as SSH2Client, type ClientChannel, type PseudoTtyOptions } from 'ssh2'
 import type { SessionStore } from '../../state/store.js'
 import debug from 'debug'
 import type { Duplex } from 'node:stream'
-import type { PseudoTtyOptions, ClientChannel } from 'ssh2'
 import { validateConnectionWithDns } from '../../ssh/hostname-resolver.js'
 import { ConnectionPool } from './connection-pool.js'
 import {

--- a/app/services/terminal/terminal-service.ts
+++ b/app/services/terminal/terminal-service.ts
@@ -10,8 +10,7 @@ import type {
   ServiceDependencies
 } from '../interfaces.js'
 import type { SessionId } from '../../types/branded.js'
-import type { Result } from '../../state/types.js'
-import { ok, err } from '../../state/types.js'
+import { ok, err, type Result } from '../../state/types.js'
 import type { SessionStore } from '../../state/store.js'
 import debug from 'debug'
 

--- a/app/socket/adapters/service-socket-terminal.ts
+++ b/app/socket/adapters/service-socket-terminal.ts
@@ -4,8 +4,7 @@ import type { SessionId } from '../../types/branded.js'
 import { SOCKET_EVENTS } from '../../constants/socket-events.js'
 import { VALIDATION_MESSAGES } from '../../constants/validation.js'
 import { buildTerminalDefaults, createConnectionIdentifier } from './ssh-config.js'
-import { emitSocketLog } from '../../logging/socket-logger.js'
-import type { SocketLogOptions } from '../../logging/socket-logger.js'
+import { emitSocketLog, type SocketLogOptions } from '../../logging/socket-logger.js'
 import type { LogLevel } from '../../logging/levels.js'
 
 interface TerminalConfig {

--- a/app/socket/adapters/ssh-config.ts
+++ b/app/socket/adapters/ssh-config.ts
@@ -1,7 +1,6 @@
 import type { AuthCredentials, TerminalSettings } from '../../types/contracts/v1/socket.js'
 import type { Config } from '../../types/config.js'
-import type { SessionId } from '../../types/branded.js'
-import { createConnectionId } from '../../types/branded.js'
+import { createConnectionId, type SessionId } from '../../types/branded.js'
 import type { Services } from '../../services/interfaces.js'
 import { TERMINAL_DEFAULTS } from '../../constants/terminal.js'
 import type { AdapterContext } from './service-socket-shared.js'

--- a/app/socket/handlers/exec-handler.ts
+++ b/app/socket/handlers/exec-handler.ts
@@ -5,9 +5,9 @@ import { validateExecPayload, createExecState } from './exec-validator.js'
 import { mergeEnvironmentVariables } from './exec-environment.js'
 
 // Re-export validator and safety functions for backwards compatibility
-export { validateExecPayload, createExecState } from './exec-validator.js'
+export { validateExecPayload, createExecState }
 export { isCommandSafe, sanitizeEnvVarName, filterEnvironmentVariables } from './exec-safety.js'
-export { mergeEnvironmentVariables } from './exec-environment.js'
+export { mergeEnvironmentVariables }
 
 export interface ExecState {
   command: string

--- a/app/state/reducers/session-reducer.ts
+++ b/app/state/reducers/session-reducer.ts
@@ -2,13 +2,12 @@
  * Root session reducer combining all sub-reducers
  */
 
-import type { SessionState } from '../types.js'
+import { createInitialState, type SessionState } from '../types.js'
 import type { SessionAction } from '../actions.js'
 import { authReducer } from './auth-reducer.js'
 import { connectionReducer } from './connection-reducer.js'
 import { terminalReducer } from './terminal-reducer.js'
 import { metadataReducer } from './metadata-reducer.js'
-import { createInitialState } from '../types.js'
 
 /**
  * Main session reducer - combines all sub-reducers

--- a/app/state/store.ts
+++ b/app/state/store.ts
@@ -3,9 +3,8 @@
  */
 
 import type { SessionId } from '../types/branded.js'
-import type { SessionState, StateListener } from './types.js'
+import { createInitialState, type SessionState, type StateListener } from './types.js'
 import type { SessionAction } from './actions.js'
-import { createInitialState } from './types.js'
 import { sessionReducer, hasStateChanged } from './reducers/session-reducer.js'
 import debug from 'debug'
 

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -2,6 +2,7 @@
 // Configuration type definitions
 
 import type { Result } from './result.js'
+import type { LogLevel } from '../logging/levels.js'
 
 /**
  * SSH algorithms configuration
@@ -87,10 +88,67 @@ export interface TerminalConfig {
 }
 
 /**
+ * Logging controls configuration for runtime sampling and rate limits
+ */
+export interface LoggingControlsConfig {
+  readonly sampling?: LoggingSamplingConfig
+  readonly rateLimit?: LoggingRateLimitConfig
+}
+
+/**
+ * Logging sampling configuration
+ */
+export interface LoggingSamplingConfig {
+  readonly defaultSampleRate?: number
+  readonly rules?: readonly LoggingSamplingRule[]
+}
+
+/**
+ * Logging sampling rule entry
+ */
+export interface LoggingSamplingRule {
+  readonly target: LoggingEventTarget
+  readonly sampleRate: number
+}
+
+/**
+ * Logging rate limit configuration
+ */
+export interface LoggingRateLimitConfig {
+  readonly rules?: readonly LoggingRateLimitRule[]
+}
+
+/**
+ * Logging rate limit rule entry
+ */
+export interface LoggingRateLimitRule {
+  readonly target: LoggingEventTarget
+  readonly limit: number
+  readonly intervalMs: number
+  readonly burst?: number
+}
+
+/**
+ * Logging configuration reload behaviour
+ */
+export interface LoggingReloadConfig {
+  readonly enabled: boolean
+  readonly intervalMs?: number
+}
+
+/**
+ * Supported logging event target identifiers
+ */
+export type LoggingEventTarget = '*' | string
+
+/**
  * Logging configuration
  */
 export interface LoggingConfig {
-  namespace?: string
+  readonly namespace?: string
+  readonly minimumLevel?: LogLevel
+  readonly controls?: LoggingControlsConfig
+  readonly reload?: LoggingReloadConfig
 }
 
 /**

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -3,6 +3,7 @@
 
 import type { Result } from './result.js'
 import type { LogLevel } from '../logging/levels.js'
+import type { LogEventName } from '../logging/event-catalog.js'
 
 /**
  * SSH algorithms configuration
@@ -139,7 +140,7 @@ export interface LoggingReloadConfig {
 /**
  * Supported logging event target identifiers
  */
-export type LoggingEventTarget = '*' | string
+export type LoggingEventTarget = '*' | LogEventName
 
 /**
  * Logging configuration

--- a/app/validation/socket/helpers.ts
+++ b/app/validation/socket/helpers.ts
@@ -2,8 +2,12 @@ import type { Result } from '../../types/result.js'
 import validator from 'validator'
 import { ENV_LIMITS, VALIDATION_LIMITS } from '../../constants/index.js'
 import { safeGet, isRecord } from '../../utils/safe-property-access.js'
-import type { FieldDescriptor, DimensionFieldDescriptor, DimensionField } from './fields.js'
-import { ENV_KEY_PATTERN } from './fields.js'
+import {
+  ENV_KEY_PATTERN,
+  type FieldDescriptor,
+  type DimensionFieldDescriptor,
+  type DimensionField
+} from './fields.js'
 
 export const ensureRecord = (
   value: unknown,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -122,6 +122,7 @@ export default [
           fixStyle: 'inline-type-imports',
         },
       ],
+      'no-duplicate-imports': 'error',
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-misused-promises': [
         'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,7 @@ export default [
       'prefer-rest-params': 'error',
       'prefer-spread': 'error',
       'prefer-template': 'error',
+      'no-duplicate-imports': 'error',
       'template-curly-spacing': ['error', 'never'],
       'node/file-extension-in-import': ['error', 'always'],
       'no-new': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -119,7 +119,7 @@ export default [
         'error',
         {
           prefer: 'type-imports',
-          fixStyle: 'separate-type-imports',
+          fixStyle: 'inline-type-imports',
         },
       ],
       '@typescript-eslint/no-floating-promises': 'error',

--- a/tests/config-async.vitest.ts
+++ b/tests/config-async.vitest.ts
@@ -4,8 +4,7 @@ import { describe, it, beforeEach, afterEach, expect } from 'vitest'
 import fs from 'node:fs'
 import { getConfig, loadConfigAsync, resetConfigForTesting } from '../app/config.js'
 import { ConfigError } from '../app/errors.js'
-import { setupTestEnvironment } from './test-utils.js'
-import type { ConfigFileManager } from './test-utils.js'
+import { setupTestEnvironment, type ConfigFileManager } from './test-utils.js'
 import { ENV_TEST_VALUES, TEST_SECRET_LONG, TEST_IPS, TEST_CUSTOM_PORTS } from './test-constants.js'
 
 // Ensure clean state at module load

--- a/tests/playwright/v2-helpers.ts
+++ b/tests/playwright/v2-helpers.ts
@@ -5,8 +5,7 @@
  * Centralizes common V2-specific test operations
  */
 
-import type { Page, Response } from '@playwright/test'
-import { expect } from '@playwright/test'
+import { expect, type Page, type Response } from '@playwright/test'
 import { TIMEOUTS } from './constants.js'
 
 /**

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -27,7 +27,7 @@ import type { Result } from '../app/types/result.js'
 import { ok, err, isErr } from '../app/utils/result.js'
 
 // Re-export Result utility functions for test use
-export { ok, err, isErr } from '../app/utils/result.js'
+export { ok, err, isErr }
 
 export interface StructuredLoggerStub extends StructuredLogger {
   readonly entries: Array<{ level: LogLevel; entry: Omit<StructuredLogInput, 'level'> }>

--- a/tests/unit/config-enhanced.vitest.ts
+++ b/tests/unit/config-enhanced.vitest.ts
@@ -45,6 +45,13 @@ const createTestEnvironment = (): Record<string, string> => ({
   WEBSSH2_SSO_HEADER_USERNAME: SSO_AUTH_HEADERS.username,
   WEBSSH2_SSO_HEADER_PASSWORD: SSO_AUTH_HEADERS.password,
   WEBSSH2_SSO_HEADER_SESSION: SSO_AUTH_HEADERS.session,
+  WEBSSH2_LOGGING_LEVEL: 'debug',
+  WEBSSH2_LOGGING_SAMPLING_DEFAULT_RATE: '0.5',
+  WEBSSH2_LOGGING_SAMPLING_RULES: '[{"target":"ssh_command","sampleRate":0.25}]',
+  WEBSSH2_LOGGING_RATE_LIMIT_RULES:
+    '[{"target":"ssh_command","limit":5,"intervalMs":1000,"burst":5}]',
+  WEBSSH2_LOGGING_RELOAD_ENABLED: 'true',
+  WEBSSH2_LOGGING_RELOAD_INTERVAL_MS: '5000',
 })
 
 const verifyListenConfig = (config: ReturnType<typeof mapEnvironmentVariables>): void => {
@@ -90,6 +97,37 @@ const verifySsoConfig = (config: ReturnType<typeof mapEnvironmentVariables>): vo
   })
 }
 
+const verifyLoggingConfig = (config: ReturnType<typeof mapEnvironmentVariables>): void => {
+  expect(config.logging).toMatchObject({
+    minimumLevel: 'debug',
+    controls: {
+      sampling: {
+        defaultSampleRate: 0.5,
+        rules: [
+          {
+            target: 'ssh_command',
+            sampleRate: 0.25,
+          },
+        ],
+      },
+      rateLimit: {
+        rules: [
+          {
+            target: 'ssh_command',
+            limit: 5,
+            intervalMs: 1000,
+            burst: 5,
+          },
+        ],
+      },
+    },
+    reload: {
+      enabled: true,
+      intervalMs: 5000,
+    },
+  })
+}
+
 describe('Enhanced Config - Environment Variable Support', () => {
   it('should support all environment variables from ENV_VAR_MAPPING', () => {
     const testEnv = createTestEnvironment()
@@ -101,6 +139,7 @@ describe('Enhanced Config - Environment Variable Support', () => {
     verifyHeaderConfig(config)
     verifyOptionsConfig(config)
     verifySsoConfig(config)
+    verifyLoggingConfig(config)
   })
 
   it('should have mapping for all core environment variables', () => {

--- a/tests/unit/config/config-processor.vitest.ts
+++ b/tests/unit/config/config-processor.vitest.ts
@@ -24,6 +24,8 @@ void describe('createDefaultConfig', () => {
     expect(config.session.secret).toBeDefined()
     expect(config.session.secret.length).toBe(64)
     expect(config.session.name).toBe('webssh2.sid')
+    expect(config.logging?.minimumLevel).toBe('info')
+    expect(config.logging?.reload?.enabled).toBe(false)
   })
   
   it('should create default config with provided session secret', () => {

--- a/tests/unit/logging/controls.vitest.ts
+++ b/tests/unit/logging/controls.vitest.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createLoggingControlState,
+  evaluateLoggingControls
+} from '../../../app/services/logging/controls.js'
+import type { LoggingControlsConfig } from '../../../app/types/config.js'
+
+describe('evaluateLoggingControls', () => {
+  it('permits events when controls are not configured', () => {
+    const initial = createLoggingControlState()
+
+    const decision = evaluateLoggingControls({
+      event: 'auth_attempt',
+      nowMs: 0,
+      state: initial
+    })
+
+    expect(decision.allow).toBe(true)
+    expect(decision.reason).toBeUndefined()
+    expect(decision.updatedState.metrics.published).toBe(1)
+    expect(initial.metrics.published).toBe(0)
+  })
+
+  it('drops events when default sampling rate is zero', () => {
+    const config: LoggingControlsConfig = {
+      sampling: { defaultSampleRate: 0 }
+    }
+    const initial = createLoggingControlState()
+
+    const decision = evaluateLoggingControls({
+      event: 'session_start',
+      nowMs: 0,
+      state: initial,
+      config,
+      random: () => 0.75
+    })
+
+    expect(decision.allow).toBe(false)
+    expect(decision.reason).toBe('sampling')
+    expect(decision.details?.samplingRate).toBe(0)
+    expect(decision.updatedState.metrics.droppedBySampling).toBe(1)
+    expect(initial.metrics.droppedBySampling).toBe(0)
+  })
+
+  it('applies event specific sampling rules before wildcard rules', () => {
+    const config: LoggingControlsConfig = {
+      sampling: {
+        defaultSampleRate: 1,
+        rules: [
+          { target: '*', sampleRate: 1 },
+          { target: 'ssh_command', sampleRate: 0 }
+        ]
+      }
+    }
+    const initial = createLoggingControlState()
+
+    const decision = evaluateLoggingControls({
+      event: 'ssh_command',
+      nowMs: 0,
+      state: initial,
+      config,
+      random: () => 0.1
+    })
+
+    expect(decision.allow).toBe(false)
+    expect(decision.reason).toBe('sampling')
+    expect(decision.details?.samplingRate).toBe(0)
+  })
+
+  it('enforces rate limit rules with shared wildcard bucket', () => {
+    const config: LoggingControlsConfig = {
+      rateLimit: {
+        rules: [{ target: '*', limit: 2, intervalMs: 1_000 }]
+      }
+    }
+    let current = createLoggingControlState()
+
+    const first = evaluateLoggingControls({
+      event: 'auth_success',
+      nowMs: 0,
+      state: current,
+      config,
+      random: () => 0.5
+    })
+    expect(first.allow).toBe(true)
+    current = first.updatedState
+
+    const second = evaluateLoggingControls({
+      event: 'auth_failure',
+      nowMs: 100,
+      state: current,
+      config,
+      random: () => 0.5
+    })
+    expect(second.allow).toBe(true)
+    current = second.updatedState
+
+    const third = evaluateLoggingControls({
+      event: 'session_end',
+      nowMs: 200,
+      state: current,
+      config,
+      random: () => 0.5
+    })
+
+    expect(third.allow).toBe(false)
+    expect(third.reason).toBe('rate_limit')
+    expect(third.updatedState.metrics.droppedByRateLimit).toBe(1)
+
+    const afterCooldown = evaluateLoggingControls({
+      event: 'session_start',
+      nowMs: 1_200,
+      state: third.updatedState,
+      config,
+      random: () => 0.5
+    })
+
+    expect(afterCooldown.allow).toBe(true)
+    expect(afterCooldown.updatedState.metrics.published).toBe(3)
+  })
+
+  it('treats rate limit rules independently per event when specified', () => {
+    const config: LoggingControlsConfig = {
+      rateLimit: {
+        rules: [
+          { target: 'auth_attempt', limit: 1, intervalMs: 1_000 },
+          { target: 'ssh_command', limit: 1, intervalMs: 1_000 }
+        ]
+      }
+    }
+    let current = createLoggingControlState()
+
+    const first = evaluateLoggingControls({
+      event: 'auth_attempt',
+      nowMs: 0,
+      state: current,
+      config,
+      random: () => 0.3
+    })
+    expect(first.allow).toBe(true)
+    current = first.updatedState
+
+    const second = evaluateLoggingControls({
+      event: 'ssh_command',
+      nowMs: 100,
+      state: current,
+      config,
+      random: () => 0.3
+    })
+    expect(second.allow).toBe(true)
+    current = second.updatedState
+
+    const third = evaluateLoggingControls({
+      event: 'auth_attempt',
+      nowMs: 200,
+      state: current,
+      config,
+      random: () => 0.3
+    })
+
+    expect(third.allow).toBe(false)
+    expect(third.reason).toBe('rate_limit')
+
+    const authAfterInterval = evaluateLoggingControls({
+      event: 'auth_attempt',
+      nowMs: 1_200,
+      state: third.updatedState,
+      config,
+      random: () => 0.3
+    })
+
+    expect(authAfterInterval.allow).toBe(true)
+  })
+})

--- a/tests/unit/logging/socket-logger.vitest.ts
+++ b/tests/unit/logging/socket-logger.vitest.ts
@@ -3,8 +3,7 @@ import { buildSocketLogContext, emitSocketLog } from '../../../app/logging/socke
 import { createAdapterSharedState, type AdapterContext } from '../../../app/socket/adapters/service-socket-shared.js'
 import type { Services } from '../../../app/services/interfaces.js'
 import type { UnifiedAuthPipeline } from '../../../app/auth/auth-pipeline.js'
-import { createStructuredLoggerStub } from '../../test-utils.js'
-import type { StructuredLoggerStub } from '../../test-utils.js'
+import { createStructuredLoggerStub, type StructuredLoggerStub } from '../../test-utils.js'
 import type { SessionId } from '../../../app/types/branded.js'
 import { TEST_NETWORK, TEST_SOCKET_CONSTANTS, TEST_USER_AGENTS } from '../../test-constants.js'
 

--- a/tests/unit/logging/structured-logger.vitest.ts
+++ b/tests/unit/logging/structured-logger.vitest.ts
@@ -1,13 +1,22 @@
 import { describe, expect, it } from 'vitest'
 import { createStructuredLogger } from '../../../app/logging/structured-logger.js'
-import type { LogTransport } from '../../../app/logging/stdout-transport.js'
-import { ok } from '../../../app/utils/result.js'
+import {
+  TransportBackpressureError,
+  type LogTransport
+} from '../../../app/logging/stdout-transport.js'
+import { ok, err } from '../../../app/utils/result.js'
 import type { Result } from '../../../app/types/result.js'
 
 class TransportStub implements LogTransport {
   public readonly lines: string[] = []
+  public nextError: Error | null = null
 
   publish(payload: string): Result<void> {
+    if (this.nextError !== null) {
+      const error = this.nextError
+      this.nextError = null
+      return err(error)
+    }
     this.lines.push(payload)
     return ok(undefined)
   }
@@ -57,5 +66,62 @@ describe('createStructuredLogger', () => {
     })
 
     expect(result.ok).toBe(false)
+  })
+
+  it('applies sampling controls before writing to transport', () => {
+    const transport = new TransportStub()
+    const logger = createStructuredLogger({
+      transport,
+      controls: {
+        sampling: { defaultSampleRate: 0 }
+      },
+      random: () => 0.25
+    })
+
+    const result = logger.info({
+      event: 'session_start',
+      message: 'should be dropped'
+    })
+
+    expect(result.ok).toBe(true)
+    expect(transport.lines).toHaveLength(0)
+    const metrics = logger.snapshotMetrics()
+    expect(metrics.droppedBySampling).toBe(1)
+    expect(metrics.published).toBe(0)
+  })
+
+  it('tracks queue drops when transport reports backpressure', () => {
+    const transport = new TransportStub()
+    const logger = createStructuredLogger({
+      transport,
+      random: () => 0.1
+    })
+
+    transport.nextError = new TransportBackpressureError()
+
+    const result = logger.info({ event: 'session_start' })
+
+    expect(result.ok).toBe(true)
+    expect(transport.lines).toHaveLength(0)
+    const metrics = logger.snapshotMetrics()
+    expect(metrics.droppedByQueue).toBe(1)
+    expect(metrics.lastError).toBeInstanceOf(TransportBackpressureError)
+  })
+
+  it('resets control state when controls are updated', () => {
+    const transport = new TransportStub()
+    const logger = createStructuredLogger({
+      transport,
+      controls: {
+        sampling: { defaultSampleRate: 0 }
+      },
+      random: () => 0.5
+    })
+
+    logger.info({ event: 'session_start' })
+    expect(logger.snapshotMetrics().droppedBySampling).toBe(1)
+
+    logger.updateControls(undefined)
+    expect(logger.snapshotMetrics().droppedBySampling).toBe(0)
   })
 })

--- a/tests/unit/services/container.vitest.ts
+++ b/tests/unit/services/container.vitest.ts
@@ -3,8 +3,12 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { createContainer, createToken, TOKENS } from '../../../app/services/container.js'
-import type { Container } from '../../../app/services/container.js'
+import {
+  createContainer,
+  createToken,
+  TOKENS,
+  type Container
+} from '../../../app/services/container.js'
 import type { Config } from '../../../app/types/config.js'
 import { TEST_SECRET } from '../../test-constants.js'
 

--- a/tests/unit/socket/control-handler.vitest.ts
+++ b/tests/unit/socket/control-handler.vitest.ts
@@ -2,8 +2,10 @@ import { describe, beforeEach, expect, it, vi } from 'vitest'
 import { EventEmitter } from 'node:events'
 import type { Socket } from 'socket.io'
 import { SOCKET_EVENTS, VALIDATION_MESSAGES } from '../../../app/constants/index.js'
-import { createInitialSessionState } from '../../../app/socket/handlers/auth-handler.js'
-import type { SessionState } from '../../../app/socket/handlers/auth-handler.js'
+import {
+  createInitialSessionState,
+  type SessionState
+} from '../../../app/socket/handlers/auth-handler.js'
 import type { Config } from '../../../app/types/config.js'
 import { createStructuredLoggerStub, type StructuredLoggerStub } from '../../test-utils.js'
 import {

--- a/tests/unit/socket/service-socket-control.vitest.ts
+++ b/tests/unit/socket/service-socket-control.vitest.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 import { ServiceSocketControl } from '../../../app/socket/adapters/service-socket-control.js'
-import { createAdapterSharedState } from '../../../app/socket/adapters/service-socket-shared.js'
-import type { AdapterContext } from '../../../app/socket/adapters/service-socket-shared.js'
+import {
+  createAdapterSharedState,
+  type AdapterContext
+} from '../../../app/socket/adapters/service-socket-shared.js'
 import type { Services } from '../../../app/services/interfaces.js'
 import type { UnifiedAuthPipeline } from '../../../app/auth/auth-pipeline.js'
 import type { ClientToServerEvents, InterServerEvents, ServerToClientEvents, SocketData } from '../../../app/types/contracts/v1/socket.js'
 import type { Socket } from 'socket.io'
-import { createStructuredLoggerStub } from '../../test-utils.js'
-import type { StructuredLoggerStub } from '../../test-utils.js'
+import { createStructuredLoggerStub, type StructuredLoggerStub } from '../../test-utils.js'
 import { TEST_PASSWORDS } from '../../test-constants.js'
 
 interface MinimalSocket extends Partial<Socket<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>> {

--- a/tests/unit/state/session-reducer.vitest.ts
+++ b/tests/unit/state/session-reducer.vitest.ts
@@ -4,11 +4,10 @@
 
 import { describe, it, expect } from 'vitest'
 import { sessionReducer } from '../../../app/state/reducers/session-reducer.js'
-import { createInitialState } from '../../../app/state/types.js'
+import { createInitialState, type SessionState } from '../../../app/state/types.js'
 import { actions } from '../../../app/state/actions.js'
 import { createSessionId, createUserId, createConnectionId } from '../../../app/types/branded.js'
 import { TEST_USERNAME, TEST_SSH } from '../../test-constants.js'
-import type { SessionState } from '../../../app/state/types.js'
 
 // Reusable test helpers
 const createTestState = (overrides: Partial<SessionState> = {}): SessionState => {


### PR DESCRIPTION
## Summary
- map new WEBSSH2_LOGGING_* env vars into runtime logging controls
- allow JSON env parsing and wire structured logging controls service
- document runtime logging env overrides and extend unit coverage

## Testing
- npx vitest run tests/unit/config-enhanced.vitest.ts
