### PR TITLE
fix: harden host-key-seed CLI (closes #528)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,31 @@ npm run hostkeys -- --host ssh.example.com
 
 The script automatically creates the database file (and parent directories) at the configured `dbPath` if it does not exist.
 
+**Bulk seeding from a hosts file (capped at 1000 entries by default):**
+
+```bash
+# Probe each line of hosts.txt; refuses files with more than 1000 entries.
+npm run hostkeys -- --hosts hosts.txt
+# Override the cap for a legitimate large rollout:
+npm run hostkeys -- --hosts hosts.txt --max-hosts 5000
+```
+
+**Importing from an OpenSSH `known_hosts` file:**
+
+The `--known-hosts` command is a **dry-run by default** — it prints a
+preview of the parsed entries and exits without touching the database.
+This is a deliberate safety gate because every entry in the trust store
+is trusted unconditionally by the server at startup. Inspect the preview,
+verify the source is what you expected, then re-run with `--commit`:
+
+```bash
+# Preview only (no writes)
+npm run hostkeys -- --known-hosts ~/.ssh/known_hosts
+
+# After verifying the preview, commit:
+npm run hostkeys -- --known-hosts ~/.ssh/known_hosts --commit
+```
+
 **Docker volume mounting:**
 
 When running in Docker, mount a volume to the directory containing your database so it persists across container restarts. The mount path must match the `dbPath` value in your configuration:
@@ -262,6 +287,20 @@ docker run --rm -p 2222:2222 \
   -e WEBSSH2_SSH_HOSTKEY_DB_PATH=/data/hostkeys.db \
   ghcr.io/billchurch/webssh2:latest
 ```
+
+**Where can the database file live?**
+
+For safety, the seeding CLI refuses to create new parent directories
+outside an allowlist:
+
+- `/data` (the documented default)
+- The directory of `WEBSSH2_SSH_HOSTKEY_DB_PATH` if set
+- The directory of `ssh.hostKeyVerification.serverStore.dbPath` in `config.json` if set
+- The current working directory
+
+Pointing `--db` at a path whose parent directory **already exists** is
+always allowed. The restriction only applies when the seeder would have
+to create new directories outside the allowlist.
 
 ### Seeding from inside the production container
 
@@ -330,16 +369,22 @@ npm run hostkeys -- --host ssh.example.com
 npm run hostkeys -- --host ssh.example.com --port 2222
 ```
 
-**Bulk import from a hosts file** (one `host[:port]` per line, `#` comments allowed):
+**Bulk import from a hosts file** (one `host[:port]` per line, `#` comments
+allowed; capped at 1000 entries by default — see `--max-hosts`):
 
 ```bash
 npm run hostkeys -- --hosts servers.txt
 ```
 
-**Import from an OpenSSH `known_hosts` file:**
+**Import from an OpenSSH `known_hosts` file** (dry-run by default — add
+`--commit` to actually write):
 
 ```bash
+# Preview only (no writes)
 npm run hostkeys -- --known-hosts ~/.ssh/known_hosts
+
+# After verifying the preview, commit:
+npm run hostkeys -- --known-hosts ~/.ssh/known_hosts --commit
 ```
 
 **List all stored keys:**

--- a/scripts/host-key-seed.ts
+++ b/scripts/host-key-seed.ts
@@ -24,6 +24,7 @@ import type { Result } from '../app/types/result.js'
 const DEFAULT_PORT = 22
 const PROBE_TIMEOUT_MS = 15_000
 const READY_TIMEOUT_MS = 10_000
+const DEFAULT_MAX_HOSTS = 1000
 
 const HOST_KEY_SCHEMA = `
 CREATE TABLE IF NOT EXISTS host_keys (
@@ -46,12 +47,14 @@ Usage:
 Commands:
   --host <hostname> [--port <port>]   Probe a host via SSH and store its key
   --hosts <file>                      Probe hosts from a file (host[:port] per line)
+                                      Capped at 1000 entries by default; see --max-hosts
   --known-hosts <file>                Import keys from an OpenSSH known_hosts file
   --list                              List all stored host keys
   --remove <host:port>                Remove all keys for a host:port pair
   --help                              Show this help message
 
 Options:
+  --max-hosts <N>                     Override the default --hosts cap (default 1000)
   --db <path>                         Database file path
                                       Resolution order:
                                         1. --db <path> argument
@@ -308,6 +311,73 @@ function probeHostKey(host: string, port: number): Promise<ProbeResult> {
 }
 
 // ---------------------------------------------------------------------------
+// --hosts file parsing
+// ---------------------------------------------------------------------------
+
+export interface HostsFileEntry {
+  host: string
+  port: number
+}
+
+/**
+ * Parse the `--hosts` file format: one `host` or `host:port` per line.
+ * Lines that are blank or start with `#` are skipped. When a `:port`
+ * suffix is non-numeric, the full line is treated as a hostname and the
+ * default port is used.
+ */
+export function parseHostsFile(content: string): HostsFileEntry[] {
+  const entries: HostsFileEntry[] = []
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim()
+    if (line === '' || line.startsWith('#')) {
+      continue
+    }
+    const colonIndex = line.lastIndexOf(':')
+    if (colonIndex > 0) {
+      const port = Number.parseInt(line.slice(colonIndex + 1), 10)
+      if (!Number.isNaN(port)) {
+        entries.push({ host: line.slice(0, colonIndex), port })
+        continue
+      }
+    }
+    entries.push({ host: line, port: DEFAULT_PORT })
+  }
+  return entries
+}
+
+/**
+ * Enforce the `--hosts` entry cap. `explicit=true` means the operator
+ * passed `--max-hosts` so the error message uses different wording.
+ */
+export function checkHostsCap(
+  count: number,
+  maxHosts: number,
+  explicit: boolean
+): Result<number, string> {
+  if (!Number.isFinite(maxHosts) || maxHosts <= 0) {
+    return {
+      ok: false,
+      error: '--max-hosts requires a positive integer'
+    }
+  }
+  if (count <= maxHosts) {
+    return { ok: true, value: maxHosts }
+  }
+  if (explicit) {
+    return {
+      ok: false,
+      error: `file contains ${count} entries, exceeds explicit --max-hosts cap of ${maxHosts}`
+    }
+  }
+  return {
+    ok: false,
+    error:
+      `file contains ${count} entries, exceeds default cap of ${maxHosts}.\n` +
+      `  Use --max-hosts N to override.`
+  }
+}
+
+// ---------------------------------------------------------------------------
 // known_hosts parsing
 // ---------------------------------------------------------------------------
 
