### PR TITLE
fix(deps): bump webssh2_client to ^3.7.0 for theming UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "socket.io": "^4.8.1",
         "ssh2": "1.17",
         "validator": "^13.15.35",
-        "webssh2_client": "^3.6.0",
+        "webssh2_client": "^3.7.0",
         "zod": "^4.1.12"
       },
       "bin": {
@@ -5788,9 +5788,9 @@
       }
     },
     "node_modules/webssh2_client": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-3.6.0.tgz",
-      "integrity": "sha512-1FiYYIIkN2o3fTpNDnEv6+8x784Dlr8CAW1vpz2anvdMet/ZkVAgcxQl3FEGX94bt3wZqz697gIL+PvJbd/7xw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-3.7.0.tgz",
+      "integrity": "sha512-+7pOQrvxJGfAZO+/KGuGRgM9s7ZYS9MoEDgYNoh3c/NTZ7Un/nFdKH2wZqeWPDNoU2sZT2q9KbpiTguDkE0nlw==",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-search": "^0.16.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "socket.io": "^4.8.1",
     "ssh2": "1.17",
     "validator": "^13.15.35",
-    "webssh2_client": "^3.6.0",
+    "webssh2_client": "^3.7.0",
     "zod": "^4.1.12"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps `webssh2_client` from `^3.6.0` → `^3.7.0` and refreshes the lockfile so the bundled client actually contains the theming UI.
- `webssh2_client@3.7.0` (published 2026-05-02) ships the "Terminal Theme" UI and `setTheme` wiring that pairs with the server-side theming feature added in f7978d1.
- `npm ci` in the Dockerfile honors the lockfile, so without this bump every Docker build pulls 3.6.0 and theming env vars have no visible effect (see #518).

## Why this slipped through

The caret range in `package.json` would *allow* 3.7.0 on a fresh `npm install`, but `npm ci` (used in `Dockerfile`) pins to whatever the lockfile resolves to — which was 3.6.0 because the lockfile was last touched in `eece96d` before 3.7.0 existed.

## Verification

After `npm install`:

- `package-lock.json` resolves `webssh2_client` → `3.7.0`
- `node_modules/webssh2_client/client/public/webssh2.bundle.js` reports `Version 3.7.0 - 2026-05-02T13:19:20.927Z - a8673e7`
- Bundle contains `Terminal Theme` label and `setTheme` exports

## Test plan

- [x] CI green (lint + typecheck + unit + e2e)
- [x] Rebuild Docker image, confirm browser console shows client `3.7.0`
- [x] Set `WEBSSH2_THEMING_ENABLED=true` and `WEBSSH2_THEMING_DEFAULT_THEME=Dracula`, confirm the terminal applies the theme and the settings gear shows a "Terminal Theme" section

Fixes #518