### PR TITLE
fix: SSH algorithm env var precedence and debug output improvements

### DIFF
--- a/DOCS/configuration/ENVIRONMENT-VARIABLES.md
+++ b/DOCS/configuration/ENVIRONMENT-VARIABLES.md
@@ -247,15 +247,50 @@ You can configure SSH algorithms in two ways:
 | `WEBSSH2_SSH_ALGORITHMS_COMPRESS` | array | Compression algorithms |
 | `WEBSSH2_SSH_ALGORITHMS_SERVER_HOST_KEY` | array | Server host key algorithms |
 
-#### Algorithm Examples
+#### Algorithm Precedence
+
+**Individual algorithm settings override preset values.** When both a preset and individual algorithm variables are specified, the preset is applied first as a baseline, then individual settings override specific algorithm types.
+
+This allows you to extend presets with additional algorithms for legacy compatibility:
 
 ```bash
-# Using preset (recommended)
+# Use modern preset as baseline, but add hmac-sha1 for legacy server support
 WEBSSH2_SSH_ALGORITHMS_PRESET=modern
+WEBSSH2_SSH_ALGORITHMS_HMAC="hmac-sha1,hmac-sha2-256,hmac-sha2-512"
 
-# Using individual arrays
+# Result: Modern preset algorithms are used, except HMAC which uses your custom list
+```
+
+#### Algorithm Examples
+
+**Using preset (recommended):**
+
+```bash
+# Simple modern security profile
+WEBSSH2_SSH_ALGORITHMS_PRESET=modern
+```
+
+**Using individual arrays only:**
+
+```bash
+# Full manual configuration (no preset)
 WEBSSH2_SSH_ALGORITHMS_CIPHER="aes256-gcm@openssh.com,aes128-gcm@openssh.com"
 WEBSSH2_SSH_ALGORITHMS_KEX="ecdh-sha2-nistp256,ecdh-sha2-nistp384"
+WEBSSH2_SSH_ALGORITHMS_HMAC="hmac-sha2-256,hmac-sha2-512"
+WEBSSH2_SSH_ALGORITHMS_COMPRESS="none,zlib@openssh.com"
+WEBSSH2_SSH_ALGORITHMS_SERVER_HOST_KEY="ecdsa-sha2-nistp256,ssh-rsa"
+```
+
+**Extending preset with legacy compatibility:**
+
+```bash
+# Government/legacy server requiring hmac-sha1 alongside modern algorithms
+WEBSSH2_SSH_ALGORITHMS_PRESET=modern
+WEBSSH2_SSH_ALGORITHMS_HMAC="hmac-sha1,hmac-sha2-256,hmac-sha2-512"
+
+# FIPS environment with custom host keys
+WEBSSH2_SSH_ALGORITHMS_PRESET=strict
+WEBSSH2_SSH_ALGORITHMS_SERVER_HOST_KEY="rsa-sha2-256,rsa-sha2-512"
 ```
 
 ### SSH Stream Backpressure and Output Limits