@@ -475,6 +545,9 @@ export interface CliArgs {
   file?: string | undefined
   removeTarget?: string | undefined
   dbPath?: string | undefined
+  commit: boolean
+  maxHosts?: number | undefined
+  maxHostsExplicit: boolean
 }
 
 function nextArg(args: readonly string[], index: number): string | undefined {
@@ -490,6 +563,9 @@ export function parseArgs(argv: readonly string[]): CliArgs {
   let file: string | undefined
   let removeTarget: string | undefined
   let dbPath: string | undefined
+  let commit = false
+  let maxHosts: number | undefined
+  let maxHostsExplicit = false
 
   for (let i = 0; i < args.length; i++) {
     const arg = args.at(i)
@@ -523,10 +599,30 @@ export function parseArgs(argv: readonly string[]): CliArgs {
     } else if (arg === '--db') {
       dbPath = nextArg(args, i)
       i++
+    } else if (arg === '--commit') {
+      // Consumed by handleKnownHosts in Task 4 to gate dry-run vs. write.
+      commit = true
+    } else if (arg === '--max-hosts') {
+      const maxStr = nextArg(args, i)
+      i++
+      if (maxStr !== undefined) {
+        maxHosts = Number.parseInt(maxStr, 10)
+        maxHostsExplicit = true
+      }
     }
   }
 
-  return { command, host, port, file, removeTarget, dbPath }
+  return {
+    command,
+    host,
+    port,
+    file,
+    removeTarget,
+    dbPath,
+    commit,
+    maxHosts,
+    maxHostsExplicit
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -554,40 +650,29 @@ async function handleProbeHost(
 
 async function handleProbeHosts(
   db: DatabaseType,
-  filePath: string
-): Promise<void> {
+  filePath: string,
+  maxHosts: number,
+  maxHostsExplicit: boolean
+): Promise<number> {
   if (!fs.existsSync(filePath)) {
     process.stderr.write(`File not found: ${sanitizeForDisplay(filePath)}\n`)
-    return
+    return 1
   }
 
   const content = fs.readFileSync(filePath, 'utf8')
-  const lines = content.split('\n').filter((line) => {
-    const trimmed = line.trim()
-    return trimmed !== '' && !trimmed.startsWith('#')
-  })
+  const entries = parseHostsFile(content)
 
-  for (const line of lines) {
-    const trimmed = line.trim()
-    const colonIndex = trimmed.lastIndexOf(':')
-
-    let host: string
-    let port: number
-
-    if (colonIndex > 0) {
-      host = trimmed.slice(0, colonIndex)
-      port = Number.parseInt(trimmed.slice(colonIndex + 1), 10)
-      if (Number.isNaN(port)) {
-        host = trimmed
-        port = DEFAULT_PORT
-      }
-    } else {
-      host = trimmed
-      port = DEFAULT_PORT
-    }
-
-    await handleProbeHost(db, host, port)
+  const cap = checkHostsCap(entries.length, maxHosts, maxHostsExplicit)
+  if (!cap.ok) {
+    process.stderr.write(`Error: ${cap.error}\n`)
+    return 1
   }
+
+  for (const entry of entries) {
+    await handleProbeHost(db, entry.host, entry.port)
+  }
+
+  return 0
 }
 
 function handleKnownHosts(
@@ -726,7 +811,16 @@ async function main(): Promise<number> {
           process.stderr.write('Error: --hosts requires a file path\n')
           return 1
         }
-        await handleProbeHosts(db, cli.file)
+        const effectiveMax = cli.maxHosts ?? DEFAULT_MAX_HOSTS
+        const probeExit = await handleProbeHosts(
+          db,
+          cli.file,
+          effectiveMax,
+          cli.maxHostsExplicit
+        )
+        if (probeExit !== 0) {
+          return probeExit
+        }
         break
       }
       case 'known-hosts': {

--- a/scripts/host-key-seed.ts
+++ b/scripts/host-key-seed.ts
@@ -15,6 +15,7 @@ import path, { basename } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import Database, { type Database as DatabaseType } from 'better-sqlite3'
 import { Client as SSH2Client } from 'ssh2'
+import type { Result } from '../app/types/result.js'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -118,6 +119,118 @@ function computeFingerprint(base64Key: string): string {
 // ---------------------------------------------------------------------------
 // Database helpers
 // ---------------------------------------------------------------------------
+
+const BASE_DB_ALLOWLIST: readonly string[] = ['/data']
+
+/**
+ * Resolve a path to its real (symlink-free) canonical form.
+ *
+ * If the path does not exist, walks up the ancestor chain to find the
+ * deepest existing prefix, resolves that via `realpathSync`, then
+ * re-appends the non-existing tail.  This normalises macOS symlinks such
+ * as `/var/folders` → `/private/var/folders` even when the full path does
+ * not yet exist on disk.
+ */
+function resolveRealpath(p: string): string {
+  let current = path.resolve(p)
+  const tail: string[] = []
+
+  while (current !== path.dirname(current)) {
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      const real = fs.realpathSync(current)
+      // Re-append any non-existing tail segments
+      return tail.length === 0 ? real : path.join(real, ...tail.toReversed())
+    } catch {
+      tail.push(path.basename(current))
+      current = path.dirname(current)
+    }
+  }
+  return p
+}
+
+/**
+ * Compose the `--db` path allowlist from its four sources, in priority order:
+ *   1. `/data` (the documented default)
+ *   2. The directory of `WEBSSH2_SSH_HOSTKEY_DB_PATH` if set
+ *   3. The directory of `config.json`'s `ssh.hostKeyVerification.serverStore.dbPath` if set
+ *   4. The current working directory
+ *
+ * Each entry is resolved to an absolute path. Duplicates are removed while
+ * preserving the order above so the runtime allowlist reads in priority order.
+ */
+export function buildDbPathAllowlist(
+  env: Record<string, string | undefined>,
+  configDbPath: string | undefined,
+  cwd: string
+): string[] {
+  const candidates: string[] = [...BASE_DB_ALLOWLIST]
+
+  const envPath = env['WEBSSH2_SSH_HOSTKEY_DB_PATH']
+  if (typeof envPath === 'string' && envPath !== '') {
+    candidates.push(path.dirname(path.resolve(envPath)))
+  }
+
+  if (configDbPath !== undefined && configDbPath !== '') {
+    candidates.push(path.dirname(path.resolve(configDbPath)))
+  }
+
+  candidates.push(path.resolve(cwd))
+
+  const seen = new Set<string>()
+  const dedup: string[] = []
+  for (const entry of candidates) {
+    if (!seen.has(entry)) {
+      seen.add(entry)
+      dedup.push(entry)
+    }
+  }
+  return dedup
+}
+
+/**
+ * Validate a `--db` path. Returns the canonical absolute path on ok.
+ *
+ * Policy:
+ *   1. Resolve the requested path to a canonical absolute path.
+ *   2. If the parent directory exists anywhere on disk, accept.
+ *   3. If the parent directory does not exist, accept only when the canonical
+ *      path equals an allowlist entry or sits under one (matched with a path
+ *      separator to avoid /datafoo matching /data).
+ *   4. Otherwise reject with a message listing the allowlist.
+ */
+export function validateDbPath(
+  requestedPath: string,
+  allowlist: readonly string[]
+): Result<string, string> {
+  const canonical = path.resolve(requestedPath)
+  const parentDir = path.dirname(canonical)
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  if (fs.existsSync(parentDir)) {
+    return { ok: true, value: canonical }
+  }
+
+  // Resolve symlinks on both sides of the comparison so that macOS paths
+  // such as /var/folders (symlink → /private/var/folders) match correctly
+  // even when the destination does not yet exist.
+  const realCanonical = resolveRealpath(canonical)
+
+  for (const allowed of allowlist) {
+    const realAllowed = resolveRealpath(path.resolve(allowed))
+    if (
+      realCanonical === realAllowed ||
+      realCanonical.startsWith(`${realAllowed}${path.sep}`)
+    ) {
+      return { ok: true, value: canonical }
+    }
+  }
+
+  return {
+    ok: false,
+    error: `refusing to create directories outside allowlist for --db. Allowed: ${allowlist.join(', ')}`
+  }
+}
 
 function openDb(dbPath: string): DatabaseType {
   const dir = path.dirname(dbPath)
@@ -301,6 +414,25 @@ export function extractDbPathFromConfig(config: unknown): string | undefined {
   }
 
   return undefined
+}
+
+/**
+ * Read the dbPath from config.json without applying any fallbacks.
+ * Used by buildDbPathAllowlist so an operator-configured dbPath dir is
+ * in the allowlist even when no DB exists there yet.
+ */
+export function readConfiguredDbPath(): string | undefined {
+  const configPath = path.resolve(process.cwd(), 'config.json')
+  if (!fs.existsSync(configPath)) {
+    return undefined
+  }
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8')
+    const config: unknown = JSON.parse(raw)
+    return extractDbPathFromConfig(config)
+  } catch {
+    return undefined
+  }
 }
 
 export function resolveDbPath(explicitPath: string | undefined): string {
@@ -564,7 +696,20 @@ async function main(): Promise<number> {
   }
 
   const dbPath = resolveDbPath(cli.dbPath)
-  const db = openDb(dbPath)
+
+  const configuredDbPath = readConfiguredDbPath()
+  const allowlist = buildDbPathAllowlist(
+    process.env,
+    configuredDbPath,
+    process.cwd()
+  )
+  const validation = validateDbPath(dbPath, allowlist)
+  if (!validation.ok) {
+    process.stderr.write(`Error: ${validation.error}\n`)
+    return 1
+  }
+
+  const db = openDb(validation.value)
 
   try {
     switch (cli.command) {

--- a/scripts/host-key-seed.ts
+++ b/scripts/host-key-seed.ts
@@ -69,6 +69,25 @@ Examples:
 `.trim()
 
 // ---------------------------------------------------------------------------
+// Display sanitization
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape control characters in a string for safe terminal display.
+ *
+ * Replaces bytes in [0x00, 0x1F] (C0 controls), 0x7F (DEL), and [0x80, 0x9F]
+ * (C1 controls) with `\xNN` escape notation. Printable ASCII (0x20-0x7E) and
+ * printable Unicode above 0x9F pass through unchanged.
+ */
+export function sanitizeForDisplay(input: string): string {
+  // eslint-disable-next-line no-control-regex
+  return input.replace(/[\x00-\x1F\x7F-\x9F]/g, (ch) => {
+    const code = ch.charCodeAt(0)
+    return `\\x${code.toString(16).padStart(2, '0').toUpperCase()}`
+  })
+}
+
+// ---------------------------------------------------------------------------
 // Algorithm extraction (mirrors host-key-verifier.ts)
 // ---------------------------------------------------------------------------
 
@@ -387,16 +406,17 @@ async function handleProbeHost(
   host: string,
   port: number
 ): Promise<void> {
-  process.stdout.write(`Probing ${host}:${port}...\n`)
+  const safeHost = sanitizeForDisplay(host)
+  process.stdout.write(`Probing ${safeHost}:${port}...\n`)
   try {
     const result = await probeHostKey(host, port)
     upsertKey(db, host, port, result.algorithm, result.key)
     const fingerprint = computeFingerprint(result.key)
-    process.stdout.write(`Added ${result.algorithm} key for ${host}:${port}\n`)
+    process.stdout.write(`Added ${result.algorithm} key for ${safeHost}:${port}\n`)
     process.stdout.write(`Fingerprint: ${fingerprint}\n`)
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err)
-    process.stderr.write(`Error probing ${host}:${port}: ${message}\n`)
+    process.stderr.write(`Error probing ${safeHost}:${port}: ${message}\n`)
   }
 }
 
@@ -405,7 +425,7 @@ async function handleProbeHosts(
   filePath: string
 ): Promise<void> {
   if (!fs.existsSync(filePath)) {
-    process.stderr.write(`File not found: ${filePath}\n`)
+    process.stderr.write(`File not found: ${sanitizeForDisplay(filePath)}\n`)
     return
   }
 
@@ -443,7 +463,7 @@ function handleKnownHosts(
   filePath: string
 ): void {
   if (!fs.existsSync(filePath)) {
-    process.stderr.write(`File not found: ${filePath}\n`)
+    process.stderr.write(`File not found: ${sanitizeForDisplay(filePath)}\n`)
     return
   }
 
@@ -503,7 +523,7 @@ function handleList(db: DatabaseType): void {
       ? `${fingerprint.slice(0, 36)}...`
       : fingerprint
     process.stdout.write(formatListRow(
-      row.host,
+      sanitizeForDisplay(row.host),
       String(row.port),
       row.algorithm,
       truncatedFp,
@@ -528,7 +548,7 @@ function handleRemove(db: DatabaseType, target: string): void {
   }
 
   const result = db.prepare('DELETE FROM host_keys WHERE host = ? AND port = ?').run(host, port)
-  process.stdout.write(`Removed ${String(result.changes)} key(s) for ${host}:${port}\n`)
+  process.stdout.write(`Removed ${String(result.changes)} key(s) for ${sanitizeForDisplay(host)}:${port}\n`)
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/host-key-seed.ts
+++ b/scripts/host-key-seed.ts
@@ -48,12 +48,15 @@ Commands:
   --host <hostname> [--port <port>]   Probe a host via SSH and store its key
   --hosts <file>                      Probe hosts from a file (host[:port] per line)
                                       Capped at 1000 entries by default; see --max-hosts
-  --known-hosts <file>                Import keys from an OpenSSH known_hosts file
+  --known-hosts <file>                Preview keys from an OpenSSH known_hosts file
+                                      (dry-run by default; add --commit to write)
   --list                              List all stored host keys
   --remove <host:port>                Remove all keys for a host:port pair
   --help                              Show this help message
 
 Options:
+  --commit                            With --known-hosts, write to the trust store
+                                      (otherwise the command is a dry-run preview)
   --max-hosts <N>                     Override the default --hosts cap (default 1000)
   --db <path>                         Database file path
                                       Resolution order:
@@ -66,7 +69,8 @@ Examples:
   npm run hostkeys -- --host example.com
   npm run hostkeys -- --host example.com --port 2222
   npm run hostkeys -- --hosts servers.txt
-  npm run hostkeys -- --known-hosts ~/.ssh/known_hosts
+  npm run hostkeys -- --known-hosts ~/.ssh/known_hosts            # preview only
+  npm run hostkeys -- --known-hosts ~/.ssh/known_hosts --commit   # write
   npm run hostkeys -- --list
   npm run hostkeys -- --list --db /custom/path/hostkeys.db
   npm run hostkeys -- --remove example.com:22
@@ -381,7 +385,7 @@ export function checkHostsCap(
 // known_hosts parsing
 // ---------------------------------------------------------------------------
 
-interface KnownHostEntry {
+export interface KnownHostEntry {
   host: string
   port: number
   algorithm: string
@@ -640,7 +644,8 @@ async function handleProbeHost(
     const result = await probeHostKey(host, port)
     upsertKey(db, host, port, result.algorithm, result.key)
     const fingerprint = computeFingerprint(result.key)
-    process.stdout.write(`Added ${result.algorithm} key for ${safeHost}:${port}\n`)
+    const safeAlgorithm = sanitizeForDisplay(result.algorithm)
+    process.stdout.write(`Added ${safeAlgorithm} key for ${safeHost}:${port}\n`)
     process.stdout.write(`Fingerprint: ${fingerprint}\n`)
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err)
@@ -677,7 +682,8 @@ async function handleProbeHosts(
 
 function handleKnownHosts(
   db: DatabaseType,
-  filePath: string
+  filePath: string,
+  commit: boolean
 ): void {
   if (!fs.existsSync(filePath)) {
     process.stderr.write(`File not found: ${sanitizeForDisplay(filePath)}\n`)
@@ -692,13 +698,25 @@ function handleKnownHosts(
     return
   }
 
-  let imported = 0
+  process.stdout.write(formatListRow('Host', 'Port', 'Algorithm', 'Fingerprint', '(preview)'))
   for (const entry of entries) {
-    upsertKey(db, entry.host, entry.port, entry.algorithm, entry.key)
-    imported++
+    process.stdout.write(formatKnownHostsPreviewRow(entry))
   }
 
-  process.stdout.write(`Imported ${String(imported)} key(s) from ${filePath}\n`)
+  const safePath = sanitizeForDisplay(filePath)
+  if (!commit) {
+    process.stdout.write(
+      `\nDRY RUN: would import ${String(entries.length)} key(s) from ${safePath}.\n` +
+      `Re-run with --commit to write to the trust store.\n`
+    )
+    return
+  }
+
+  for (const entry of entries) {
+    upsertKey(db, entry.host, entry.port, entry.algorithm, entry.key)
+  }
+
+  process.stdout.write(`\nImported ${String(entries.length)} key(s) from ${safePath}\n`)
 }
 
 function formatListRow(
@@ -714,6 +732,25 @@ function formatListRow(
   const fpWidth = 38
   const dateWidth = 20
   return `${hostVal.padEnd(hostWidth)}${portVal.padEnd(portWidth)}${algVal.padEnd(algWidth)}${fpVal.padEnd(fpWidth)}${dateVal.padEnd(dateWidth)}\n`
+}
+
+/**
+ * Format one preview row for `--known-hosts` dry-run output. Sanitizes the
+ * host for safe terminal display, computes the SHA-256 fingerprint, and
+ * lays out the columns using formatListRow's widths.
+ */
+export function formatKnownHostsPreviewRow(entry: KnownHostEntry): string {
+  const fingerprint = computeFingerprint(entry.key)
+  const truncatedFp = fingerprint.length > 36
+    ? `${fingerprint.slice(0, 36)}...`
+    : fingerprint
+  return formatListRow(
+    sanitizeForDisplay(entry.host),
+    String(entry.port),
+    sanitizeForDisplay(entry.algorithm),
+    truncatedFp,
+    ''
+  )
 }
 
 function handleList(db: DatabaseType): void {
@@ -742,7 +779,7 @@ function handleList(db: DatabaseType): void {
     process.stdout.write(formatListRow(
       sanitizeForDisplay(row.host),
       String(row.port),
-      row.algorithm,
+      sanitizeForDisplay(row.algorithm),
       truncatedFp,
       row.added_at
     ))
@@ -828,7 +865,7 @@ async function main(): Promise<number> {
           process.stderr.write('Error: --known-hosts requires a file path\n')
           return 1
         }
-        handleKnownHosts(db, cli.file)
+        handleKnownHosts(db, cli.file, cli.commit)
         break
       }
       case 'list': {

--- a/tests/integration/scripts/host-key-seed-cli.vitest.ts
+++ b/tests/integration/scripts/host-key-seed-cli.vitest.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { spawnSync } from 'node:child_process'
+import {
+  spawnSync,
+  type SpawnSyncOptionsWithStringEncoding,
+  type SpawnSyncReturns
+} from 'node:child_process'
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
@@ -9,6 +13,47 @@ import Database from 'better-sqlite3'
 // Project ESM convention — see tests/playwright/utils/test-config.ts
 const here = dirname(fileURLToPath(import.meta.url))
 const distScript = resolve(here, '../../../dist/scripts/host-key-seed.js')
+
+interface RunCliOptions {
+  cwd?: string
+  timeout?: number
+}
+
+/**
+ * Run the compiled CLI with the given args. Uses `process.execPath` (not the
+ * bare 'node' string) so Sonar rule typescript:S4036 stays satisfied and the
+ * spawned binary matches the version running the test.
+ *
+ * spawnSync's default `killSignal` is SIGTERM, which is what every test here
+ * needs — we don't override it.
+ */
+function runCli(args: string[], opts: RunCliOptions = {}): SpawnSyncReturns<string> {
+  const spawnOpts: SpawnSyncOptionsWithStringEncoding = {
+    encoding: 'utf8',
+    timeout: opts.timeout ?? 10_000
+  }
+  if (opts.cwd !== undefined) {
+    spawnOpts.cwd = opts.cwd
+  }
+  return spawnSync(process.execPath, [distScript, ...args], spawnOpts)
+}
+
+/**
+ * Run `fn` inside a fresh `mkdtemp` directory, passing both the dir path and
+ * a conventional `<dir>/keys.db` path. The directory is removed afterward
+ * regardless of whether `fn` threw.
+ */
+function withSeedTempDir(
+  slug: string,
+  fn: (tmp: string, dbPath: string) => void
+): void {
+  const tmp = mkdtempSync(join(tmpdir(), `webssh2-seed-${slug}-`))
+  try {
+    fn(tmp, join(tmp, 'keys.db'))
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+}
 
 describe('host-key-seed CLI (compiled artifact)', () => {
   it('exists at the expected build output path', () => {
@@ -24,16 +69,7 @@ describe('host-key-seed CLI (compiled artifact)', () => {
   })
 
   it('prints the usage banner and exits 0 when invoked with --help', () => {
-    // Use process.execPath (the absolute path to the currently-running node
-    // binary) rather than the bare 'node' string. Bare 'node' would be
-    // resolved via $PATH, which Sonar rule typescript:S4036 flags as unsafe
-    // if PATH contains a writable directory. process.execPath is fixed at
-    // process start, bypasses PATH entirely, and guarantees we spawn the
-    // same node version that ran the test.
-    const result = spawnSync(process.execPath, [distScript, '--help'], {
-      encoding: 'utf8',
-      timeout: 10_000
-    })
+    const result = runCli(['--help'])
 
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('webssh2 host key management tool')
@@ -41,10 +77,7 @@ describe('host-key-seed CLI (compiled artifact)', () => {
   })
 
   it('escapes control characters in --list output when DB rows contain them', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-test-'))
-    const dbPath = join(tmp, 'hostkeys.db')
-
-    try {
+    withSeedTempDir('list-adv', (_tmp, dbPath) => {
       const seed = new Database(dbPath)
       seed.exec(
         `CREATE TABLE host_keys (
@@ -62,217 +95,134 @@ describe('host-key-seed CLI (compiled artifact)', () => {
       ).run('\x1b[31mevil.example\x1b[0m', 22, 'ssh-rsa', 'AAAA')
       seed.close()
 
-      const result = spawnSync(process.execPath, [distScript, '--list', '--db', dbPath], {
-        encoding: 'utf8',
-        timeout: 10_000
-      })
+      const result = runCli(['--list', '--db', dbPath])
 
       expect(result.status).toBe(0)
       expect(result.stdout).toContain('\\x1B[31mevil.example\\x1B[0m')
       expect(result.stdout.includes('\x1b')).toBe(false)
-    } finally {
-      rmSync(tmp, { recursive: true, force: true })
-    }
+    })
   })
 
   it('rejects --db with missing parent dir outside allowlist', () => {
-    const result = spawnSync(
-      process.execPath,
-      [distScript, '--list', '--db', '/nonexistent/sub/dir/keys.db'],
-      { encoding: 'utf8', timeout: 10_000 }
-    )
+    const result = runCli(['--list', '--db', '/nonexistent/sub/dir/keys.db'])
 
     expect(result.status).not.toBe(0)
     expect(result.stderr).toContain('refusing to create directories')
   })
 
   it('accepts --db with existing parent dir', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-db-'))
-    const dbPath = join(tmp, 'keys.db')
-    try {
-      const result = spawnSync(
-        process.execPath,
-        [distScript, '--list', '--db', dbPath],
-        { encoding: 'utf8', timeout: 10_000 }
-      )
+    withSeedTempDir('db-existing', (_tmp, dbPath) => {
+      const result = runCli(['--list', '--db', dbPath])
       expect(result.status).toBe(0)
       expect(result.stdout).toContain('No host keys stored.')
-    } finally {
-      rmSync(tmp, { recursive: true, force: true })
-    }
+    })
   })
 
   it('accepts --db with missing parent dir under cwd (allowlist member)', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-cwd-'))
-    const dbPath = join(tmp, 'fresh-subdir', 'keys.db')
-    try {
-      const result = spawnSync(
-        process.execPath,
-        [distScript, '--list', '--db', dbPath],
-        {
-          encoding: 'utf8',
-          timeout: 10_000,
-          cwd: tmp
-        }
-      )
+    withSeedTempDir('db-cwd', (tmp) => {
+      const dbPath = join(tmp, 'fresh-subdir', 'keys.db')
+      const result = runCli(['--list', '--db', dbPath], { cwd: tmp })
       expect(result.status).toBe(0)
       // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(existsSync(join(tmp, 'fresh-subdir'))).toBe(true)
-    } finally {
-      rmSync(tmp, { recursive: true, force: true })
-    }
+    })
   })
 
   it('rejects --hosts file exceeding default cap of 1000', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-cap-'))
-    const dbPath = join(tmp, 'keys.db')
-    const hostsFile = join(tmp, 'hosts.txt')
-    try {
+    withSeedTempDir('hosts-cap', (tmp, dbPath) => {
+      const hostsFile = join(tmp, 'hosts.txt')
       const lines: string[] = []
       for (let i = 0; i < 1001; i++) {
         lines.push(`host-${i.toString()}.example`)
       }
       writeFileSync(hostsFile, lines.join('\n'))
 
-      const result = spawnSync(
-        process.execPath,
-        [distScript, '--hosts', hostsFile, '--db', dbPath],
-        { encoding: 'utf8', timeout: 10_000 }
-      )
+      const result = runCli(['--hosts', hostsFile, '--db', dbPath])
 
       expect(result.status).not.toBe(0)
       expect(result.stderr).toContain('exceeds default cap of 1000')
       expect(result.stderr).toContain('--max-hosts')
       expect(result.stdout).not.toContain('Probing')
-    } finally {
-      rmSync(tmp, { recursive: true, force: true })
-    }
+    })
   })
 
   it('accepts --hosts file at default cap (1000)', { timeout: 30_000 }, () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-cap-ok-'))
-    const dbPath = join(tmp, 'keys.db')
-    const hostsFile = join(tmp, 'hosts.txt')
-    try {
+    withSeedTempDir('hosts-cap-ok', (tmp, dbPath) => {
+      const hostsFile = join(tmp, 'hosts.txt')
       const lines: string[] = []
       for (let i = 0; i < 1000; i++) {
         lines.push(`unroutable-${i.toString()}.invalid`)
       }
       writeFileSync(hostsFile, lines.join('\n'))
 
-      const result = spawnSync(
-        process.execPath,
-        [distScript, '--hosts', hostsFile, '--db', dbPath],
-        { encoding: 'utf8', timeout: 20_000, killSignal: 'SIGTERM' }
+      const result = runCli(
+        ['--hosts', hostsFile, '--db', dbPath],
+        { timeout: 20_000 }
       )
 
       expect(result.stderr).not.toContain('exceeds')
-    } finally {
-      rmSync(tmp, { recursive: true, force: true })
-    }
+    })
   })
 
   it('honors --max-hosts override above default', { timeout: 30_000 }, () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-override-'))
-    const dbPath = join(tmp, 'keys.db')
-    const hostsFile = join(tmp, 'hosts.txt')
-    try {
+    withSeedTempDir('hosts-override', (tmp, dbPath) => {
+      const hostsFile = join(tmp, 'hosts.txt')
       const lines: string[] = []
       for (let i = 0; i < 1500; i++) {
         lines.push(`unroutable-${i.toString()}.invalid`)
       }
       writeFileSync(hostsFile, lines.join('\n'))
 
-      const result = spawnSync(
-        process.execPath,
-        [
-          distScript,
-          '--hosts', hostsFile,
-          '--max-hosts', '1500',
-          '--db', dbPath
-        ],
-        { encoding: 'utf8', timeout: 20_000, killSignal: 'SIGTERM' }
+      const result = runCli(
+        ['--hosts', hostsFile, '--max-hosts', '1500', '--db', dbPath],
+        { timeout: 20_000 }
       )
 
       expect(result.stderr).not.toContain('exceeds')
-    } finally {
-      rmSync(tmp, { recursive: true, force: true })
-    }
+    })
   })
 
   it('--known-hosts without --commit is a dry-run (DB row count unchanged)', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-kh-dry-'))
-    const dbPath = join(tmp, 'keys.db')
-    const khFile = join(tmp, 'known_hosts')
-    try {
+    withSeedTempDir('kh-dry', (tmp, dbPath) => {
+      const khFile = join(tmp, 'known_hosts')
       writeFileSync(khFile, 'example.com ssh-rsa AAAAB3NzaC1yc2EAAAA\n')
 
-      const result = spawnSync(
-        process.execPath,
-        [distScript, '--known-hosts', khFile, '--db', dbPath],
-        { encoding: 'utf8', timeout: 10_000 }
-      )
+      const result = runCli(['--known-hosts', khFile, '--db', dbPath])
 
       expect(result.status).toBe(0)
       expect(result.stdout).toContain('DRY RUN')
       expect(result.stdout).toContain('--commit')
 
-      const listResult = spawnSync(
-        process.execPath,
-        [distScript, '--list', '--db', dbPath],
-        { encoding: 'utf8', timeout: 10_000 }
-      )
+      const listResult = runCli(['--list', '--db', dbPath])
       expect(listResult.stdout).toContain('No host keys stored.')
-    } finally {
-      rmSync(tmp, { recursive: true, force: true })
-    }
+    })
   })
 
   it('--known-hosts --commit writes to the DB', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-kh-commit-'))
-    const dbPath = join(tmp, 'keys.db')
-    const khFile = join(tmp, 'known_hosts')
-    try {
+    withSeedTempDir('kh-commit', (tmp, dbPath) => {
+      const khFile = join(tmp, 'known_hosts')
       writeFileSync(khFile, 'example.com ssh-rsa AAAAB3NzaC1yc2EAAAA\n')
 
-      const result = spawnSync(
-        process.execPath,
-        [distScript, '--known-hosts', khFile, '--commit', '--db', dbPath],
-        { encoding: 'utf8', timeout: 10_000 }
-      )
+      const result = runCli(['--known-hosts', khFile, '--commit', '--db', dbPath])
 
       expect(result.status).toBe(0)
       expect(result.stdout).toContain('Imported 1 key(s)')
 
-      const listResult = spawnSync(
-        process.execPath,
-        [distScript, '--list', '--db', dbPath],
-        { encoding: 'utf8', timeout: 10_000 }
-      )
+      const listResult = runCli(['--list', '--db', dbPath])
       expect(listResult.stdout).toContain('example.com')
-    } finally {
-      rmSync(tmp, { recursive: true, force: true })
-    }
+    })
   })
 
   it('--known-hosts preview sanitizes adversarial hostnames', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-kh-adv-'))
-    const dbPath = join(tmp, 'keys.db')
-    const khFile = join(tmp, 'known_hosts')
-    try {
+    withSeedTempDir('kh-adv', (tmp, dbPath) => {
+      const khFile = join(tmp, 'known_hosts')
       writeFileSync(khFile, '\x1b[31mevil\x1b[0m ssh-rsa AAAAB3NzaC1yc2EAAAA\n')
 
-      const result = spawnSync(
-        process.execPath,
-        [distScript, '--known-hosts', khFile, '--db', dbPath],
-        { encoding: 'utf8', timeout: 10_000 }
-      )
+      const result = runCli(['--known-hosts', khFile, '--db', dbPath])
 
       expect(result.status).toBe(0)
       expect(result.stdout).toContain('\\x1B[31mevil\\x1B[0m')
       expect(result.stdout.includes('\x1b')).toBe(false)
-    } finally {
-      rmSync(tmp, { recursive: true, force: true })
-    }
+    })
   })
 })

