### PR TITLE
fix: pin node:22-alpine base image by digest (#498)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 # syntax=docker/dockerfile:1.7
 
+ARG BASE_IMAGE=node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f
+
 # =============================================================================
 # Stage 1: Dependencies
 # Purpose: Install and cache all dependencies with BuildKit cache mounts
 # This stage is optimized for layer caching and reuse
 # =============================================================================
-FROM node:22-alpine AS deps
+FROM ${BASE_IMAGE} AS deps
 WORKDIR /srv/webssh2
 
 # Install dependencies with cache mount for faster rebuilds
@@ -22,7 +24,7 @@ RUN --mount=type=cache,target=/root/.npm \
 # Purpose: Compile TypeScript to JavaScript
 # Uses dependencies from deps stage to avoid reinstalling
 # =============================================================================
-FROM node:22-alpine AS builder
+FROM ${BASE_IMAGE} AS builder
 WORKDIR /srv/webssh2
 
 ENV NODE_ENV=development
@@ -46,7 +48,7 @@ RUN npm run build
 # Purpose: Minimal production image with only runtime dependencies
 # Includes tini for proper init system (signal handling, zombie reaping)
 # =============================================================================
-FROM node:22-alpine AS runtime
+FROM ${BASE_IMAGE} AS runtime
 WORKDIR /srv/webssh2
 
 # Install tini for proper signal handling and zombie process reaping

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
+# The "22-alpine" tag is intentional alongside the digest: Renovate's
+# matchCurrentValue rule keys on it to gate digest-only auto-merges
+# (see .github/renovate.json). Docker resolves the pull via the digest;
+# the tag is documentation + Renovate metadata. The Sonar rule
+# docker:S8431 is suppressed for this file in sonar-project.properties.
 ARG BASE_IMAGE=node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f
 
 # =============================================================================

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,7 +25,9 @@ sonar.exclusions=node_modules/**,coverage/**,client/public/**,*.md,*.json,tests/
 # S2068: Hard-coded credentials (acceptable in test files)
 # S4036: Searching OS commands in PATH (needed for test infrastructure)
 # S6290: Hardcoded secrets (TypeScript variant)
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10
+# S8431: Tag+digest in FROM is the Renovate-recommended pattern; the
+#        tag is required by .github/renovate.json matchCurrentValue.
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S2068
 sonar.issue.ignore.multicriteria.e1.resourceKey=tests/**/*
 sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S4036
@@ -46,6 +48,8 @@ sonar.issue.ignore.multicriteria.e9.ruleKey=typescript:S2068
 sonar.issue.ignore.multicriteria.e9.resourceKey=tests/test-constants.ts
 sonar.issue.ignore.multicriteria.e10.ruleKey=typescript:S1313
 sonar.issue.ignore.multicriteria.e10.resourceKey=tests/test-constants.ts
+sonar.issue.ignore.multicriteria.e11.ruleKey=docker:S8431
+sonar.issue.ignore.multicriteria.e11.resourceKey=Dockerfile
 
 # Language Configuration
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

Closes #498.

Adds a global `ARG BASE_IMAGE=node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f` before the first `FROM`, and rewrites each `FROM` stage (`deps`, `builder`, `runtime`) to reference `${BASE_IMAGE}`. The pinned digest is the current `node:22-alpine` manifest-list digest (Alpine 3.23.4, multi-arch preserving). Renovate in a later PR will update the digest via a one-line diff.

## Why the digest differs from the issue-cited value

The issue cites `sha256:cb15fca9...` (the amd64 sub-manifest digest nested inside the manifest list). This PR pins `sha256:8ea2348b...` (the manifest-list/index digest) — same Alpine 3.23.4 content, but preserves multi-arch (linux/amd64 + linux/arm64) support that the current `docker buildx` multi-platform build needs.

## Test plan

- [x] `docker buildx build --platform linux/amd64 --load .` succeeds locally
- [x] Smoke test: container logs "server started successfully" within ~4s
- [ ] After merge, dispatch `docker-publish.yml` with `publish_latest=true` to republish `latest` / `main`
- [ ] Comment on #498 with the new published image digest; close

## Part of the larger plan

This is PR 1 of 4. Subsequent PRs add image scanning (PR 2), Renovate auto-merge for digest updates (PR 3), and an event-driven release-tag rebuild workflow (PR 4).