### PR TITLE
ci: set OCI image.version label to semver tag instead of "latest"

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -144,7 +144,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.action == 'published' }}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish_latest == 'true' }}
             type=raw,value=main,enable=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && github.event.action == 'published') }}
-            type=raw,value=${{ steps.release_meta.outputs.semver_full }},enable=${{ steps.release_meta.outputs.has_release == 'true' }}
+            type=raw,value=${{ steps.release_meta.outputs.semver_full }},priority=900,enable=${{ steps.release_meta.outputs.has_release == 'true' }}
             type=raw,value=${{ steps.release_meta.outputs.semver_minor }},enable=${{ steps.release_meta.outputs.has_release == 'true' }}
             type=raw,value=${{ steps.release_meta.outputs.semver_major }},enable=${{ steps.release_meta.outputs.has_release == 'true' }}
             type=ref,event=branch,enable=${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
## Summary

- `docker/metadata-action` derives `org.opencontainers.image.version` from the highest-priority tag. With every `type=raw` tag at the default priority (200), `latest` was listed first and won, so released images were labeled `version=latest` instead of `version=<semver>`.
- Bumping the `semver_full` tag's priority to `900` makes it win on releases (falls back to `latest` / `main` / branch ref when `has_release=false`), so e.g. `webssh2:4.2.2` is labeled `org.opencontainers.image.version=4.2.2`.

## Background

Verified against the current `webssh2-server-v4.2.2` image:

```console
$ docker buildx imagetools inspect ghcr.io/billchurch/webssh2:4.2.2 --format '{{json .Image}}' \
    | jq -r '."linux/amd64".config.Labels."org.opencontainers.image.version"'
latest
```

After this change, a release-triggered build will label the image `version=4.2.2` while still publishing the same multi-tag set (`latest`, `4.2.2`, `4.2`, `4`).

Image digests, tarball checksums, and tag→commit alignment were all verified correct for v4.2.2 — only the version label was wrong.

## Test plan

- [ ] Trigger `docker-publish` via `workflow_dispatch` (or wait for next release) and confirm the resulting image's `org.opencontainers.image.version` label equals the semver tag (e.g. `4.2.2`).
- [ ] Confirm non-release builds (push to `main`, branch pushes) still produce a sensible version label (`latest` / `main` / branch ref) since `has_release=false` disables the semver tag.