--- a/tests/integration/scripts/host-key-seed-cli.vitest.ts
+++ b/tests/integration/scripts/host-key-seed-cli.vitest.ts
@@ -74,4 +74,52 @@ describe('host-key-seed CLI (compiled artifact)', () => {
       rmSync(tmp, { recursive: true, force: true })
     }
   })
+
+  it('rejects --db with missing parent dir outside allowlist', () => {
+    const result = spawnSync(
+      process.execPath,
+      [distScript, '--list', '--db', '/nonexistent/sub/dir/keys.db'],
+      { encoding: 'utf8', timeout: 10_000 }
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('refusing to create directories')
+  })
+
+  it('accepts --db with existing parent dir', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-db-'))
+    const dbPath = join(tmp, 'keys.db')
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [distScript, '--list', '--db', dbPath],
+        { encoding: 'utf8', timeout: 10_000 }
+      )
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain('No host keys stored.')
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts --db with missing parent dir under cwd (allowlist member)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-cwd-'))
+    const dbPath = join(tmp, 'fresh-subdir', 'keys.db')
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [distScript, '--list', '--db', dbPath],
+        {
+          encoding: 'utf8',
+          timeout: 10_000,
+          cwd: tmp
+        }
+      )
+      expect(result.status).toBe(0)
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      expect(existsSync(join(tmp, 'fresh-subdir'))).toBe(true)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
 })

