### PR TITLE
ci: add image scanning gate to PR and publish flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,74 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
+
+  docker-image-scan:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    concurrency:
+      group: docker-image-scan-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            image:
+              - 'Dockerfile'
+              - 'package-lock.json'
+              - 'package.json'
+              - '.github/workflows/docker-publish.yml'
+
+      - name: Note when nothing image-relevant changed
+        if: steps.filter.outputs.image != 'true'
+        run: echo "No image-relevant changes; passing required check as a no-op."
+
+      - name: Note fork PR skip
+        if: >-
+          steps.filter.outputs.image == 'true' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "Fork PR; image scan skipped (advisory; main-branch scan is the gate)."
+
+      - name: Login to Docker Hub (raise anon rate-limit)
+        if: >-
+          steps.filter.outputs.image == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Set up buildx
+        if: >-
+          steps.filter.outputs.image == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build amd64 image for scanning
+        if: >-
+          steps.filter.outputs.image == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          load: true
+          tags: webssh2:pr-${{ github.event.pull_request.number }}
+          platforms: linux/amd64
+          cache-from: type=gha,scope=publish-refs/heads/main
+
+      - name: Trivy image scan
+        if: >-
+          steps.filter.outputs.image == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: webssh2:pr-${{ github.event.pull_request.number }}
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+          cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,4 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
           cache: true
+          trivyignores: .trivyignore

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -165,6 +165,7 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
           cache: true
+          trivyignores: .trivyignore
 
       - name: Upload SARIF
         if: always()

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,8 +24,8 @@ on:
       - main
 
 concurrency:
-  group: docker-publish-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: image-publish
+  cancel-in-progress: false
 
 jobs:
   build-and-push:
@@ -144,6 +144,50 @@ jobs:
             type=ref,event=branch,enable=${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref != 'refs/heads/main' }}
             type=sha
 
+      - name: Build amd64 image (load, for scan + smoke)
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          platforms: linux/amd64
+          tags: local/webssh2:scan
+          cache-from: type=gha,scope=publish-${{ github.ref }}
+          cache-to: type=gha,mode=max,scope=publish-${{ github.ref }}
+
+      - name: Trivy image scan (fail closed)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: local/webssh2:scan
+          format: sarif
+          output: trivy-image.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+          cache: true
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image
+
+      - name: Smoke-test amd64 image
+        run: |
+          CID=$(docker run -d --rm \
+            -e DEBUG=webssh2:* local/webssh2:scan)
+          for i in {1..30}; do
+            if docker logs "$CID" 2>&1 | grep -q "server started successfully"; then
+              docker stop "$CID"
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs "$CID"
+          docker stop "$CID" || true
+          exit 1
+
       - name: Build and push docker image
         id: build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -158,36 +202,11 @@ jobs:
           # BuildKit cache configuration
           # - Use GitHub Actions cache for faster rebuilds
           # - mode=max caches all layers (not just final stage)
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=publish-${{ github.ref }}
+          cache-to: type=gha,mode=max,scope=publish-${{ github.ref }}
           # BuildKit features for optimization
           build-args: |
             BUILDKIT_INLINE_CACHE=1
-
-      - name: Test docker image
-        run: |
-          # Pull the image we just built (for current platform)
-          docker pull ${{ steps.ghcr.outputs.image }}:sha-${GITHUB_SHA::7}
-
-          # Start container and verify it runs
-          CONTAINER_ID=$(docker run -d --rm \
-            -e DEBUG=webssh2:* \
-            ${{ steps.ghcr.outputs.image }}:sha-${GITHUB_SHA::7})
-
-          # Wait up to 30 seconds for startup
-          for i in {1..30}; do
-            if docker logs "$CONTAINER_ID" 2>&1 | grep -q "server started successfully"; then
-              echo "✓ Container started successfully"
-              docker stop "$CONTAINER_ID"
-              exit 0
-            fi
-            sleep 1
-          done
-
-          echo "✗ Container failed to start"
-          docker logs "$CONTAINER_ID"
-          docker stop "$CONTAINER_ID"
-          exit 1
 
       - name: Update release notes with Docker images
         if: ${{ steps.release_meta.outputs.has_release == 'true' }}

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,10 @@
+# Trivy ignore rules — every entry MUST link to a SECURITY.md assessment.
+# Format: one CVE per line; trailing comment optional but encouraged.
+
+# CVE-2026-33671 — picomatch 4.0.3 ReDoS bundled inside the global npm shipped
+# in node:22-alpine. Not exploitable in our runtime image: the container
+# entrypoint is `node dist/index.js`; the bundled npm is never invoked.
+# See SECURITY.md → "CVE-2026-33671 (picomatch ReDoS in bundled npm)".
+# Re-evaluate when upstream node:22-alpine ships an npm release that pulls
+# picomatch >= 4.0.4; remove this entry then.
+CVE-2026-33671

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,6 +89,34 @@ This vulnerability affects the `fromJSON` and `fromCrossJSON` functions in clien
 - All JSX uses Solid.js safe text binding
 - Terminal output is rendered through xterm.js which safely handles escape sequences
 
