### PR TITLE
fix(ci): restore CRITICAL,HIGH gate in docker-publish Trivy step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -166,6 +166,12 @@ jobs:
           exit-code: '1'
           cache: true
           trivyignores: .trivyignore
+          # Keep --severity CRITICAL,HIGH applied to BOTH SARIF generation
+          # and exit-code evaluation. Without this, trivy-action unsets
+          # TRIVY_SEVERITY in sarif mode (to capture all severities), which
+          # silently disables our gate and lets MEDIUM/LOW findings fail
+          # the publish.
+          limit-severities-for-sarif: 'true'
 
       - name: Upload SARIF
         if: always()


### PR DESCRIPTION
## Summary

The post-merge publish from PR #500 failed because `trivy-action` v0.35.0 unsets `TRIVY_SEVERITY` when `format: sarif` is used (so the SARIF can carry all severities for the Security tab). As a side effect, `--exit-code 1` then fires on **any** finding, including MEDIUM/LOW — silently disabling our intended `CRITICAL,HIGH` gate.

Today's main publish failed on two MEDIUM findings in the bundled `npm` shipped inside `node:22-alpine`:

- `CVE-2026-33672` (picomatch 4.0.3 — a second ReDoS, distinct from the already-suppressed 33671)
- `CVE-2026-33750` (brace-expansion 2.0.2)

Both are bundled-npm only, never executed at runtime in the produced image — same exposure profile as `CVE-2026-33671`.

## Fix

Set `limit-severities-for-sarif: 'true'` on the `docker-publish.yml` Trivy step. This keeps `--severity CRITICAL,HIGH` applied to both SARIF generation and the exit-code check.

## Tradeoff

The SARIF uploaded to the Security tab will only contain CRITICAL/HIGH findings, not all severities. That matches the PR-level `docker-image-scan` in `ci.yml` (which uses `format: table` with the severity filter applied) and matches our stated gate intent.

## Test plan

- [x] CI green (build-lint-test, docker-image-scan)
- [x] After merge, dispatch `docker-publish.yml --ref main -f publish_latest=true` and confirm the Trivy step passes
- [x] Confirm `latest` is republished with the pinned-base image

## Related

- PR #499 (digest pin) merged as ac41510
- PR #500 (image scan + restructure) merged as a2661c6
- Failed publish: https://github.com/billchurch/webssh2/actions/runs/24932812231