### PR TITLE
fix(deps): override qs to 6.15.2 for CVE-2026-8723

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4728,9 +4728,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
     "flatted": "3.4.2",
     "picomatch": "4.0.4",
     "path-to-regexp": "8.4.0",
-    "vite": "7.3.2"
+    "vite": "7.3.2",
+    "qs": "6.15.2"
   },
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "^4.60.2"


### PR DESCRIPTION
## Summary

- Adds an npm `overrides` entry pinning `qs` to `6.15.2` (was `6.15.0`)
- Resolves Dependabot alert #89 and code-scanning alert #26 (both CVE-2026-8723)
- `qs` is a transitive dep via `express`, `body-parser`, and `supertest`

## Why

CVE-2026-8723 (MEDIUM) — `qs.stringify` throws `TypeError` when called with `arrayFormat: 'comma'` + `encodeValuesOnly: true` on arrays containing `null`/`undefined`. This project does **not** call `qs.stringify` directly, and Express/body-parser only use `qs.parse`, so the vulnerable code path is unreachable here. Update applied as hygiene to clear the alerts.

## Verification

- `npm ls qs` — all three transitive paths show `qs@6.15.2 overridden`
- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run test` — 1513/1514 passing (the one failure in `config-enhanced.vitest.ts` is a pre-existing test-ordering bug on main, unrelated to this change; passes in isolation)

## Test plan

- [ ] CI passes
- [ ] Dependabot alert #89 auto-closes
- [ ] Code-scanning alert #26 auto-closes on next Trivy run