@@ -621,6 +656,7 @@ Once satisfied with environment variable configuration, you can remove `config.j
 1. Use presets (`modern`, `legacy`, `strict`) for simplicity
 2. Individual algorithms must be valid SSH algorithm names
 3. Check SSH2 library documentation for supported algorithms
+4. Individual algorithm variables override preset values - use this to extend presets with legacy algorithms
 
 ## Support
 

--- a/app/config.ts
+++ b/app/config.ts
@@ -1,6 +1,7 @@
 // server
 // app/config.ts
 
+import { inspect } from 'node:util'
 import { generateSecureSecret, enhanceConfig, err } from './utils/index.js'
 import { createNamespacedDebug } from './logger.js'
 import { ConfigError } from './errors.js'
@@ -153,7 +154,9 @@ export async function loadConfigAsync(): Promise<Config> {
   }
   
   const finalConfig = result.value
-  debug('Loaded configuration: %O', maskSensitiveConfig(finalConfig))
+  const maskedConfig = maskSensitiveConfig(finalConfig)
+  // Use util.inspect with depth=null to show all nested arrays (especially algorithms)
+  debug('Loaded configuration: %s', inspect(maskedConfig, { depth: null, colors: false }))
   return finalConfig
 }
 

--- a/app/config/safe-logging.ts
+++ b/app/config/safe-logging.ts
@@ -6,7 +6,7 @@ import type { Config } from '../types/config.js'
 export interface MaskedConfig {
   listen: Config['listen']
   http: {
-    origins: string
+    origins: string[]
   }
   user: {
     name: string | null
@@ -25,11 +25,11 @@ export interface MaskedConfig {
     keepaliveCountMax: Config['ssh']['keepaliveCountMax']
     allowedSubnets: number
     algorithms: {
-      cipher: number
-      kex: number
-      hmac: number
-      compress: number
-      serverHostKey: number
+      cipher: string[]
+      kex: string[]
+      hmac: string[]
+      compress: string[]
+      serverHostKey: string[]
     }
   }
   header: Config['header']
@@ -55,13 +55,6 @@ const maskWhenFilled = (value: string | null | undefined): string | null => {
   return '***'
 }
 
-const describeOrigins = (origins: string[]): string => {
-  if (origins.length === 0) {
-    return 'none'
-  }
-  return `${origins.length} origin(s)`
-}
-
 const maskSessionSecret = (secret: string): string => {
   if (secret.length === 0) {
     return 'not set'
@@ -79,7 +72,7 @@ export const maskSensitiveConfig = (config: Config): MaskedConfig => {
   return {
     listen: config.listen,
     http: {
-      origins: describeOrigins(config.http.origins)
+      origins: [...config.http.origins]
     },
     user: {
       name: maskWhenFilled(config.user.name),
@@ -98,11 +91,11 @@ export const maskSensitiveConfig = (config: Config): MaskedConfig => {
       keepaliveCountMax: config.ssh.keepaliveCountMax,
       allowedSubnets: config.ssh.allowedSubnets?.length ?? 0,
       algorithms: {
-        cipher: config.ssh.algorithms.cipher.length,
-        kex: config.ssh.algorithms.kex.length,
-        hmac: config.ssh.algorithms.hmac.length,
-        compress: config.ssh.algorithms.compress.length,
-        serverHostKey: config.ssh.algorithms.serverHostKey.length
+        cipher: [...config.ssh.algorithms.cipher],
+        kex: [...config.ssh.algorithms.kex],
+        hmac: [...config.ssh.algorithms.hmac],
+        compress: [...config.ssh.algorithms.compress],
+        serverHostKey: [...config.ssh.algorithms.serverHostKey]
       }
     },
     header: config.header,

--- a/tests/unit/config/env-mapper.vitest.ts
+++ b/tests/unit/config/env-mapper.vitest.ts
@@ -1,0 +1,410 @@
+// tests/unit/config/env-mapper.vitest.ts
+// Unit tests for environment variable mapping with algorithm preset precedence
+
+import { describe, it, expect } from 'vitest'
+import { mapEnvironmentVariables } from '../../../app/config/env-mapper.js'
+
+describe('mapEnvironmentVariables', () => {
+  describe('algorithm preset precedence', () => {
+    it('applies preset when only preset is specified', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'modern'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          algorithms: {
+            cipher: ['aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes128-ctr'],
+            kex: ['ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521'],
+            hmac: ['hmac-sha2-256', 'hmac-sha2-512'],
+            compress: ['none', 'zlib@openssh.com'],
+            serverHostKey: ['ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'ssh-rsa']
+          }
+        }
+      })
+    })
+
+    it('individual HMAC setting overrides preset HMAC', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'modern',
+        WEBSSH2_SSH_ALGORITHMS_HMAC: 'hmac-sha1,hmac-sha2-256,hmac-sha2-512'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          algorithms: {
+            cipher: ['aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes128-ctr'],
+            kex: ['ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521'],
+            hmac: ['hmac-sha1', 'hmac-sha2-256', 'hmac-sha2-512'], // Individual override
+            compress: ['none', 'zlib@openssh.com'],
+            serverHostKey: ['ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'ssh-rsa']
+          }
+        }
+      })
+    })
+
+    it('individual cipher setting overrides preset cipher', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'modern',
+        WEBSSH2_SSH_ALGORITHMS_CIPHER: 'aes256-cbc,aes128-cbc'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          algorithms: {
+            cipher: ['aes256-cbc', 'aes128-cbc'], // Individual override
+            kex: ['ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521'],
+            hmac: ['hmac-sha2-256', 'hmac-sha2-512'],
+            compress: ['none', 'zlib@openssh.com'],
+            serverHostKey: ['ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'ssh-rsa']
+          }
+        }
+      })
+    })
+
+    it('individual KEX setting overrides preset KEX', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'modern',
+        WEBSSH2_SSH_ALGORITHMS_KEX: 'diffie-hellman-group14-sha256'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          algorithms: {
+            cipher: ['aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes128-ctr'],
+            kex: ['diffie-hellman-group14-sha256'], // Individual override
+            hmac: ['hmac-sha2-256', 'hmac-sha2-512'],
+            compress: ['none', 'zlib@openssh.com'],
+            serverHostKey: ['ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'ssh-rsa']
+          }
+        }
+      })
+    })
+
+    it('multiple individual settings override multiple preset values', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'modern',
+        WEBSSH2_SSH_ALGORITHMS_HMAC: 'hmac-sha1,hmac-sha2-256',
+        WEBSSH2_SSH_ALGORITHMS_CIPHER: 'aes256-cbc',
+        WEBSSH2_SSH_ALGORITHMS_COMPRESS: 'zlib'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          algorithms: {
+            cipher: ['aes256-cbc'], // Individual override
+            kex: ['ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521'], // From preset
+            hmac: ['hmac-sha1', 'hmac-sha2-256'], // Individual override
+            compress: ['zlib'], // Individual override
+            serverHostKey: ['ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'ssh-rsa']
+          }
+        }
+      })
+    })
+
+    it('individual settings work without preset', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_HMAC: 'hmac-sha1,hmac-sha2-256',
+        WEBSSH2_SSH_ALGORITHMS_CIPHER: 'aes256-cbc'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          algorithms: {
+            cipher: ['aes256-cbc'],
+            hmac: ['hmac-sha1', 'hmac-sha2-256']
+          }
+        }
+      })
+    })
+
+    it('applies legacy preset correctly', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'legacy'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          algorithms: {
+            cipher: ['aes256-cbc', 'aes192-cbc', 'aes128-cbc', '3des-cbc'],
+            kex: ['diffie-hellman-group14-sha1', 'diffie-hellman-group1-sha1'],
+            hmac: ['hmac-sha1', 'hmac-md5'],
+            compress: ['none', 'zlib'],
+            serverHostKey: ['ssh-rsa', 'ssh-dss']
+          }
+        }
+      })
+    })
+
+    it('applies strict preset correctly', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'strict'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          algorithms: {
+            cipher: ['aes256-gcm@openssh.com'],
+            kex: ['ecdh-sha2-nistp256'],
+            hmac: ['hmac-sha2-256'],
+            compress: ['none'],
+            serverHostKey: ['ecdsa-sha2-nistp256']
+          }
+        }
+      })
+    })
+
+    it('ignores invalid preset name', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'invalid-preset-name'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({})
+    })
+
+    it('case-insensitive preset names', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'MODERN'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          algorithms: {
+            cipher: ['aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes128-ctr'],
+            kex: ['ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521'],
+            hmac: ['hmac-sha2-256', 'hmac-sha2-512'],
+            compress: ['none', 'zlib@openssh.com'],
+            serverHostKey: ['ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'ssh-rsa']
+          }
+        }
+      })
+    })
+  })
+
+  describe('other environment variables', () => {
+    it('maps PORT to listen.port', () => {
+      const env = {
+        PORT: '3000'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        listen: {
+          port: 3000
+        }
+      })
+    })
+
+    it('maps WEBSSH2_LISTEN_IP and WEBSSH2_LISTEN_PORT', () => {
+      const env = {
+        WEBSSH2_LISTEN_IP: '127.0.0.1',
+        WEBSSH2_LISTEN_PORT: '8080'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        listen: {
+          ip: '127.0.0.1',
+          port: 8080
+        }
+      })
+    })
+
+    it('maps SSH connection settings', () => {
+      const env = {
+        WEBSSH2_SSH_HOST: 'example.com',
+        WEBSSH2_SSH_PORT: '2222',
+        WEBSSH2_SSH_TERM: 'xterm-256color'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          host: 'example.com',
+          port: 2222,
+          term: 'xterm-256color'
+        }
+      })
+    })
+
+    it('maps array values correctly', () => {
+      const env = {
+        WEBSSH2_HTTP_ORIGINS: 'http://localhost:3000,https://example.com',
+        WEBSSH2_SSH_ENV_ALLOWLIST: 'LANG,PATH,HOME'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        http: {
+          origins: ['http://localhost:3000', 'https://example.com']
+        },
+        ssh: {
+          envAllowlist: ['LANG', 'PATH', 'HOME']
+        }
+      })
+    })
+
+    it('maps boolean values correctly', () => {
+      const env = {
+        WEBSSH2_OPTIONS_CHALLENGE_BUTTON: 'true',
+        WEBSSH2_OPTIONS_AUTO_LOG: 'false'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        options: {
+          challengeButton: true,
+          autoLog: false
+        }
+      })
+    })
+
+    it('ignores undefined environment variables', () => {
+      const env = {
+        WEBSSH2_SSH_HOST: 'example.com',
+        SOME_OTHER_VAR: 'ignored'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          host: 'example.com'
+        }
+      })
+    })
+
+    it('maps complex nested paths correctly', () => {
+      const env = {
+        WEBSSH2_SSO_ENABLED: 'true',
+        WEBSSH2_SSO_HEADER_USERNAME: 'X-Remote-User',
+        WEBSSH2_SSO_HEADER_PASSWORD: 'X-Remote-Password'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        sso: {
+          enabled: true,
+          headerMapping: {
+            username: 'X-Remote-User',
+            password: 'X-Remote-Password'
+          }
+        }
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty environment object', () => {
+      const result = mapEnvironmentVariables({})
+      expect(result).toEqual({})
+    })
+
+    it('handles empty string values', () => {
+      const env = {
+        WEBSSH2_SSH_HOST: ''
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      // Empty strings are parsed as null by the env parser
+      expect(result).toEqual({
+        ssh: {
+          host: null
+        }
+      })
+    })
+
+    it('combines preset with non-algorithm settings', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'modern',
+        WEBSSH2_SSH_HOST: 'example.com',
+        WEBSSH2_SSH_PORT: '22',
+        WEBSSH2_OPTIONS_AUTO_LOG: 'true'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result).toEqual({
+        ssh: {
+          host: 'example.com',
+          port: 22,
+          algorithms: {
+            cipher: ['aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes128-ctr'],
+            kex: ['ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521'],
+            hmac: ['hmac-sha2-256', 'hmac-sha2-512'],
+            compress: ['none', 'zlib@openssh.com'],
+            serverHostKey: ['ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'ssh-rsa']
+          }
+        },
+        options: {
+          autoLog: true
+        }
+      })
+    })
+  })
+
+  describe('real-world use cases', () => {
+    it('government/legacy server requiring hmac-sha1 with modern preset', () => {
+      // Use case from issue: extend modern preset with hmac-sha1 for legacy servers
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'modern',
+        WEBSSH2_SSH_ALGORITHMS_HMAC: 'hmac-sha1,hmac-sha2-256,hmac-sha2-512'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result.ssh).toHaveProperty('algorithms')
+      const algorithms = result.ssh as Record<string, unknown>
+      expect(algorithms.algorithms).toHaveProperty('hmac')
+      const algoObj = algorithms.algorithms as Record<string, unknown>
+      expect(algoObj.hmac).toEqual(['hmac-sha1', 'hmac-sha2-256', 'hmac-sha2-512'])
+      // Other preset values remain
+      expect(algoObj.cipher).toEqual(['aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes128-ctr'])
+    })
+
+    it('FIPS environment with custom server host keys', () => {
+      const env = {
+        WEBSSH2_SSH_ALGORITHMS_PRESET: 'strict',
+        WEBSSH2_SSH_ALGORITHMS_SERVER_HOST_KEY: 'rsa-sha2-256,rsa-sha2-512'
+      }
+
+      const result = mapEnvironmentVariables(env)
+
+      expect(result.ssh).toHaveProperty('algorithms')
+      const algorithms = result.ssh as Record<string, unknown>
+      expect(algorithms.algorithms).toHaveProperty('serverHostKey')
+      const algoObj = algorithms.algorithms as Record<string, unknown>
+      expect(algoObj.serverHostKey).toEqual(['rsa-sha2-256', 'rsa-sha2-512'])
+      // Other strict preset values remain
+      expect(algoObj.cipher).toEqual(['aes256-gcm@openssh.com'])
+      expect(algoObj.hmac).toEqual(['hmac-sha2-256'])
+    })
+  })
+})


### PR DESCRIPTION
This commit addresses two related issues with SSH algorithm configuration:

1. Environment Variable Precedence Issue
   - Individual algorithm env vars now correctly override preset values
   - Previously: WEBSSH2_SSH_ALGORITHMS_PRESET would overwrite individual algorithm settings (e.g., WEBSSH2_SSH_ALGORITHMS_HMAC)
   - Now: Preset is applied first as baseline, then individual vars override specific algorithm types

2. Debug Output Enhancement (Issue #459)
   - Debug config output now shows actual values instead of counts
   - Previously: algorithms: { cipher: 4 }, http: { origins: '1 origin(s)' }
   - Now: algorithms: { cipher: ['aes256-ctr', ...] }, http: { origins: [...] }
   - Added util.inspect with depth=null to show all nested arrays
   - Improves debugging and configuration validation

Root Causes Fixed:
- Processing order: Preset now processed before individual overrides
- Shared object mutation: Added deep cloning of preset objects to prevent mutation of global ALGORITHM_PRESETS constant
- Debug depth limit: Used util.inspect with depth=null instead of %O formatter
- Origins masking: Changed from count string to actual origins array

Changes:
- app/config.ts: Import util.inspect and use it with depth=null for full output
- app/config/env-mapper.ts: Two-pass processing with defensive cloning
- app/config/safe-logging.ts: Updated MaskedConfig type and implementation to show algorithm arrays and origins array instead of counts
- tests/unit/config/env-mapper.vitest.ts: Added 22 comprehensive tests
- tests/unit/config/safe-logging.vitest.ts: Updated tests for arrays
- DOCS/configuration/ENVIRONMENT-VARIABLES.md: Added Algorithm Precedence docs

Benefits:
- Users can extend security presets with legacy algorithms for compatibility
- Improved debugging with actual algorithm and origin names visible in logs
- Better validation of environment variable configurations
- Consistent with security best practices (algorithm/origin names are not secrets)

Testing:
- All 57 config unit tests pass (35 new tests added)
- TypeScript compilation: 0 errors
- ESLint: 0 errors, 0 warnings
- Tested real-world scenarios: legacy server compatibility, FIPS environments
- Manually verified debug output shows full nested arrays

Closes #459

## Summary

- What changed and why?

## Checklist

- [x] Unit tests updated/added
- [x] Ran local smoke tests (HTTP routes, Socket.IO exec/resize)
- [x] No public route changes (paths, query params)
- [x] No Socket.IO event name/payload changes
- [x] `npm run typecheck` (if configured) passes
- [x] `npm test`/`vitest` passes
- [x] Updated docs (TS-MIGRATTE.md or relevant DOCS/* if needed)

## Checkpoint (optional)

Add `[checkpoint]` to the PR title to trigger a manual approval gate in CI for human functional testing.

