### PR TITLE
ci: skip docker-image-scan on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,18 @@ jobs:
           github.event.pull_request.head.repo.full_name != github.repository
         run: echo "Fork PR; image scan skipped (advisory; main-branch scan is the gate)."
 
+      - name: Note dependabot PR skip
+        if: >-
+          steps.filter.outputs.image == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor == 'dependabot[bot]'
+        run: echo "Dependabot PR; image scan skipped (advisory; main-branch scan is the gate). GitHub does not expose repo secrets to dependabot-triggered workflows by default, so the Docker Hub login required here cannot succeed."
+
       - name: Login to Docker Hub (raise anon rate-limit)
         if: >-
           steps.filter.outputs.image == 'true' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -116,13 +124,15 @@ jobs:
       - name: Set up buildx
         if: >-
           steps.filter.outputs.image == 'true' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build amd64 image for scanning
         if: >-
           steps.filter.outputs.image == 'true' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
@@ -134,7 +144,8 @@ jobs:
       - name: Trivy image scan
         if: >-
           steps.filter.outputs.image == 'true' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: webssh2:pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Why

The \`docker-image-scan\` job's Docker Hub login step fails on every dependabot PR with \`Username and password required\` (see e.g. the failed check on #521 / run [26361605822](https://github.com/billchurch/webssh2/actions/runs/26361605822)).

Root cause: GitHub does **not** expose \`secrets.*\` to workflows triggered by dependabot PRs by default — a security policy added in late 2021 to prevent malicious dependency updates from exfiltrating tokens. So \`secrets.DOCKER_USERNAME\` and \`secrets.DOCKER_TOKEN\` resolve to empty strings, and \`docker/login-action\` exits non-zero.

Existing fork-PR gating (\`head.repo.full_name != github.repository\`) handled real forks but not dependabot PRs, which live on the same repo (\`dependabot/...\` branch on \`billchurch/webssh2\`).

## Fix

Treat dependabot PRs like fork PRs:

- Add a \`Note dependabot PR skip\` step parallel to the existing fork-skip note.
- Gate the four secret-using steps (login, buildx, build, trivy) with \`github.actor != 'dependabot[bot]'\`.

The main-branch scan that runs immediately after merge is the actual gate. Pre-merge scans on dependency-only PRs are duplicate effort.

## Alternatives considered

- **Add secrets to the Dependabot secrets store**: more permissive, accepts the risk that a malicious upstream update could exfiltrate the Docker Hub token. For our use case (raise anon rate-limit on Docker Hub pulls) the risk-reward isn't great.
- **\`continue-on-error: true\` on login**: fragile; downstream steps would still try to push against unauthenticated Docker Hub and rate-limit.

## Test plan

- [x] No functional impact on non-dependabot PRs (same gating, additional \`&&\` clause that's always true for human authors).
- [ ] Re-trigger the scan on a dependabot PR after this lands and confirm it passes with the new "Note dependabot PR skip" step.

## Follow-up

After this merges, PR #521 (the \`ws\` bump) will become mergeable on a re-run without needing \`--admin\` override.