### PR TITLE
ci: use client-id for App token (drop deprecated app-id)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0


### PR DESCRIPTION
## Summary

`actions/create-github-app-token@v3` deprecated the `app-id` input in favor of `client-id`. Switch to the new input to silence the deprecation warning.

## Required setup before merge

Add a new repo secret:

- `RELEASE_APP_CLIENT_ID` — the **Client ID** value (looks like `Iv23li...`) shown at the top of your GitHub App's settings page, **not** the numeric App ID.

You can copy it from: https://github.com/settings/apps/<your-app-name>

```bash
gh secret set RELEASE_APP_CLIENT_ID --repo billchurch/webssh2 --body "Iv23li..."
```

## Cleanup after first successful release

Delete `RELEASE_APP_ID` once a release runs cleanly through this branch.

## Test plan

- [x] Add `RELEASE_APP_CLIENT_ID` secret
- [x] Merge this PR
- [ ] On next push to `main`: confirm `release-please` workflow runs without the deprecation warning
- [ ] Delete `RELEASE_APP_ID`