### PR TITLE
fix: respect config ssh port

### DIFF
--- a/app/auth/credential-processor.ts
+++ b/app/auth/credential-processor.ts
@@ -97,8 +97,8 @@ export function validateConnectionParams(params: ConnectionParams): ValidatedCon
     throw new Error('Host is required but not provided')
   }
   
-  // Determine port
-  const port = getValidatedPort(params.port)
+  // Determine port - fall back to configured SSH port when not provided
+  const port = getValidatedPort(params.port ?? params.config.ssh.port)
   
   // Determine terminal
   const term = params.sshterm == null

--- a/package-lock.json
+++ b/package-lock.json
@@ -5928,6 +5928,7 @@
       "integrity": "sha512-oBXvfSHEOL8jF+R9Am7h59Up07kVVGH1NrFGFoEG6bPDZP3tGpQhvkBpy5x7U6+E6wZCu9OihsWgJqDbQIm8LQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@
  * - If ENABLE_E2E_SSH=1, starts containerized sshd in global setup and stops in teardown
  */
 import { defineConfig, devices } from '@playwright/test'
-import { WEB_PORT, BASE_URL, TIMEOUTS } from './tests/playwright/constants.js'
+import { WEB_PORT, BASE_URL, TIMEOUTS, SSH_PORT, SSH_HOST, USERNAME, PASSWORD } from './tests/playwright/constants.js'
 
 const enableE2E = process.env.ENABLE_E2E_SSH === '1'
 
