### PR TITLE
feat(debug): add ssh2 protocol-level debug logging

### DIFF
--- a/DOCS/reference/TROUBLESHOOTING.md
+++ b/DOCS/reference/TROUBLESHOOTING.md
@@ -71,6 +71,57 @@ DEBUG=* npm run start
 3. Check SSH logs: `tail -f /var/log/auth.log`
 4. Verify network path: `ping target-host`
 
+#### "No matching key exchange method" or Algorithm Negotiation Failure
+
+**Causes:**
+- Target device only supports legacy algorithms (common with Cisco IOS, older network equipment)
+- WebSSH2 algorithms configuration not including required algorithms
+
+**Solutions:**
+1. Enable SSH2 protocol debug to see negotiation details:
+   ```bash
+   DEBUG=webssh2:ssh2 npm run start
+   ```
+
+2. Check the debug output for algorithm negotiation:
+   - Look for `Outgoing: Sending KEXINIT` to see what WebSSH2 offers
+   - Look for `Inbound: Received KEXINIT` to see what the server offers
+   - Compare the lists to find mismatches
+
+3. Configure required algorithms in `config.json`:
+   ```json
+   {
+     "ssh": {
+       "algorithms": {
+         "kex": [
+           "ecdh-sha2-nistp256",
+           "diffie-hellman-group14-sha1"
+         ],
+         "serverHostKey": [
+           "ssh-ed25519",
+           "ssh-rsa"
+         ],
+         "cipher": [
+           "aes256-ctr",
+           "aes128-ctr"
+         ],
+         "hmac": [
+           "hmac-sha2-256",
+           "hmac-sha1"
+         ]
+       }
+     }
+   }
+   ```
+
+4. For legacy devices (Cisco IOS, older equipment), ensure these algorithms are included:
+   - KEX: `diffie-hellman-group14-sha1`
+   - Host Key: `ssh-rsa`
+   - Cipher: `aes256-ctr` or `aes128-ctr`
+   - MAC: `hmac-sha2-256` or `hmac-sha1`
+
+See [Supported Algorithms](ALGORITHMS.md) for the full list of available algorithms.
+
 ### Authentication Issues
 
 #### "401 Unauthorized"

--- a/app/services/ssh/ssh-service.ts
+++ b/app/services/ssh/ssh-service.ts
@@ -34,6 +34,7 @@ import { isAuthMethodAllowed } from '../../auth/auth-method-policy.js'
 import { STREAM_LIMITS } from '../../constants/index.js'
 
 const logger = debug('webssh2:services:ssh')
+const ssh2ProtocolLogger = debug('webssh2:ssh2')
 
 export class SSHServiceImpl implements SSHService {
   private readonly pool = new ConnectionPool()
@@ -92,6 +93,11 @@ export class SSHServiceImpl implements SSHService {
 
     if (config.algorithms !== undefined) {
       connectConfig.algorithms = config.algorithms
+    }
+
+    // Enable ssh2 protocol-level debug when webssh2:ssh2 namespace is active
+    if (ssh2ProtocolLogger.enabled) {
+      connectConfig.debug = (msg: string) => ssh2ProtocolLogger(msg)
     }
 
     return connectConfig


### PR DESCRIPTION
## Summary
- Enable detailed SSH2 protocol debugging via the `webssh2:ssh2` debug namespace
- Exposes algorithm negotiation, key exchange, and authentication details from the underlying ssh2 library
- Add troubleshooting documentation for algorithm negotiation failures with legacy devices

## Usage
```bash
DEBUG=webssh2:ssh2 npm run start
```

This is useful for diagnosing connection issues with legacy SSH servers (Cisco IOS, older network equipment) that only support older algorithms like `diffie-hellman-group14-sha1`.

## Test plan
- [x] Run with `DEBUG=webssh2:ssh2` and verify protocol output appears
- [x] Connect to legacy SSH server and verify algorithm negotiation is visible
- [x] Lint and typecheck pass