### PR TITLE
ci: fix release-publish concurrency race + migrate workflows to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'npm'
@@ -43,7 +43,7 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -53,7 +53,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -65,10 +65,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
@@ -82,10 +82,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             image:
@@ -116,7 +116,7 @@ jobs:
           steps.filter.outputs.image == 'true' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           github.actor != 'dependabot[bot]'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -126,14 +126,14 @@ jobs:
           steps.filter.outputs.image == 'true' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           github.actor != 'dependabot[bot]'
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build amd64 image for scanning
         if: >-
           steps.filter.outputs.image == 'true' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           github.actor != 'dependabot[bot]'
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           load: true
@@ -146,7 +146,7 @@ jobs:
           steps.filter.outputs.image == 'true' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           github.actor != 'dependabot[bot]'
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: webssh2:pr-${{ github.event.pull_request.number }}
           format: table

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -255,6 +255,15 @@ jobs:
           # Get current release body
           CURRENT_BODY=$(gh release view "$RELEASE_TAG" --json body --jq '.body')
 
+          # Idempotency guard: skip if this release already has its Docker
+          # section (e.g. on a manual recovery re-run). Mirrors the
+          # rebuild-sha marker used by rebuild-release-tags.yml.
+          MARKER="<!-- docker-images:${SEMVER_FULL} -->"
+          if printf '%s' "$CURRENT_BODY" | grep -qF "$MARKER"; then
+            echo "::notice::Docker section already present for ${SEMVER_FULL}; skipping"
+            exit 0
+          fi
+
           # Create Docker images section
           DOCKER_SECTION="
 
@@ -283,6 +292,8 @@ jobs:
           **Links:**
           - [Docker Hub Repository](https://hub.docker.com/r/billchurch/webssh2)
           - [GitHub Container Registry](https://github.com/billchurch/webssh2/pkgs/container/webssh2)
+
+          ${MARKER}
           "
 
           # Append Docker section to release notes

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,26 +76,26 @@ jobs:
           echo '::error::DOCKER_USERNAME and DOCKER_TOKEN secrets are required' >&2
           exit 1
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref }}
 
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           platforms: linux/amd64,linux/arm64
 
-      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: docker.io
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -158,7 +158,7 @@ jobs:
           echo "image=ghcr.io/${owner}/webssh2" >> "${GITHUB_OUTPUT}"
 
       - id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: |
             docker.io/billchurch/webssh2
@@ -174,7 +174,7 @@ jobs:
             type=sha
 
       - name: Build amd64 image (load, for scan + smoke)
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ./Dockerfile
@@ -185,7 +185,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=publish-${{ github.ref }}
 
       - name: Trivy image scan (fail closed)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: local/webssh2:scan
           format: sarif
@@ -204,7 +204,7 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
@@ -226,7 +226,7 @@ jobs:
 
       - name: Build and push docker image
         id: build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         timeout-minutes: 60
         with:
           context: .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,7 +41,13 @@ on:
       - '.github/workflows/docker-publish.yml'
 
 concurrency:
-  group: image-publish
+  # Event-scoped so the release-publish run and the main-push run never
+  # contend for one slot. GitHub cancels a *pending* run when a newer run
+  # joins the same group (even with cancel-in-progress: false) — that
+  # starved the v5.0.1 release run, which lost its semver tags and notes.
+  # release + workflow_dispatch share the 'release' lane; push (main/sha
+  # tags) gets its own 'main' lane.
+  group: image-publish-${{ github.event_name == 'push' && 'main' || 'release' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/e2e-ssh.yml
+++ b/.github/workflows/e2e-ssh.yml
@@ -17,10 +17,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'npm'
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload Playwright report (if present)
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-test-results
           path: |

--- a/.github/workflows/rebuild-release-tags.yml
+++ b/.github/workflows/rebuild-release-tags.yml
@@ -15,7 +15,11 @@ on:
         options: ['true', 'false']
 
 concurrency:
-  group: image-publish
+  # Own lane (was the shared 'image-publish' group, which cancelled the
+  # pending release-publish run during the v5.0.1 release). rebuild only
+  # runs for renovate base-image bumps and defers if a release published in
+  # the last 10 minutes, so it never genuinely races a real release publish.
+  group: image-rebuild
   cancel-in-progress: false
 
 # Workflow-level permissions are read-only. Each job overrides with the

--- a/.github/workflows/rebuild-release-tags.yml
+++ b/.github/workflows/rebuild-release-tags.yml
@@ -69,7 +69,7 @@ jobs:
       # below (signature, digest-only diff, strict patterns). persist-credentials
       # is disabled so no token is left in the worktree; all later git ops are
       # local and `gh` uses GH_TOKEN explicitly.
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ steps.ctx.outputs.head_sha }}
           fetch-depth: 0
