### PR TITLE
chore(deps): update webssh2_client to 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "socket.io": "^4.8.1",
         "ssh2": "1.17",
         "validator": "^13.15.23",
-        "webssh2_client": "^3.2.2",
+        "webssh2_client": "^3.3.0",
         "zod": "^4.1.12"
       },
       "bin": {
@@ -5393,9 +5393,9 @@
       }
     },
     "node_modules/webssh2_client": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-3.2.2.tgz",
-      "integrity": "sha512-ic0efGktlfc5WxwsHjVoBdYUPmW4x40wDnlr7kFn1c5fo5GvLDXVaC4g81RCsx/NaFtW98+uNfJB8f/KktYVdQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-3.3.0.tgz",
+      "integrity": "sha512-Fa6GA/f4shi/ykqiKHIi7W1thRXRfR1005oMho7o2OGWSdLcBMRjB5Ng5Q4CU/6d0AoJLKgA8PQoV5Txza8baw==",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-search": "^0.16.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "socket.io": "^4.8.1",
     "ssh2": "1.17",
     "validator": "^13.15.23",
-    "webssh2_client": "^3.2.2",
+    "webssh2_client": "^3.3.0",
     "zod": "^4.1.12"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- Updates webssh2_client from 3.2.2 to 3.3.0
- Adds slide-out special key sender panel (billchurch/webssh2_client#90, ca81f68)

## Test plan
- [x] Verify terminal loads correctly with updated client
- [x] Verify new key sender panel appears and sends keys