### PR TITLE
ci: gate docker-publish push trigger by image-relevant paths

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,23 @@ on:
   push:
     branches:
       - main
+    # Only rebuild when files that actually affect the image change.
+    # Workflow-only and docs-only commits skip this build; `release:published`
+    # and `workflow_dispatch` are unaffected.
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'app/**'
+      - 'index.ts'
+      - 'types/**'
+      - 'scripts/**'
+      - 'tsconfig.json'
+      - 'tsconfig.build.json'
+      - 'LICENSE'
+      - 'README.md'
+      - '.github/workflows/docker-publish.yml'
 
 concurrency:
   group: image-publish


### PR DESCRIPTION
## Summary

Every commit to `main` rebuilds the Docker image, regardless of whether the change touches anything the image consumes. Of the last 10 main-push runs of `docker-publish.yml`, roughly half rebuilt byte-identical images.

Add a `paths:` filter to the `push` trigger so we only build when something the Dockerfile actually pulls in changes.

## What's in the filter

Mirrors the `COPY` lines in `Dockerfile`:

- `Dockerfile`, `.dockerignore`
- `package.json`, `package-lock.json`
- `app/**`, `index.ts`, `types/**`, `scripts/**`
- `tsconfig.json`, `tsconfig.build.json`
- `LICENSE`, `README.md`
- `.github/workflows/docker-publish.yml` itself (so changes to the build workflow re-validate)

## What stays unchanged

- `release: types: [published]` — tagged release builds still fire automatically through the App-token path
- `workflow_dispatch` — manual builds still work
- The `chore(main): release webssh2-server` commit-message guard — release commits change `package*.json`, which is in the filter, so the existing skip-on-release-commit check stays as a backstop to avoid double-building when release event also fires

## Wasted runs eliminated

Examples from today that would now skip:

- #509 (only `.github/workflows/release-please.yml`)
- #508 (only workflow files)
- #507 (only `.github/workflows/rebuild-release-tags.yml`)
- #501, #502, #505, #500 (various `.github/` changes)

## Test plan

- [ ] Merge this PR — the merge commit only changes `.github/workflows/docker-publish.yml` (which IS in the filter on purpose), so docker-publish should fire one last time on this PR's merge to validate the new gate
- [ ] Next workflow-only commit to main: confirm docker-publish does NOT run
- [ ] Next image-relevant commit (Dockerfile/Renovate/`app/**`/etc): confirm docker-publish DOES run
- [ ] Next release: confirm docker-publish fires from the `release` event (not `push`)