### PR TITLE
ci: add Renovate config for node:22-alpine digest auto-merge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "schedule": ["* 0-6 * * *"],
+  "timezone": "America/New_York",
+  "dockerfile": { "enabled": true },
+  "packageRules": [
+    {
+      "description": "Auto-merge digest-only base image updates for node:22-alpine",
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["digest"],
+      "matchDepNames": ["node"],
+      "matchCurrentValue": "22-alpine",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "rebaseWhen": "behind-base-branch",
+      "groupName": null,
+      "separateMinorPatch": true
+    },
+    {
+      "description": "Require human review for base image version bumps",
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "automerge": false
+    }
+  ]
+}

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,4 +1,8 @@
-# Use node:22-alpine as a parent image for smallest size and best security
+# NOTE: This is a documentation sample, not the production Dockerfile.
+# For production, pin the base image to a specific manifest digest, e.g.:
+#   ARG BASE_IMAGE=node:22-alpine@sha256:<64-hex>
+#   FROM ${BASE_IMAGE}
+# This protects against upstream tag mutation and supply-chain attacks.
 FROM node:22-alpine
 
 # Alpine uses ash shell by default, which is sufficient for our needs


### PR DESCRIPTION
## Summary

- New `.github/renovate.json`. Daily schedule (`"* 0-6 * * *"`, America/New_York) for fast CVE response. Auto-merge restricted to digest-only updates of exactly `node:22-alpine` via `matchDepNames: ["node"]` + `matchCurrentValue: "22-alpine"` + `matchUpdateTypes: ["digest"]`. Any tag-coordinate change (`22-alpine` → `23-alpine`, `22-slim`, etc.) falls through to the second rule which requires human review. `groupName: null` + `separateMinorPatch: true` prevent Renovate from bundling a digest bump with a version change into one PR. `rebaseWhen: behind-base-branch` set explicitly so auto-merge doesn't stall under strict branch protection.
- `examples/Dockerfile` gains a doc-level pinning reminder (comment-only; no directive changes). Wording describes what production should do without asserting current repo-root state, so the comment is resilient to merge order.

## Depends on

- PR 0 operator-run repo settings (`allow_auto_merge: true`, required status checks). Without those, `platformAutomerge: true` is a silent no-op.
- PR 2 (image scanning) — the `docker-image-scan` job is what makes Renovate auto-merge safe.

## Prerequisite (not in this PR)

Install the Renovate GitHub App against `billchurch/webssh2` at https://github.com/apps/renovate. Renovate will auto-open an onboarding PR; close it pointing to this PR.

## Test plan

- [ ] After merge + app install: wait for Renovate's first real digest PR
- [ ] Verify `docker-image-scan` runs on the PR
- [ ] Verify Renovate auto-merges on green
- [ ] Verify `docker-publish.yml` fires on the merge and publishes fresh `latest`/`main`
- [ ] (After PR 4 lands) Verify `rebuild-release-tags.yml` fans out and refreshes the current release tag series

## Part of the larger plan

PR 3 of 4.