### PR TITLE
fix(deps): bump webssh2_client to ^4.0.0 (#102)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "socket.io": "^4.8.1",
         "ssh2": "1.17",
         "validator": "^13.15.35",
-        "webssh2_client": "^3.7.0",
+        "webssh2_client": "^4.0.0",
         "zod": "^4.1.12"
       },
       "bin": {
@@ -5788,9 +5788,9 @@
       }
     },
     "node_modules/webssh2_client": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-3.7.0.tgz",
-      "integrity": "sha512-+7pOQrvxJGfAZO+/KGuGRgM9s7ZYS9MoEDgYNoh3c/NTZ7Un/nFdKH2wZqeWPDNoU2sZT2q9KbpiTguDkE0nlw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-4.0.0.tgz",
+      "integrity": "sha512-65fZbIwSHRDuppma+MT7kA7v/0WND3YtiUS37lMnOi4BRAtdPOy2Aqt933YDXfZqRkWUuvCbPr+75gmH2PuiIA==",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-search": "^0.16.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "socket.io": "^4.8.1",
     "ssh2": "1.17",
     "validator": "^13.15.35",
-    "webssh2_client": "^3.7.0",
+    "webssh2_client": "^4.0.0",
     "zod": "^4.1.12"
   },
   "scripts": {


### PR DESCRIPTION
Bumps `webssh2_client` from `^3.7.0` to `^4.0.0`. The 4.0.0 release ships the client-side removal of the unsafe `headerStyle` / Tailwind-class injection paths from billchurch/webssh2_client#102; the server-side companion landed in v5.0 (#522).

## Verification

- Published bundle (`node_modules/webssh2_client/client/public/webssh2.bundle.js`) contains **zero** references to `case 'headerStyle'` or `styleIsTailwind` (the historical attack-surface code).
- `npm run lint` — 0 errors (21 pre-existing warnings in unrelated `telnet-*` test files)
- `npm run typecheck` clean
- `npm run test` — 1443/1443 pass
- `npm run build` clean
- `npx playwright test tests/playwright/issue-102-header-smoke.spec.ts` — 7/7 pass against the published 4.0.0 bundle

## Follow-up

After this merges, a compat-matrix entry should land documenting the 5.0 ↔ 4.x relationship. Tracking that as a separate small docs change.