@@ -216,7 +216,7 @@ jobs:
       # this file; the scan policy must track current main, not the
       # release's frozen state.
       - name: Checkout main .trivyignore for scan suppression
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           sparse-checkout: |
             .trivyignore
@@ -229,7 +229,7 @@ jobs:
       # tree, NEW_DIGEST, was strict-pattern validated in `guard` before being
       # overlaid below. Credentials are not persisted into release-src.
       - name: Checkout release-tag source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ env.RELEASE_SHA }}
           path: release-src
@@ -242,22 +242,22 @@ jobs:
           sed -i "s|^ARG BASE_IMAGE=.*|ARG BASE_IMAGE=${NEW_DIGEST}|" Dockerfile
           grep -E '^ARG BASE_IMAGE=' Dockerfile
 
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build amd64 for scan
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: release-src
           load: true
@@ -265,7 +265,7 @@ jobs:
           tags: local/webssh2-rebuild:scan
 
       - name: Trivy image scan (fail closed)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: local/webssh2-rebuild:scan
           format: sarif
@@ -294,7 +294,7 @@ jobs:
       - name: Multi-arch build and push (semver tags only; no sha-tag)
         id: push
         if: env.SIMULATE != 'true'
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: release-src
           push: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -30,11 +30,11 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       # Checkout code if release was created
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         if: ${{ steps.release.outputs.release_created }}
 
       # Setup Node.js for building release artifacts
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: ${{ steps.release.outputs.release_created }}
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

Three CI-only changes (no application code). Fixes the root cause of the
v5.0.1 release publishing without semver image tags or Docker release notes,
and retires every Node-20 GitHub Action ahead of the 2026-06-16 forced-Node-24
deadline.

### 1. Fix the release-publish concurrency race

`docker-publish.yml`, `rebuild-release-tags.yml`, and (formerly) the release
push all shared one `concurrency.group: image-publish`. GitHub cancels a
*pending* run when a newer run joins the same group — **even with
`cancel-in-progress: false`**. During the v5.0.1 release the chain
`push → release → rebuild` arrivals starved the `release:published`
docker-publish run while it was still pending, so it never produced the semver
tags (`5.0.1`/`5.0`/`5`) or the Docker notes section. A manual `workflow_dispatch`
re-run later did the work.

Fix: event-scope the groups so the release run reaches *in-progress*
immediately (an in-progress run is never cancelled by a newly-pending sibling):

- `docker-publish.yml` → `image-publish-${{ github.event_name == 'push' && 'main' || 'release' }}` (release + workflow_dispatch share the `release` lane; push gets `main`)
- `rebuild-release-tags.yml` → its own `image-rebuild` group

The lanes publish disjoint tag sets, and `rebuild` already gates on
`renovate[bot]` + a 10-minute release-defer guard, so dropping the shared
group introduces no real concurrent-push risk.

### 2. Idempotent release-notes Docker section

The "Update release notes with Docker images" step now stamps an HTML-comment
marker `<!-- docker-images:${SEMVER_FULL} -->` and skips if it's already
present — mirroring the `rebuild-sha:` marker in `rebuild-release-tags.yml`.
This makes the manual recovery re-run safe from double-appending.

### 3. Node-24 action sweep (repo-wide)

All 13 Node-20 actions across the 5 workflows bumped to Node-24, SHA-pinned,
14-day-quarantine-compliant (published ≤2026-05-16) versions. `actions/cache`
(the `0400d5f…` pin from the deprecation warning) is bundled inside
`aquasecurity/trivy-action` and is retired transitively by bumping it to
v0.36.0 (which ships `actions/cache@v5.0.5`).

Notable majors, both verified behavior-preserving for our usage:
`github/codeql-action` v3→v4.35.5 (v3 never went Node 24),
`actions/upload-artifact` v4→v7.0.1, `googleapis/release-please-action` v4→v5.0.0.

## Test Plan

- [x] `actionlint` (via Docker) clean — only pre-existing shellcheck info/style findings, no new errors
- [x] Idempotency-guard logic covered by a bash contract test (fresh → append, same-version marker → skip, different version → append)
- [x] All 13 pinned SHAs verified against the GitHub API to match their tags, confirmed `using: node24`, and confirmed published ≤2026-05-16
- [ ] **End-to-end (next real release):** the `release:published` docker-publish run stays in-progress and completes with semver tags + Docker notes section present, and `rebuild-release-tags` is skipped by its guard
- [ ] Watch the next image scan — trivy-action v0.36.0 ships Trivy v0.70.0; if it surfaces a new CRITICAL/HIGH, triage via `.trivyignore` per existing policy (do not weaken the gate)