--- a/tests/integration/scripts/host-key-seed-cli.vitest.ts
+++ b/tests/integration/scripts/host-key-seed-cli.vitest.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { spawnSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
-import { dirname, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
+import Database from 'better-sqlite3'
 
 // Project ESM convention — see tests/playwright/utils/test-config.ts
 const here = dirname(fileURLToPath(import.meta.url))
@@ -36,5 +38,40 @@ describe('host-key-seed CLI (compiled artifact)', () => {
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('webssh2 host key management tool')
     expect(result.stdout).toContain('Show this help message')
+  })
+
+  it('escapes control characters in --list output when DB rows contain them', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-test-'))
+    const dbPath = join(tmp, 'hostkeys.db')
+
+    try {
+      const seed = new Database(dbPath)
+      seed.exec(
+        `CREATE TABLE host_keys (
+          host TEXT NOT NULL,
+          port INTEGER NOT NULL DEFAULT 22,
+          algorithm TEXT NOT NULL,
+          key TEXT NOT NULL,
+          added_at TEXT NOT NULL DEFAULT (datetime('now')),
+          comment TEXT,
+          PRIMARY KEY (host, port, algorithm)
+        )`
+      )
+      seed.prepare(
+        'INSERT INTO host_keys (host, port, algorithm, key) VALUES (?, ?, ?, ?)'
+      ).run('\x1b[31mevil.example\x1b[0m', 22, 'ssh-rsa', 'AAAA')
+      seed.close()
+
+      const result = spawnSync(process.execPath, [distScript, '--list', '--db', dbPath], {
+        encoding: 'utf8',
+        timeout: 10_000
+      })
+
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain('\\x1B[31mevil.example\\x1B[0m')
+      expect(result.stdout.includes('\x1b')).toBe(false)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/integration/scripts/host-key-seed-cli.vitest.ts
+++ b/tests/integration/scripts/host-key-seed-cli.vitest.ts
@@ -199,4 +199,80 @@ describe('host-key-seed CLI (compiled artifact)', () => {
       rmSync(tmp, { recursive: true, force: true })
     }
   })
+
+  it('--known-hosts without --commit is a dry-run (DB row count unchanged)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-kh-dry-'))
+    const dbPath = join(tmp, 'keys.db')
+    const khFile = join(tmp, 'known_hosts')
+    try {
+      writeFileSync(khFile, 'example.com ssh-rsa AAAAB3NzaC1yc2EAAAA\n')
+
+      const result = spawnSync(
+        process.execPath,
+        [distScript, '--known-hosts', khFile, '--db', dbPath],
+        { encoding: 'utf8', timeout: 10_000 }
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain('DRY RUN')
+      expect(result.stdout).toContain('--commit')
+
+      const listResult = spawnSync(
+        process.execPath,
+        [distScript, '--list', '--db', dbPath],
+        { encoding: 'utf8', timeout: 10_000 }
+      )
+      expect(listResult.stdout).toContain('No host keys stored.')
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('--known-hosts --commit writes to the DB', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-kh-commit-'))
+    const dbPath = join(tmp, 'keys.db')
+    const khFile = join(tmp, 'known_hosts')
+    try {
+      writeFileSync(khFile, 'example.com ssh-rsa AAAAB3NzaC1yc2EAAAA\n')
+
+      const result = spawnSync(
+        process.execPath,
+        [distScript, '--known-hosts', khFile, '--commit', '--db', dbPath],
+        { encoding: 'utf8', timeout: 10_000 }
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain('Imported 1 key(s)')
+
+      const listResult = spawnSync(
+        process.execPath,
+        [distScript, '--list', '--db', dbPath],
+        { encoding: 'utf8', timeout: 10_000 }
+      )
+      expect(listResult.stdout).toContain('example.com')
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('--known-hosts preview sanitizes adversarial hostnames', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-kh-adv-'))
+    const dbPath = join(tmp, 'keys.db')
+    const khFile = join(tmp, 'known_hosts')
+    try {
+      writeFileSync(khFile, '\x1b[31mevil\x1b[0m ssh-rsa AAAAB3NzaC1yc2EAAAA\n')
+
+      const result = spawnSync(
+        process.execPath,
+        [distScript, '--known-hosts', khFile, '--db', dbPath],
+        { encoding: 'utf8', timeout: 10_000 }
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain('\\x1B[31mevil\\x1B[0m')
+      expect(result.stdout.includes('\x1b')).toBe(false)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
 })

--- a/tests/integration/scripts/host-key-seed-cli.vitest.ts
+++ b/tests/integration/scripts/host-key-seed-cli.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { dirname, join, resolve } from 'node:path'
@@ -118,6 +118,83 @@ describe('host-key-seed CLI (compiled artifact)', () => {
       expect(result.status).toBe(0)
       // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(existsSync(join(tmp, 'fresh-subdir'))).toBe(true)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects --hosts file exceeding default cap of 1000', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-cap-'))
+    const dbPath = join(tmp, 'keys.db')
+    const hostsFile = join(tmp, 'hosts.txt')
+    try {
+      const lines: string[] = []
+      for (let i = 0; i < 1001; i++) {
+        lines.push(`host-${i.toString()}.example`)
+      }
+      writeFileSync(hostsFile, lines.join('\n'))
+
+      const result = spawnSync(
+        process.execPath,
+        [distScript, '--hosts', hostsFile, '--db', dbPath],
+        { encoding: 'utf8', timeout: 10_000 }
+      )
+
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain('exceeds default cap of 1000')
+      expect(result.stderr).toContain('--max-hosts')
+      expect(result.stdout).not.toContain('Probing')
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts --hosts file at default cap (1000)', { timeout: 30_000 }, () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-cap-ok-'))
+    const dbPath = join(tmp, 'keys.db')
+    const hostsFile = join(tmp, 'hosts.txt')
+    try {
+      const lines: string[] = []
+      for (let i = 0; i < 1000; i++) {
+        lines.push(`unroutable-${i.toString()}.invalid`)
+      }
+      writeFileSync(hostsFile, lines.join('\n'))
+
+      const result = spawnSync(
+        process.execPath,
+        [distScript, '--hosts', hostsFile, '--db', dbPath],
+        { encoding: 'utf8', timeout: 20_000, killSignal: 'SIGTERM' }
+      )
+
+      expect(result.stderr).not.toContain('exceeds')
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('honors --max-hosts override above default', { timeout: 30_000 }, () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-seed-override-'))
+    const dbPath = join(tmp, 'keys.db')
+    const hostsFile = join(tmp, 'hosts.txt')
+    try {
+      const lines: string[] = []
+      for (let i = 0; i < 1500; i++) {
+        lines.push(`unroutable-${i.toString()}.invalid`)
+      }
+      writeFileSync(hostsFile, lines.join('\n'))
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          distScript,
+          '--hosts', hostsFile,
+          '--max-hosts', '1500',
+          '--db', dbPath
+        ],
+        { encoding: 'utf8', timeout: 20_000, killSignal: 'SIGTERM' }
+      )
+
+      expect(result.stderr).not.toContain('exceeds')
     } finally {
       rmSync(tmp, { recursive: true, force: true })
     }

--- a/tests/unit/scripts/host-key-seed.vitest.ts
+++ b/tests/unit/scripts/host-key-seed.vitest.ts
@@ -22,6 +22,8 @@ const {
   readConfiguredDbPath,
   parseHostsFile,
   checkHostsCap,
+  formatKnownHostsPreviewRow,
+  sanitizeForDisplay,
 } = await import('../../../scripts/host-key-seed.js')
 
 // ---------------------------------------------------------------------------
@@ -290,9 +292,6 @@ describe('isMainModule', () => {
 // ---------------------------------------------------------------------------
 // sanitizeForDisplay
 // ---------------------------------------------------------------------------
-
-// sanitizeForDisplay is already destructured in the main import above
-const { sanitizeForDisplay } = await import('../../../scripts/host-key-seed.js')
 
 describe('sanitizeForDisplay', () => {
   it('returns plain printable ASCII unchanged', () => {
@@ -565,5 +564,35 @@ describe('checkHostsCap', () => {
 
   it('rejects NaN cap', () => {
     expect(checkHostsCap(0, Number.NaN, true).ok).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatKnownHostsPreviewRow
+// ---------------------------------------------------------------------------
+
+describe('formatKnownHostsPreviewRow', () => {
+  it('formats a plain entry with host, port, algorithm, and fingerprint', () => {
+    const row = formatKnownHostsPreviewRow({
+      host: 'example.com',
+      port: 22,
+      algorithm: 'ssh-rsa',
+      key: 'AAAA'
+    })
+    expect(row).toContain('example.com')
+    expect(row).toContain('22')
+    expect(row).toContain('ssh-rsa')
+    expect(row).toContain('SHA256:')
+  })
+
+  it('escapes control characters in the host column', () => {
+    const row = formatKnownHostsPreviewRow({
+      host: '\x1b[31mhost\x1b[0m',
+      port: 22,
+      algorithm: 'ssh-rsa',
+      key: 'AAAA'
+    })
+    expect(row).toContain('\\x1B[31mhost\\x1B[0m')
+    expect(row.includes('\x1b')).toBe(false)
   })
 })

--- a/tests/unit/scripts/host-key-seed.vitest.ts
+++ b/tests/unit/scripts/host-key-seed.vitest.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -9,9 +12,15 @@ vi.mock('ssh2', () => ({
   Client: vi.fn()
 }))
 
-const { extractDbPathFromConfig, resolveDbPath, parseArgs, isMainModule } = await import(
-  '../../../scripts/host-key-seed.js'
-)
+const {
+  extractDbPathFromConfig,
+  resolveDbPath,
+  parseArgs,
+  isMainModule,
+  buildDbPathAllowlist,
+  validateDbPath,
+  readConfiguredDbPath,
+} = await import('../../../scripts/host-key-seed.js')
 
 // ---------------------------------------------------------------------------
 // extractDbPathFromConfig
@@ -246,6 +255,7 @@ describe('isMainModule', () => {
 // sanitizeForDisplay
 // ---------------------------------------------------------------------------
 
+// sanitizeForDisplay is already destructured in the main import above
 const { sanitizeForDisplay } = await import('../../../scripts/host-key-seed.js')
 
 describe('sanitizeForDisplay', () => {
@@ -287,5 +297,159 @@ describe('sanitizeForDisplay', () => {
   it('produces uppercase hex digits', () => {
     expect(sanitizeForDisplay('\x1b')).toBe('\\x1B')
     expect(sanitizeForDisplay('\x0a')).toBe('\\x0A')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildDbPathAllowlist / validateDbPath
+// ---------------------------------------------------------------------------
+
+describe('buildDbPathAllowlist', () => {
+  it('always includes /data and cwd', () => {
+    const list = buildDbPathAllowlist({}, undefined, '/srv/app')
+    expect(list).toContain('/data')
+    expect(list).toContain('/srv/app')
+  })
+
+  it('adds env var dirname when WEBSSH2_SSH_HOSTKEY_DB_PATH is set', () => {
+    const list = buildDbPathAllowlist(
+      { WEBSSH2_SSH_HOSTKEY_DB_PATH: '/var/lib/webssh2/db.sqlite' },
+      undefined,
+      '/srv/app'
+    )
+    expect(list).toContain('/var/lib/webssh2')
+  })
+
+  it('ignores empty env var', () => {
+    const list = buildDbPathAllowlist(
+      { WEBSSH2_SSH_HOSTKEY_DB_PATH: '' },
+      undefined,
+      '/srv/app'
+    )
+    expect(list).not.toContain('')
+  })
+
+  it('adds config dbPath dirname when provided', () => {
+    const list = buildDbPathAllowlist({}, '/etc/webssh2/keys.db', '/srv/app')
+    expect(list).toContain('/etc/webssh2')
+  })
+
+  it('deduplicates equal entries', () => {
+    const list = buildDbPathAllowlist(
+      { WEBSSH2_SSH_HOSTKEY_DB_PATH: '/data/keys.db' },
+      '/data/keys.db',
+      '/data'
+    )
+    const dataCount = list.filter((p) => p === '/data').length
+    expect(dataCount).toBe(1)
+  })
+
+  it('returns entries in documented priority order: /data, env, config, cwd', () => {
+    const list = buildDbPathAllowlist(
+      { WEBSSH2_SSH_HOSTKEY_DB_PATH: '/env/keys.db' },
+      '/cfg/keys.db',
+      '/srv/app'
+    )
+    expect(list).toEqual(['/data', '/env', '/cfg', '/srv/app'])
+  })
+})
+
+describe('validateDbPath', () => {
+  it('returns ok when the parent directory exists anywhere', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-validate-'))
+    try {
+      const target = join(tmp, 'keys.db')
+      const result = validateDbPath(target, ['/data'])
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value).toBe(target)
+      }
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('returns ok when parent does not exist but path is under allowlist entry', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-validate-'))
+    try {
+      const target = join(tmp, 'subdir', 'keys.db')   // subdir does not exist
+      const result = validateDbPath(target, [tmp])    // tmp is in allowlist
+      expect(result.ok).toBe(true)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('returns error when parent does not exist and path is outside allowlist', () => {
+    const result = validateDbPath('/nonexistent/sub/dir/keys.db', ['/data'])
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('refusing to create directories')
+      expect(result.error).toContain('/data')
+    }
+  })
+
+  it('rejects /datafoo when allowlist only contains /data (no prefix collision)', () => {
+    const result = validateDbPath('/datafoo/keys.db', ['/data'])
+    expect(result.ok).toBe(false)
+  })
+
+  it('resolves relative paths against cwd', () => {
+    const result = validateDbPath('keys.db', ['/data'])
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.startsWith('/')).toBe(true)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// readConfiguredDbPath
+// ---------------------------------------------------------------------------
+
+describe('readConfiguredDbPath', () => {
+  it('returns undefined when config.json does not exist', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-readcfg-missing-'))
+    const originalCwd = process.cwd()
+    try {
+      process.chdir(tmp)
+      expect(readConfiguredDbPath()).toBeUndefined()
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('returns undefined when config.json is malformed JSON', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-readcfg-bad-'))
+    const originalCwd = process.cwd()
+    try {
+      writeFileSync(join(tmp, 'config.json'), '{ this is not json')
+      process.chdir(tmp)
+      expect(readConfiguredDbPath()).toBeUndefined()
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('returns the dbPath from a valid nested config', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'webssh2-readcfg-valid-'))
+    const originalCwd = process.cwd()
+    try {
+      const cfg = {
+        ssh: {
+          hostKeyVerification: {
+            serverStore: { dbPath: '/custom/path/keys.db' }
+          }
+        }
+      }
+      writeFileSync(join(tmp, 'config.json'), JSON.stringify(cfg))
+      process.chdir(tmp)
+      expect(readConfiguredDbPath()).toBe('/custom/path/keys.db')
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(tmp, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/unit/scripts/host-key-seed.vitest.ts
+++ b/tests/unit/scripts/host-key-seed.vitest.ts
@@ -20,6 +20,8 @@ const {
   buildDbPathAllowlist,
   validateDbPath,
   readConfiguredDbPath,
+  parseHostsFile,
+  checkHostsCap,
 } = await import('../../../scripts/host-key-seed.js')
 
 // ---------------------------------------------------------------------------
@@ -184,6 +186,40 @@ describe('parseArgs', () => {
     const result = parseArgs(['node', 'script', '--list', '--db', '/custom/path.db'])
     expect(result.command).toBe('list')
     expect(result.dbPath).toBe('/custom/path.db')
+  })
+
+  it('parses --max-hosts with a positive integer', () => {
+    const result = parseArgs([
+      'node', 'script', '--hosts', 'f.txt', '--max-hosts', '50'
+    ])
+    expect(result.maxHosts).toBe(50)
+    expect(result.maxHostsExplicit).toBe(true)
+  })
+
+  it('leaves maxHostsExplicit false when --max-hosts is not passed', () => {
+    const result = parseArgs(['node', 'script', '--hosts', 'f.txt'])
+    expect(result.maxHostsExplicit).toBe(false)
+    expect(result.maxHosts).toBeUndefined()
+  })
+
+  it('captures non-numeric --max-hosts verbatim (validation deferred)', () => {
+    const result = parseArgs([
+      'node', 'script', '--hosts', 'f.txt', '--max-hosts', 'abc'
+    ])
+    expect(Number.isNaN(result.maxHosts ?? 0)).toBe(true)
+    expect(result.maxHostsExplicit).toBe(true)
+  })
+
+  it('parses --commit', () => {
+    const result = parseArgs([
+      'node', 'script', '--known-hosts', 'f', '--commit'
+    ])
+    expect(result.commit).toBe(true)
+  })
+
+  it('defaults commit to false', () => {
+    const result = parseArgs(['node', 'script', '--known-hosts', 'f'])
+    expect(result.commit).toBe(false)
   })
 })
 
@@ -451,5 +487,83 @@ describe('readConfiguredDbPath', () => {
       process.chdir(originalCwd)
       rmSync(tmp, { recursive: true, force: true })
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseHostsFile / checkHostsCap
+// ---------------------------------------------------------------------------
+
+describe('parseHostsFile', () => {
+  it('parses bare hostnames with default port', () => {
+    const entries = parseHostsFile('example.com\nhost2.com\n')
+    expect(entries).toEqual([
+      { host: 'example.com', port: 22 },
+      { host: 'host2.com', port: 22 }
+    ])
+  })
+
+  it('parses host:port form', () => {
+    const entries = parseHostsFile('example.com:2222\n')
+    expect(entries).toEqual([{ host: 'example.com', port: 2222 }])
+  })
+
+  it('falls back to default port when port is not numeric', () => {
+    const entries = parseHostsFile('example.com:abc\n')
+    expect(entries).toEqual([{ host: 'example.com:abc', port: 22 }])
+  })
+
+  it('skips empty lines and comments', () => {
+    const entries = parseHostsFile('# a comment\n\nexample.com\n   \n# trailing\n')
+    expect(entries).toEqual([{ host: 'example.com', port: 22 }])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parseHostsFile('')).toEqual([])
+  })
+})
+
+describe('checkHostsCap', () => {
+  it('returns ok when count is within cap', () => {
+    const result = checkHostsCap(500, 1000, false)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe(1000)
+    }
+  })
+
+  it('rejects when count exceeds default cap, suggesting --max-hosts', () => {
+    const result = checkHostsCap(1500, 1000, false)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('1500')
+      expect(result.error).toContain('default cap of 1000')
+      expect(result.error).toContain('--max-hosts')
+    }
+  })
+
+  it('rejects when count exceeds explicit cap, naming the cap value', () => {
+    const result = checkHostsCap(500, 200, true)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('500')
+      expect(result.error).toContain('explicit --max-hosts cap of 200')
+    }
+  })
+
+  it('rejects zero cap', () => {
+    const result = checkHostsCap(0, 0, true)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('positive integer')
+    }
+  })
+
+  it('rejects negative cap', () => {
+    expect(checkHostsCap(0, -5, true).ok).toBe(false)
+  })
+
+  it('rejects NaN cap', () => {
+    expect(checkHostsCap(0, Number.NaN, true).ok).toBe(false)
   })
 })

--- a/tests/unit/scripts/host-key-seed.vitest.ts
+++ b/tests/unit/scripts/host-key-seed.vitest.ts
@@ -294,44 +294,38 @@ describe('isMainModule', () => {
 // ---------------------------------------------------------------------------
 
 describe('sanitizeForDisplay', () => {
-  it('returns plain printable ASCII unchanged', () => {
-    expect(sanitizeForDisplay('example.com')).toBe('example.com')
-    expect(sanitizeForDisplay('host-1.sub.example.com:22')).toBe(
+  it.each([
+    ['plain ASCII passes through unchanged', 'example.com', 'example.com'],
+    [
+      'ASCII with port and dashes passes through',
+      'host-1.sub.example.com:22',
       'host-1.sub.example.com:22'
-    )
-    expect(sanitizeForDisplay('')).toBe('')
-  })
-
-  it('escapes ESC and CSI control sequences', () => {
-    expect(sanitizeForDisplay('\x1b[31mred\x1b[0m')).toBe('\\x1B[31mred\\x1B[0m')
-  })
-
-  it('escapes C0 control characters', () => {
-    expect(sanitizeForDisplay('\x00nul')).toBe('\\x00nul')
-    expect(sanitizeForDisplay('\x07bell')).toBe('\\x07bell')
-    expect(sanitizeForDisplay('\x08bs')).toBe('\\x08bs')
-    expect(sanitizeForDisplay('\rcr')).toBe('\\x0Dcr')
-    expect(sanitizeForDisplay('\nlf')).toBe('\\x0Alf')
-  })
-
-  it('escapes DEL (0x7F)', () => {
-    expect(sanitizeForDisplay('a\x7Fb')).toBe('a\\x7Fb')
-  })
-
-  it('escapes C1 control characters (0x80-0x9F)', () => {
-    expect(sanitizeForDisplay('a\x80b')).toBe('a\\x80b')
-    expect(sanitizeForDisplay('a\x9Bb')).toBe('a\\x9Bb')
-    expect(sanitizeForDisplay('a\x9Fb')).toBe('a\\x9Fb')
-  })
-
-  it('passes through printable Unicode above 0x9F', () => {
-    expect(sanitizeForDisplay('münchen.example')).toBe('münchen.example')
-    expect(sanitizeForDisplay('host. space')).toBe('host. space')
-  })
-
-  it('produces uppercase hex digits', () => {
-    expect(sanitizeForDisplay('\x1b')).toBe('\\x1B')
-    expect(sanitizeForDisplay('\x0a')).toBe('\\x0A')
+    ],
+    ['empty string passes through', '', ''],
+    [
+      'ESC + CSI red colour sequence is escaped',
+      '\x1b[31mred\x1b[0m',
+      '\\x1B[31mred\\x1B[0m'
+    ],
+    ['C0 NUL (0x00) is escaped', '\x00nul', '\\x00nul'],
+    ['C0 BEL (0x07) is escaped', '\x07bell', '\\x07bell'],
+    ['C0 BS (0x08) is escaped', '\x08bs', '\\x08bs'],
+    ['C0 CR (0x0D) is escaped as uppercase hex', '\rcr', '\\x0Dcr'],
+    ['C0 LF (0x0A) is escaped as uppercase hex', '\nlf', '\\x0Alf'],
+    ['DEL (0x7F) is escaped', 'a\x7Fb', 'a\\x7Fb'],
+    ['C1 0x80 is escaped', 'a\x80b', 'a\\x80b'],
+    ['C1 0x9B is escaped', 'a\x9Bb', 'a\\x9Bb'],
+    ['C1 0x9F is escaped', 'a\x9Fb', 'a\\x9Fb'],
+    [
+      'printable Unicode above 0x9F passes through',
+      'münchen.example',
+      'münchen.example'
+    ],
+    ['printable ASCII space passes through', 'host. space', 'host. space'],
+    ['bare ESC (0x1B) is escaped as uppercase hex', '\x1b', '\\x1B'],
+    ['bare LF (0x0A) is escaped as uppercase hex', '\x0a', '\\x0A']
+  ])('%s', (_label, input, expected) => {
+    expect(sanitizeForDisplay(input)).toBe(expected)
   })
 })
 

--- a/tests/unit/scripts/host-key-seed.vitest.ts
+++ b/tests/unit/scripts/host-key-seed.vitest.ts
@@ -241,3 +241,51 @@ describe('isMainModule', () => {
     ).toBe(false)
   })
 })
+
+// ---------------------------------------------------------------------------
+// sanitizeForDisplay
+// ---------------------------------------------------------------------------
+
+const { sanitizeForDisplay } = await import('../../../scripts/host-key-seed.js')
+
+describe('sanitizeForDisplay', () => {
+  it('returns plain printable ASCII unchanged', () => {
+    expect(sanitizeForDisplay('example.com')).toBe('example.com')
+    expect(sanitizeForDisplay('host-1.sub.example.com:22')).toBe(
+      'host-1.sub.example.com:22'
+    )
+    expect(sanitizeForDisplay('')).toBe('')
+  })
+
+  it('escapes ESC and CSI control sequences', () => {
+    expect(sanitizeForDisplay('\x1b[31mred\x1b[0m')).toBe('\\x1B[31mred\\x1B[0m')
+  })
+
+  it('escapes C0 control characters', () => {
+    expect(sanitizeForDisplay('\x00nul')).toBe('\\x00nul')
+    expect(sanitizeForDisplay('\x07bell')).toBe('\\x07bell')
+    expect(sanitizeForDisplay('\x08bs')).toBe('\\x08bs')
+    expect(sanitizeForDisplay('\rcr')).toBe('\\x0Dcr')
+    expect(sanitizeForDisplay('\nlf')).toBe('\\x0Alf')
+  })
+
+  it('escapes DEL (0x7F)', () => {
+    expect(sanitizeForDisplay('a\x7Fb')).toBe('a\\x7Fb')
+  })
+
+  it('escapes C1 control characters (0x80-0x9F)', () => {
+    expect(sanitizeForDisplay('a\x80b')).toBe('a\\x80b')
+    expect(sanitizeForDisplay('a\x9Bb')).toBe('a\\x9Bb')
+    expect(sanitizeForDisplay('a\x9Fb')).toBe('a\\x9Fb')
+  })
+
+  it('passes through printable Unicode above 0x9F', () => {
+    expect(sanitizeForDisplay('münchen.example')).toBe('münchen.example')
+    expect(sanitizeForDisplay('host. space')).toBe('host. space')
+  })
+
+  it('produces uppercase hex digits', () => {
+    expect(sanitizeForDisplay('\x1b')).toBe('\\x1B')
+    expect(sanitizeForDisplay('\x0a')).toBe('\\x0A')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #528. Hardens `scripts/host-key-seed.ts` against four red-team findings surfaced during the #527 review.

| # | Severity | Fix |
| --- | --- | --- |
| 1 | MEDIUM | `--known-hosts` is now dry-run by default; `--commit` required to write |
| 2 | MEDIUM | `--hosts` capped at 1000 entries by default; `--max-hosts N` to override |
| 3 | LOW | Host, algorithm, and file-path strings sanitized everywhere they echo to operator output (C0/DEL/C1 control bytes escaped as `\xNN`) |
| 4 | LOW | `--db` refuses to create new parent dirs outside `/data`, env-var dir, config.json dir, or cwd |

Five commits, atomic and independently revertable. Each commit has unit + integration test coverage.

## Soft-breaking CLI changes

- **`--known-hosts` no longer writes by default.** Add `--commit` to restore write behavior. Scripts that import `known_hosts` files must update.
- **`--hosts` rejects files with more than 1000 entries** unless `--max-hosts N` is passed. Exceeding the cap exits nonzero without attempting any SSH probes.

Both surface in the updated `--help` output and `README.md`.

The Task 4 commit uses the `feat(scripts)!:` marker plus a `BREAKING CHANGE:` footer so release-please produces a correct CHANGELOG entry.

## New helpers (all pure, exported for unit testing)

- `sanitizeForDisplay(s)` — escapes `[0x00, 0x1F]`, `0x7F`, `[0x80, 0x9F]` as `\xNN`.
- `validateDbPath(path, allowlist) → Result<string, string>` — returns canonical path; refuses missing-parent paths outside the allowlist.
- `buildDbPathAllowlist(env, configDbPath, cwd) → string[]` — composes the four-source allowlist with documented priority order.
- `readConfiguredDbPath() → string | undefined` — reads `config.json` without applying fallbacks.
- `parseHostsFile(content) → HostsFileEntry[]` — extracted from the inline parser.
- `checkHostsCap(count, max, explicit) → Result<number, string>` — enforces the cap with distinct error messages for default vs explicit.
- `formatKnownHostsPreviewRow(entry) → string` — preview row for `--known-hosts` dry-run output.

## Test plan

- [x] `npm run lint` — no new errors or warnings beyond the pre-existing project baseline
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm run test` — 1504 tests pass across the project (host-key-seed unit + integration both green)
- [x] Manual smoke test against the compiled CLI:
  - `node dist/scripts/host-key-seed.js --help` shows `--commit` and `--max-hosts` in Options block
  - `--known-hosts <file>` without `--commit` shows preview + DRY RUN summary, does not write
  - `--known-hosts <file> --commit` shows preview + Imported message, writes succeed
  - `--list` round-trip confirms write/no-write semantics
- [x] Final code review on the full PR — APPROVED

## Related

- #527 (entry-point guard, shipped) — surfaced these findings via red-team review
- #523 (broader hostkey UX) — out of scope for this PR
