### PR TITLE
docs: client compatibility matrix + SECURITY.md 5.x bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ WebSSH2 is an HTML5 web-based terminal emulator and SSH client with optional tel
 
 WebSSH2 development is supported by [Tailwind Resource Group](https://tailwindrg.com), an engineering-led IT services firm specializing in application delivery, zero trust security, and identity for federal and commercial customers.
 
+## Compatibility
+
+WebSSH2 server bundles a matching version of the [`webssh2_client`](https://github.com/billchurch/webssh2_client) browser bundle as an npm dependency. The compatibility matrix below tracks which client major each server major ships with.
+
+| Server (`webssh2`) | Client (`webssh2_client`) | Notes |
+| --- | --- | --- |
+| 5.x | ^4.0.0 | `headerStyle` / `header.color` removed ([#102](https://github.com/billchurch/webssh2_client/issues/102)) |
+| 4.x | ^3.x | Theming UI support (3.7.0+) |
+
+Operators using the published Docker image or installing `webssh2` from npm get the correct client automatically. The matrix matters if you self-build the client, link a local fork, or pin to a different client version than the server's dependency declares.
+
 ## Quick Start
 
 ### Requirements

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We currently support only the latest released version of WebSSH2 with security u
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 4.2.x   | :white_check_mark: |
-| < 4.2.0 | :x:                |
+| 5.x     | :white_check_mark: |
+| < 5.0.0 | :x:                |
 
 **We strongly recommend always using the latest release to ensure you have the most recent security patches and improvements.**
 


### PR DESCRIPTION
Two small docs changes ahead of the 5.0 release-please cut (#514).

## README.md — new Compatibility section

Adds a server↔client version matrix between the Sponsors and Quick Start sections:

| Server (\`webssh2\`) | Client (\`webssh2_client\`) | Notes |
| --- | --- | --- |
| 5.x | ^4.0.0 | \`headerStyle\` / \`header.color\` removed (#102) |
| 4.x | ^3.x | Theming UI support (3.7.0+) |

Operators using the published Docker image or installing \`webssh2\` from npm get the right client automatically — the matrix is for anyone self-building, linking a fork, or pinning across the boundary.

## SECURITY.md — bump supported version

Supported-versions table goes from \`4.2.x\` → \`5.x\`. Anything below 5.0.0 stops receiving security updates once 5.0 ships.

## Why now

Ships *as part of* 5.0 instead of as an immediate follow-up patch. After #524 + #525 + #521 merged, this is the last meaningful pre-release doc change.

## Follow-up (deferred)

A "Migrating from 4.x to 5.x" section in CHANGELOG or a dedicated MIGRATION.md is not in scope here — release-please's BREAKING CHANGE bullet is sufficient for the headline notice; the expanded migration story can go in 5.0.1 if useful.