### PR TITLE
ci: tighten rebuild-release-tags workflow permissions to least privilege

### DIFF
--- a/.github/workflows/rebuild-release-tags.yml
+++ b/.github/workflows/rebuild-release-tags.yml
@@ -18,9 +18,10 @@ concurrency:
   group: image-publish
   cancel-in-progress: false
 
+# Workflow-level permissions are read-only. Each job overrides with the
+# minimum it needs (least privilege per Sonar githubactions:S8233).
 permissions:
   contents: read
-  packages: write
 
 jobs:
   guard:


### PR DESCRIPTION
## Summary

Resolves SonarCloud \`githubactions:S8233\` on \`rebuild-release-tags.yml\` line 23.

The workflow-level \`permissions\` block granted \`packages: write\` to every job, but only the \`rebuild\` job ever pushes to a registry. The \`guard\` job is read-only (uses \`gh api\` / \`gh release\` for status checks; no writes anywhere).

## Change

- Workflow-level: drop \`packages: write\`; keep \`contents: read\`
- \`rebuild\` job: unchanged (already declares its own \`contents: write\` + \`packages: write\`)
- \`guard\` job: inherits \`contents: read\` only

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the next workflow_run-triggered guard execution still completes (the trigger comes from docker-publish.yml; guard's gh api reads only need contents: read)