@@ -30,12 +30,17 @@ export default defineConfig({
   ],
   webServer: {
     // Keep server logs quiet by default; opt-in with E2E_DEBUG
-    command: `WEBSSH2_LISTEN_PORT=${WEB_PORT} node dist/index.js`,
+    command: 'node ./tests/playwright/scripts/start-server.mjs',
     url: `${BASE_URL}/ssh`,
     reuseExistingServer: true,
     timeout: TIMEOUTS.WEB_SERVER,
     env: {
       DEBUG: process.env.E2E_DEBUG ?? '',
+      WEBSSH2_LISTEN_PORT: String(WEB_PORT),
+      E2E_SSH_HOST: SSH_HOST,
+      E2E_SSH_PORT: String(SSH_PORT),
+      E2E_SSH_USER: USERNAME,
+      E2E_SSH_PASS: PASSWORD,
       WEBSSH2_SSH_READY_TIMEOUT: '10000' // Faster timeout for test suite
     },
   },

--- a/tests/playwright/assets/config.template.json
+++ b/tests/playwright/assets/config.template.json
@@ -1,0 +1,100 @@
+{
+  "listen": {
+    "ip": "0.0.0.0",
+    "port": 0
+  },
+  "http": {
+    "origins": ["*:*"]
+  },
+  "user": {
+    "name": null,
+    "password": null,
+    "privateKey": null,
+    "passphrase": null
+  },
+  "ssh": {
+    "host": null,
+    "port": 0,
+    "term": "xterm-256color",
+    "readyTimeout": 20000,
+    "keepaliveInterval": 120000,
+    "keepaliveCountMax": 10,
+    "allowedSubnets": [],
+    "alwaysSendKeyboardInteractivePrompts": false,
+    "disableInteractiveAuth": false,
+    "algorithms": {
+      "cipher": [
+        "chacha20-poly1305@openssh.com",
+        "aes128-gcm",
+        "aes128-gcm@openssh.com",
+        "aes256-gcm",
+        "aes256-gcm@openssh.com",
+        "aes128-ctr",
+        "aes192-ctr",
+        "aes256-ctr",
+        "aes256-cbc"
+      ],
+      "compress": ["none", "zlib@openssh.com", "zlib"],
+      "hmac": [
+        "hmac-sha2-256-etm@openssh.com",
+        "hmac-sha2-512-etm@openssh.com",
+        "hmac-sha1-etm@openssh.com",
+        "hmac-sha2-256",
+        "hmac-sha2-512",
+        "hmac-sha1"
+      ],
+      "kex": [
+        "curve25519-sha256",
+        "curve25519-sha256@libssh.org",
+        "ecdh-sha2-nistp256",
+        "ecdh-sha2-nistp384",
+        "ecdh-sha2-nistp521",
+        "diffie-hellman-group14-sha256",
+        "diffie-hellman-group-exchange-sha256",
+        "diffie-hellman-group14-sha1"
+      ],
+      "serverHostKey": [
+        "ssh-ed25519",
+        "rsa-sha2-512",
+        "rsa-sha2-256",
+        "ecdsa-sha2-nistp256",
+        "ecdsa-sha2-nistp384",
+        "ecdsa-sha2-nistp521",
+        "ssh-rsa"
+      ]
+    },
+    "envAllowlist": []
+  },
+  "header": {
+    "text": null,
+    "background": "green"
+  },
+  "options": {
+    "challengeButton": true,
+    "autoLog": false,
+    "allowReauth": true,
+    "allowReconnect": true,
+    "allowReplay": true,
+    "replayCRLF": false
+  },
+  "session": {
+    "secret": "test-session-secret-0123456789abcdef0123456789abcdef",
+    "name": "webssh2.sid"
+  },
+  "sso": {
+    "enabled": false,
+    "csrfProtection": false,
+    "trustedProxies": [],
+    "headerMapping": {
+      "username": "x-apm-username",
+      "password": "x-apm-password",
+      "session": "x-apm-session"
+    }
+  },
+  "logging": {
+    "minimumLevel": "info",
+    "stdout": {
+      "enabled": true
+    }
+  }
+}

--- a/tests/playwright/basic-auth-config-port.spec.ts
+++ b/tests/playwright/basic-auth-config-port.spec.ts
@@ -1,0 +1,22 @@
+import { test } from '@playwright/test'
+import { TEST_CONFIG } from './constants.js'
+import { connectWithBasicAuth, waitForV2Prompt, executeAndVerifyCommand } from './v2-helpers.js'
+
+const E2E_ENABLED = process.env.ENABLE_E2E_SSH === '1'
+
+test.describe('Config SSH port fallback', () => {
+  test.skip(!E2E_ENABLED, 'Set ENABLE_E2E_SSH=1 to run this test')
+
+  test('uses configured ssh.port when Basic Auth URL omits port parameter', async ({ page }) => {
+    await connectWithBasicAuth(
+      page,
+      TEST_CONFIG.baseUrl,
+      TEST_CONFIG.validUsername,
+      TEST_CONFIG.validPassword,
+      TEST_CONFIG.sshHost
+    )
+
+    await waitForV2Prompt(page)
+    await executeAndVerifyCommand(page, 'whoami', TEST_CONFIG.validUsername)
+  })
+})

--- a/tests/playwright/scripts/start-server.mjs
+++ b/tests/playwright/scripts/start-server.mjs
@@ -1,0 +1,81 @@
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const rootDir = path.resolve(__dirname, '..', '..', '..')
+const templatePath = path.resolve(__dirname, '..', 'assets', 'config.template.json')
+const configPath = path.resolve(rootDir, 'config.json')
+
+function loadTemplate() {
+  const raw = readFileSync(templatePath, 'utf8')
+  return JSON.parse(raw)
+}
+
+function buildConfig() {
+  const template = loadTemplate()
+  const listenPort = Number.parseInt(process.env.WEBSSH2_LISTEN_PORT ?? '', 10) || 4444
+  const sshPort = Number.parseInt(process.env.E2E_SSH_PORT ?? '', 10) || 22
+
+  template.listen.port = listenPort
+  template.ssh.port = sshPort
+
+  return template
+}
+
+function writeConfig(config) {
+  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8')
+}
+
+function cleanup() {
+  if (existsSync(configPath)) {
+    try {
+      rmSync(configPath)
+    } catch (error) {
+      console.warn('[playwright:start-server] Failed to remove config.json:', error)
+    }
+  }
+}
+
+const config = buildConfig()
+writeConfig(config)
+
+const childEnv = {
+  ...process.env,
+  WEBSSH2_LISTEN_PORT: String(config.listen.port)
+}
+
+const child = spawn(process.execPath, ['dist/index.js'], {
+  cwd: rootDir,
+  stdio: 'inherit',
+  env: childEnv
+})
+
+child.on('error', (error) => {
+  console.error('[playwright:start-server] Failed to start WebSSH2 server:', error)
+  cleanup()
+  process.exit(1)
+})
+
+const signals = ['SIGINT', 'SIGTERM', 'SIGQUIT']
+
+for (const signal of signals) {
+  process.on(signal, () => {
+    if (child.killed) {
+      return
+    }
+    child.kill(signal)
+  })
+}
+
+process.on('exit', () => {
+  cleanup()
+})
+
+child.on('exit', (code, signal) => {
+  cleanup()
+  const exitCode = code ?? (typeof signal === 'string' ? 1 : 0)
+  process.exit(exitCode)
+})

--- a/tests/playwright/v2-helpers.ts
+++ b/tests/playwright/v2-helpers.ts
@@ -168,16 +168,30 @@ export async function connectV2(page: Page, options: {
 /**
  * Builds a Basic Auth URL for SSH connection
  */
-export function buildBasicAuthUrl(baseUrl: string, username: string, password: string, host: string, port: string | number): string {
+export function buildBasicAuthUrl(
+  baseUrl: string,
+  username: string,
+  password: string,
+  host: string,
+  port?: string | number
+): string {
   const basicAuth = `${username}:${password}`
   const baseUrlWithAuth = baseUrl.replace('://', `://${basicAuth}@`)
-  return `${baseUrlWithAuth}/ssh/host/${host}?port=${port}`
+  const portQuery = port == null ? '' : `?port=${port}`
+  return `${baseUrlWithAuth}/ssh/host/${host}${portQuery}`
 }
 
 /**
  * Navigates to SSH with Basic Auth and waits for connection
  */
-export async function connectWithBasicAuth(page: Page, baseUrl: string, username: string, password: string, host: string, port: string | number): Promise<void> {
+export async function connectWithBasicAuth(
+  page: Page,
+  baseUrl: string,
+  username: string,
+  password: string,
+  host: string,
+  port?: string | number
+): Promise<void> {
   const url = buildBasicAuthUrl(baseUrl, username, password, host, port)
   await page.goto(url)
   await waitForV2Connection(page)

--- a/tests/unit/auth/credential-processor.vitest.ts
+++ b/tests/unit/auth/credential-processor.vitest.ts
@@ -103,14 +103,15 @@ describe('validateConnectionParams', () => {
   it('should fallback to config host', () => {
     const config = createDefaultConfig()
     config.ssh.host = 'default.com'
-    
+    config.ssh.port = 2022
+
     const params = { config }
-    
+
     const result = validateConnectionParams(params)
-    
+
     expect(result).toEqual({
       host: 'default.com',
-      port: 22,
+      port: 2022,
       term: 'xterm-256color'
     })
   })
@@ -135,15 +136,16 @@ describe('validateConnectionParams', () => {
     expect(() => validateConnectionParams(params)).toThrow('Host is required')
   })
   
-  it('should use default port when not provided', () => {
+  it('should use config port when not provided', () => {
     const config = createDefaultConfig()
     config.ssh.host = 'example.com'
-    
-    const params = { config }
-    
+    config.ssh.port = 3022
+
+    const params = { host: 'example.com', config }
+
     const result = validateConnectionParams(params)
-    
-    expect(result.port).toBe(22)
+
+    expect(result.port).toBe(3022)
   })
 })
 


### PR DESCRIPTION
## Summary
- reproduce #431 where Basic Auth connections ignored ssh.port from config.json
- update credential processing to fall back to the configured SSH port whenever the
request omits ?port=
- add unit coverage and a Playwright regression test that boots WebSSH2 with a
generated config and exercises Basic Auth without a port parameter

## Testing
- npm run check
- tested sample `config.json` against ssh_test server to url `http://localhost:4444/ssh/host`

```json
{
  "listen": {
    "ip": "0.0.0.0",
    "port": 4444
  },
  "http": {
    "origins": [
      "*:*"
    ]
  },
  "user": {
    "name": "testuser",
    "password": "testpassword",
    "privateKey": null,
    "passphrase": null
  },
  "ssh": {
    "host": "localhost",
    "port": 4422,
    "term": "xterm-256color",
    "readyTimeout": 20000,
    "keepaliveInterval": 120000,
    "keepaliveCountMax": 10,
    "allowedSubnets": [],
    "alwaysSendKeyboardInteractivePrompts": false,
    "disableInteractiveAuth": false,
    "algorithms": {
      "cipher": [
        "chacha20-poly1305@openssh.com",
        "aes128-gcm",
        "aes128-gcm@openssh.com",
        "aes256-gcm",
        "aes256-gcm@openssh.com",
        "aes128-ctr",
        "aes192-ctr",
        "aes256-ctr",
        "aes256-cbc"
      ],
      "compress": [
        "none",
        "zlib@openssh.com",
        "zlib"
      ],
      "hmac": [
        "hmac-sha2-256-etm@openssh.com",
        "hmac-sha2-512-etm@openssh.com",
        "hmac-sha1-etm@openssh.com",
        "hmac-sha2-256",
        "hmac-sha2-512",
        "hmac-sha1"
      ],
      "kex": [
        "curve25519-sha256",
        "curve25519-sha256@libssh.org",
        "ecdh-sha2-nistp256",
        "ecdh-sha2-nistp384",
        "ecdh-sha2-nistp521",
        "diffie-hellman-group14-sha256",
        "diffie-hellman-group-exchange-sha256",
        "diffie-hellman-group14-sha1"
      ],
      "serverHostKey": [
        "ssh-ed25519",
        "rsa-sha2-512",
        "rsa-sha2-256",
        "ecdsa-sha2-nistp256",
        "ecdsa-sha2-nistp384",
        "ecdsa-sha2-nistp521",
        "ssh-rsa"
      ]
    },
    "envAllowlist": []
  },
  "header": {
    "text": null,
    "background": "green"
  },
  "options": {
    "challengeButton": true,
    "autoLog": false,
    "allowReauth": true,
    "allowReconnect": true,
    "allowReplay": true,
    "replayCRLF": false
  },
  "session": {
    "secret": "test-session-secret-0123456789abcdef0123456789abcdef",
    "name": "webssh2.sid"
  },
  "sso": {
    "enabled": false,
    "csrfProtection": false,
    "trustedProxies": [],
    "headerMapping": {
      "username": "x-apm-username",
      "password": "x-apm-password",
      "session": "x-apm-session"
    }
  },
  "logging": {
    "minimumLevel": "info",
    "stdout": {
      "enabled": true
    }
  }
}
```

ssh_test server:
```bash
docker run -p 4422:22 \
  -e SSH_USER=testuser \
  -e SSH_PASSWORD=testpassword \ 
  ghcr.io/billchurch/ssh_test:alpine
```