+### CVE-2026-33671 (picomatch ReDoS in bundled npm)
+
+| Aspect             | Status                                                                          |
+| ------------------ | ------------------------------------------------------------------------------- |
+| Vulnerability type | Regular Expression Denial of Service (ReDoS) via crafted extglob patterns       |
+| Affected versions  | picomatch < 4.0.4 (also fixed in 3.0.2 and 2.3.2)                               |
+| Our exposure       | picomatch 4.0.3 bundled inside the global `npm` shipped in `node:22-alpine`     |
+| Path on disk       | `/usr/local/lib/node_modules/npm/node_modules/picomatch` (in the runtime image) |
+| Status             | **Not exploitable** — bundled `npm` is never executed at runtime                |
+
+**Why we are not affected:**
+
+- The container's `ENTRYPOINT` is `tini` and `CMD` is `node dist/index.js`.
+- The application never invokes `npm`, `npx`, or any code path that loads
+  `picomatch` from the global npm install. There is no shell exec of `npm`,
+  no `child_process.spawn('npm', ...)`, and no library in our production
+  dependency closure that pulls picomatch.
+- An attacker would need code execution inside the container to reach
+  picomatch — at which point ReDoS is the least of our concerns.
+
+**Mitigation status:**
+
+- The `.trivyignore` file at the repo root suppresses this single CVE for the
+  Trivy image scan gate so unrelated image regressions still fail the build.
+- Tracking upstream: re-evaluate when `node:22-alpine` ships a bundled
+  `npm` whose `picomatch` is `>= 4.0.4`. At that point Renovate's auto-merged
+  digest bump will land the fix and the `.trivyignore` entry should be removed.
+
 ---
 
 ## Shai-hulud 2.0 supply chain risk


### PR DESCRIPTION
## Summary

- New `docker-image-scan` job in `.github/workflows/ci.yml`. Always runs so it satisfies a future required status check, but only does real work (Docker Hub authenticated pull → amd64 build with `--load` → Trivy image scan, fail closed on CRITICAL/HIGH fixable findings) when the PR touches `Dockerfile`, `package-lock.json`, `package.json`, or `.github/workflows/docker-publish.yml`. Fork PRs skip the scan (no secrets; `main`-branch scan is the gate).
- `.github/workflows/docker-publish.yml` restructured to four phases: build amd64 (load) → Trivy image scan (fail closed, SARIF uploaded) → smoke-test → multi-arch build+push. The previous `Test docker image` step (which ran AFTER push) is removed; a broken image can no longer land on `latest` before the test catches it.
- Shared concurrency group `image-publish` on the publish workflow. PR 4's upcoming `rebuild-release-tags.yml` joins the same group so release publishes and base-image rebuilds cannot interleave.
- GHA cache scoped per `github.ref` in publish flow (prevents feature-branch cache poisoning). PR-time scan uses read-only cache from the main-line scope.

## Secret names

Uses `secrets.DOCKER_USERNAME` / `secrets.DOCKER_TOKEN` (matches existing `docker-publish.yml` env block). The plan's original sample YAML had `DOCKERHUB_*`; corrected in the plan on main.

## Required-check bootstrap

PR 0 (operator-run `gh api` commands, see `DOCS/superpowers/plans/2026-04-24-docker-supply-chain-hardening.md`) registers `docker-image-scan` as a required status check on `main`. Since the job doesn't exist yet until this PR merges, admin override is needed for this PR's own merge — or temporarily remove `docker-image-scan` from the required contexts for the merge, then re-add.

## Test plan

- [ ] Open a draft PR with a deliberately vulnerable base digest; confirm `docker-image-scan` fails it
- [ ] After merge, dispatch `docker-publish.yml` on main and verify the new ordering: build amd64 → Trivy → Upload SARIF → Smoke → Multi-arch push
- [ ] Confirm the `trivy-image` SARIF category appears in Security → Code scanning

## Part of the larger plan

PR 2 of 4. Follows PR 1 (Dockerfile digest pin) and precedes PR 3 (Renovate auto-merge) and PR 4 (release-tag rebuild).