### PR TITLE
fix(deps): bump brace-expansion to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,9 +1600,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2083,9 +2083,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Bumps the transitive dev dependency `brace-expansion` to patched versions, clearing the moderate ReDoS advisories GHSA-f886-m6hf-6m8v and GHSA-jxxr-4gwj-5jf2.

- `@typescript-eslint/typescript-estree` → `minimatch@10` path: 5.0.5 → 5.0.6
- hoisted (eslint-plugin-node → `minimatch@3` path): 1.1.12 → 1.1.15

Both instances are dev-only (`npm ls brace-expansion --omit=dev` is empty) and not present in the production Docker image. Both patched versions clear the 14-day supply-chain quarantine policy and have identical dependency sets to the versions they replace. `package.json` is untouched; the lockfile diff is confined to the two entries.

## Verification

- `npm audit` → 0 vulnerabilities
- `npm audit --audit-level=high` → exit 0 (CI gate parity)
- `npm ls brace-expansion` → 5.0.6 and 1.1.15 only
- `npm run lint` → clean
- `npm run build && npm run test` → 1514 tests passed

Fixes #538