### PR TITLE
ci(fix): grant docker-publish security-events: write for SARIF upload

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,6 +37,12 @@ jobs:
     permissions:
       contents: write
       packages: write
+      # Required for github/codeql-action/upload-sarif to push the
+      # Trivy image-scan SARIF into the repo's Security tab. Without
+      # this, the upload step fails with "Resource not accessible by
+      # integration" and aborts the rest of the pipeline (smoke test
+      # and multi-arch push get skipped via default success() gating).
+      security-events: write
     env:
       DOCKERHUB_USER: ${{ secrets.DOCKER_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
## Summary

The post-merge \`docker-publish\` run on \`main\` after PR #502 failed at the \"Upload SARIF\" step with \`Resource not accessible by integration\`. Cause: the \`build-and-push\` job's \`permissions\` block declares \`contents: write\` and \`packages: write\` but **not** \`security-events: write\`, which \`github/codeql-action/upload-sarif\` requires.

Because \`Upload SARIF\` failed, the subsequent \`Smoke-test\`, \`Build and push\`, and release-notes steps were skipped (default \`success()\` gating). No image was pushed.

## Fix

Add \`security-events: write\` to the job-level \`permissions\` block.

## Test plan

- [ ] CI green on this PR (no required check needs the new permission)
- [ ] After merge, the auto-fired \`docker-publish\` on \`main\` runs end-to-end: build → scan → SARIF upload → smoke-test → multi-arch push → release-notes
- [ ] \`billchurch/webssh2:latest\` and \`:main\` reflect the new image digest
- [ ] Trivy SARIF appears under Security → Code scanning with category \`trivy-image\`

## Related

- Failed run: https://github.com/billchurch/webssh2/actions/runs/24933656776
- PR #500 added the SARIF upload but didn't add the matching permission
- PR #505 fixed the unrelated severity-gate bug in the same step