### PR TITLE
feat(security): warn loudly at startup on permissive security defaults

### DIFF
--- a/DOCS/configuration/CONFIG-JSON.md
+++ b/DOCS/configuration/CONFIG-JSON.md
@@ -475,6 +475,8 @@ See [ENVIRONMENT-VARIABLES.md](./ENVIRONMENT-VARIABLES.md) for details on enviro
 
 SSH host key verification provides TOFU (Trust On First Use) protection against man-in-the-middle attacks. It supports three modes of operation: server-only (SQLite store), client-only (browser localStorage), and hybrid (server-first with client fallback).
 
+> **Security:** Host key verification is disabled by default and the server logs a startup warning until it is enabled. See [Default security posture](../../SECURITY.md#default-security-posture).
+
 #### Configuration Options
 
 - `ssh.hostKeyVerification.enabled` (boolean, default: `false`): Enable or disable host key verification. When disabled (the default), all host keys are accepted without verification.
@@ -665,6 +667,8 @@ WebSSH2 includes optional telnet support for connecting to legacy devices and sy
 - `telnet.auth.expectTimeout` (number, default: `10000`): Maximum time in milliseconds to wait for prompt pattern matches during authentication. If no prompt is detected within this time, the authenticator falls back to pass-through mode, forwarding raw data to the terminal.
 
 - `telnet.allowedSubnets` (string[], default: `[]`): Restrict which hosts can be connected to via telnet. Uses the same CIDR notation format as `ssh.allowedSubnets`. When empty, all hosts are allowed.
+
+> **Security:** Empty `ssh.allowedSubnets` / `telnet.allowedSubnets` lists allow connections to ANY host (open proxy / SSRF exposure) and the server logs a startup warning until they are restricted. See [Default security posture](../../SECURITY.md#default-security-posture).
 
 #### Default Telnet Configuration
 

--- a/DOCS/configuration/OVERVIEW.md
+++ b/DOCS/configuration/OVERVIEW.md
@@ -11,7 +11,7 @@ WebSSH2 supports multiple configuration methods with a clear priority order, fol
 Configuration is loaded with the following priority (highest to lowest):
 
 1. **Environment Variables** (highest priority)
-2. **config.json file** 
+2. **config.json file**
 3. **Built-in defaults** (lowest priority)
 
 This means environment variables always override config.json settings, which in turn override defaults.
@@ -69,6 +69,7 @@ WEBSSH2_<SECTION>_<SUBSECTION>_<SETTING>
 ```
 
 Examples:
+
 - `WEBSSH2_LISTEN_PORT` → `listen.port`
 - `WEBSSH2_SSH_ALGORITHMS_KEX` → `ssh.algorithms.kex`
 - `WEBSSH2_SESSION_COOKIE_SECRET` → `session.cookie.secret`
@@ -115,6 +116,7 @@ data:
 ### 1. Server Configuration
 
 Controls how the WebSSH2 server runs:
+
 - Listen address and port
 - SSL/TLS settings
 - Logging configuration
@@ -124,6 +126,7 @@ Controls how the WebSSH2 server runs:
 ### 2. SSH Configuration
 
 SSH connection defaults and algorithms:
+
 - Default host and port
 - Algorithm presets (modern, legacy, default)
 - Authentication methods
@@ -134,6 +137,7 @@ SSH connection defaults and algorithms:
 ### 3. Session Configuration
 
 Web session management:
+
 - Session secret
 - Cookie settings
 - Timeout values
@@ -143,6 +147,7 @@ Web session management:
 ### 4. UI Configuration
 
 User interface customization:
+
 - Header text and styling
 - Terminal defaults
 - Theme settings
@@ -152,9 +157,11 @@ User interface customization:
 ### 5. Security Configuration
 
 Security-related settings:
+
 - CORS origins
 - SSO integration
 - HTTPS enforcement
+- Host key verification and target-host restrictions (permissive by default — see [Default security posture](../../SECURITY.md#default-security-posture))
 
 [Learn more →](./ENVIRONMENT-VARIABLES.md#security-configuration)
 
@@ -221,6 +228,7 @@ WEBSSH2_HTTP_ORIGINS=https://yourdomain.com
 ### From config.json to Environment Variables
 
 **Old (config.json):**
+
 ```json
 {
   "listen": {
@@ -234,6 +242,7 @@ WEBSSH2_HTTP_ORIGINS=https://yourdomain.com
 ```
 
 **New (Environment Variables):**
+
 ```bash
 export WEBSSH2_LISTEN_PORT=3000
 export WEBSSH2_SSH_HOST=ssh.example.com
@@ -266,6 +275,7 @@ Invalid configuration will prevent startup with clear error messages.
 ### Precedence Issues
 
 Remember the priority order:
+
 1. URL parameters (for applicable settings)
 2. Environment variables
 3. config.json
@@ -274,6 +284,7 @@ Remember the priority order:
 ### Type Conversion
 
 Environment variables are strings. WebSSH2 automatically converts:
+
 - `"true"`/`"false"` → boolean
 - `"123"` → number
 - `'["a","b"]'` → array
@@ -281,6 +292,7 @@ Environment variables are strings. WebSSH2 automatically converts:
 
 ## Related Documentation
 
+- [Security Policy — Default security posture](../../SECURITY.md#default-security-posture)
 - [Environment Variables Reference](./ENVIRONMENT-VARIABLES.md)
 - [config.json Schema](./CONFIG-JSON.md)
 - [URL Parameters](./URL-PARAMETERS.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,86 @@ When deploying WebSSH2:
 - Review and follow security guidance in our [documentation](README.md)
 - Use environment variables for sensitive configuration (see [ENV_VARIABLES.md](DOCS/ENV_VARIABLES.md))
 
+## Default security posture
+
+Two defaults ship intentionally permissive and are kept that way for
+backward compatibility. Both are audited when the server starts and emit
+warn-level structured logs (`event: security_posture`) until you harden
+them. Review this section before exposing any deployment beyond a trusted
+network.
+
+### Host key verification is disabled by default
+
+| Config key | Default | Exposure |
+| --- | --- | --- |
+| `ssh.hostKeyVerification.enabled` | `false` | The gateway accepts ANY SSH host key, so an attacker positioned between the gateway and the target can silently man-in-the-middle sessions and capture credentials |
+
+To harden, enable verification (the `prompt` action gives users a
+TOFU-style accept/reject decision for unknown keys):
+
+```json
+{
+  "ssh": {
+    "hostKeyVerification": {
+      "enabled": true,
+      "unknownKeyAction": "prompt"
+    }
+  }
+}
+```
+
+Or via environment variables:
+
+```bash
+WEBSSH2_SSH_HOSTKEY_ENABLED=true
+WEBSSH2_SSH_HOSTKEY_UNKNOWN_ACTION=prompt
+```
+
+Additional notes:
+
+- Pre-seed the server-side key store with `npm run hostkeys` so known
+  hosts are pinned before first use
+- Enabling verification covers socket-based SSH connections; some
+  non-socket connection paths skip the verifier even when it is enabled,
+  so do not treat it as covering every code path
+- Full option reference:
+  [Host Key Verification](DOCS/configuration/CONFIG-JSON.md#host-key-verification)
+
+### No target-host restrictions by default
+
+| Config key | Default | Exposure |
+| --- | --- | --- |
+| `ssh.allowedSubnets` | `[]` (allow all) | Any authenticated client can ask the gateway to open an SSH connection to ANY reachable host/port — an open SSH proxy and SSRF pivot into internal networks and cloud metadata endpoints |
+| `telnet.allowedSubnets` | `[]` (allow all) | Same exposure for telnet targets when `telnet.enabled` is `true` (telnet is disabled by default) |
+
+To harden, restrict destinations to the CIDR ranges you actually serve:
+
+```json
+{
+  "ssh": {
+    "allowedSubnets": ["10.0.0.0/8", "192.168.1.0/24"]
+  },
+  "telnet": {
+    "allowedSubnets": ["10.0.0.0/8"]
+  }
+}
+```
+
+Or via environment variables:
+
+```bash
+WEBSSH2_SSH_ALLOWED_SUBNETS="10.0.0.0/8,192.168.1.0/24"
+WEBSSH2_TELNET_ALLOWED_SUBNETS="10.0.0.0/8"
+```
+
+Additional notes:
+
+- Validation happens at connect time using DNS resolution of the
+  requested host; there is no DNS-rebinding pinning between validation
+  and connection (tracked separately)
+- Prefer the narrowest CIDR ranges possible and pair them with
+  network-level egress controls
+
 ## Security Disclosure Policy
 
 - **Private Disclosure**: We request that you give us reasonable time to address the issue before public disclosure
@@ -304,6 +384,6 @@ For reference, the following IOCs were published by Snyk:
 
 ---
 
-**Last updated:** 2026-05-03
+**Last updated:** 2026-06-10
 
 **Next review:** 2026-06-01

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -386,4 +386,4 @@ For reference, the following IOCs were published by Snyk:
 
 **Last updated:** 2026-06-10
 
-**Next review:** 2026-06-01
+**Next review:** 2026-09-10

--- a/app/app.ts
+++ b/app/app.ts
@@ -9,7 +9,12 @@ import { applyMiddleware } from './middleware.js'
 import { createServer, startServer } from './server.js'
 import { configureSocketIO, configureTelnetNamespace } from './io.js'
 import { handleError, ConfigError } from './errors.js'
-import { createNamespacedDebug, applyLoggingConfiguration } from './logger.js'
+import {
+  createNamespacedDebug,
+  applyLoggingConfiguration,
+  logSecurityPostureWarning
+} from './logger.js'
+import { auditSecurityPosture } from './security-posture.js'
 import { MESSAGES } from './constants/index.js'
 import { getClientPublicPath } from './client-path.js'
 import type { Config } from './types/config.js'
@@ -62,6 +67,10 @@ export async function initializeServerAsync(): Promise<{
     debug('Configuration loaded asynchronously')
 
     applyLoggingConfiguration(appConfig.logging)
+
+    for (const warning of auditSecurityPosture(appConfig)) {
+      logSecurityPostureWarning(warning)
+    }
 
     // Pre-warm the theming injection cache and wire the resolved theming
     // config into the connection handler. When theming is disabled (or

--- a/app/logger.ts
+++ b/app/logger.ts
@@ -13,6 +13,7 @@ import { createLevelFilteredTransport } from './logging/transport-filters.js'
 import { createSyslogTransport } from './logging/syslog-transport.js'
 import type { LogContext } from './logging/log-context.js'
 import type { Config, LoggingConfig } from './types/config.js'
+import type { SecurityPostureWarning } from './security-posture.js'
 
 let defaultStructuredLogger = createStructuredLogger({
   namespace: 'webssh2:app',
@@ -79,6 +80,25 @@ export function logThemingConfigWarning(warning: ThemingConfigWarning): void {
 
   if (!result.ok) {
     console.warn('Failed to emit theming config warning log:', result.error)
+  }
+}
+
+export function logSecurityPostureWarning(warning: SecurityPostureWarning): void {
+  const result = defaultStructuredLogger.warn({
+    event: 'security_posture',
+    message: warning.message,
+    context: {
+      status: 'failure',
+      reason: warning.check
+    },
+    data: {
+      configKey: warning.configKey,
+      remediation: warning.remediation
+    }
+  })
+
+  if (!result.ok) {
+    console.warn('Failed to emit security posture warning log:', result.error)
   }
 }
 

--- a/app/logging/event-catalog.ts
+++ b/app/logging/event-catalog.ts
@@ -34,7 +34,8 @@ export const LOG_EVENT_NAMES = [
   'prompt_timeout',
   'prompt_error',
   // Configuration / theming
-  'theming_config_invalid'
+  'theming_config_invalid',
+  'security_posture'
 ] as const
 
 export type LogEventName = typeof LOG_EVENT_NAMES[number]

--- a/app/security-posture.ts
+++ b/app/security-posture.ts
@@ -61,7 +61,7 @@ const TELNET_SUBNETS_WARNING: SecurityPostureWarning = {
 }
 
 function isSubnetListEmpty(subnets: readonly string[] | undefined): boolean {
-  return subnets === undefined || subnets.length === 0
+  return subnets === undefined || subnets.filter((s) => s.trim().length > 0).length === 0
 }
 
 export function auditSecurityPosture(config: Config): SecurityPostureWarning[] {

--- a/app/security-posture.ts
+++ b/app/security-posture.ts
@@ -1,0 +1,84 @@
+// app/security-posture.ts
+// Pure audit of security-relevant configuration defaults.
+// Emits warnings for permissive defaults so operators harden deployments.
+
+import type { Config } from './types/config.js'
+
+export interface SecurityPostureWarning {
+  readonly check:
+    | 'host_key_verification_disabled'
+    | 'ssh_allowed_subnets_empty'
+    | 'telnet_allowed_subnets_empty'
+  readonly configKey: string
+  readonly message: string
+  readonly remediation: string
+}
+
+// Structural view of the fields this audit inspects. Everything is optional
+// so the audit tolerates partial or hand-built configs without crashing.
+interface SecurityPostureView {
+  readonly ssh?: {
+    readonly hostKeyVerification?: { readonly enabled?: boolean }
+    readonly allowedSubnets?: readonly string[]
+  }
+  readonly telnet?: {
+    readonly enabled?: boolean
+    readonly allowedSubnets?: readonly string[]
+  }
+}
+
+const HOST_KEY_WARNING: SecurityPostureWarning = {
+  check: 'host_key_verification_disabled',
+  configKey: 'ssh.hostKeyVerification.enabled',
+  message:
+    'SECURITY WARNING: SSH host key verification is DISABLED (default). ' +
+    'The gateway will accept ANY SSH host key, exposing sessions to man-in-the-middle attacks.',
+  remediation:
+    'Set ssh.hostKeyVerification.enabled=true (WEBSSH2_SSH_HOSTKEY_ENABLED=true), ' +
+    "recommended with unknownKeyAction='prompt'. See SECURITY.md 'Default security posture'."
+}
+
+const SSH_SUBNETS_WARNING: SecurityPostureWarning = {
+  check: 'ssh_allowed_subnets_empty',
+  configKey: 'ssh.allowedSubnets',
+  message:
+    'SECURITY WARNING: ssh.allowedSubnets is empty (default). ' +
+    'The gateway will connect to ANY host/port requested by clients (open SSH proxy / SSRF).',
+  remediation:
+    'Restrict destinations by setting ssh.allowedSubnets ' +
+    "(WEBSSH2_SSH_ALLOWED_SUBNETS, CIDR list). See SECURITY.md 'Default security posture'."
+}
+
+const TELNET_SUBNETS_WARNING: SecurityPostureWarning = {
+  check: 'telnet_allowed_subnets_empty',
+  configKey: 'telnet.allowedSubnets',
+  message:
+    'SECURITY WARNING: telnet.allowedSubnets is empty (default) while telnet is enabled. ' +
+    'The gateway will connect to ANY host/port requested by clients (open telnet proxy / SSRF).',
+  remediation:
+    'Restrict destinations by setting telnet.allowedSubnets ' +
+    "(WEBSSH2_TELNET_ALLOWED_SUBNETS, CIDR list). See SECURITY.md 'Default security posture'."
+}
+
+function isSubnetListEmpty(subnets: readonly string[] | undefined): boolean {
+  return subnets === undefined || subnets.length === 0
+}
+
+export function auditSecurityPosture(config: Config): SecurityPostureWarning[] {
+  const view: SecurityPostureView = config
+  const warnings: SecurityPostureWarning[] = []
+
+  if (view.ssh?.hostKeyVerification?.enabled !== true) {
+    warnings.push(HOST_KEY_WARNING)
+  }
+
+  if (isSubnetListEmpty(view.ssh?.allowedSubnets)) {
+    warnings.push(SSH_SUBNETS_WARNING)
+  }
+
+  if (view.telnet?.enabled === true && isSubnetListEmpty(view.telnet.allowedSubnets)) {
+    warnings.push(TELNET_SUBNETS_WARNING)
+  }
+
+  return warnings
+}

--- a/tests/unit/logging/security-posture-logger.vitest.ts
+++ b/tests/unit/logging/security-posture-logger.vitest.ts
@@ -1,0 +1,37 @@
+// tests/unit/logging/security-posture-logger.vitest.ts
+// Emitter tests for logSecurityPostureWarning
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { logSecurityPostureWarning } from '../../../app/logger.js'
+import type { SecurityPostureWarning } from '../../../app/security-posture.js'
+
+const SAMPLE_WARNING: SecurityPostureWarning = {
+  check: 'host_key_verification_disabled',
+  configKey: 'ssh.hostKeyVerification.enabled',
+  message: 'sample security posture message',
+  remediation: 'sample remediation guidance'
+}
+
+describe('logSecurityPostureWarning', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('emits a warn-level security_posture event with remediation details', () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    logSecurityPostureWarning(SAMPLE_WARNING)
+
+    expect(writeSpy).toHaveBeenCalledTimes(1)
+    const payload = JSON.parse(String(writeSpy.mock.calls[0]?.[0])) as Record<string, unknown>
+    expect(payload['level']).toBe('warn')
+    expect(payload['event']).toBe('security_posture')
+    expect(payload['message']).toBe(SAMPLE_WARNING.message)
+    expect(payload['status']).toBe('failure')
+    expect(payload['reason']).toBe(SAMPLE_WARNING.check)
+    expect(payload['details']).toEqual({
+      configKey: SAMPLE_WARNING.configKey,
+      remediation: SAMPLE_WARNING.remediation
+    })
+  })
+})

--- a/tests/unit/security-posture.vitest.ts
+++ b/tests/unit/security-posture.vitest.ts
@@ -1,0 +1,123 @@
+// tests/unit/security-posture.vitest.ts
+// Unit tests for the startup security posture audit
+
+import { describe, it, expect } from 'vitest'
+import { createDefaultConfig } from '../../app/config/config-processor.js'
+import { auditSecurityPosture, type SecurityPostureWarning } from '../../app/security-posture.js'
+import type { Config } from '../../app/types/config.js'
+import { TEST_SUBNETS } from '../test-constants.js'
+
+function findWarning(
+  warnings: SecurityPostureWarning[],
+  check: SecurityPostureWarning['check']
+): SecurityPostureWarning | undefined {
+  return warnings.find((warning) => warning.check === check)
+}
+
+function createHardenedConfig(): Config {
+  const config = createDefaultConfig()
+  config.ssh.hostKeyVerification.enabled = true
+  config.ssh.allowedSubnets = [TEST_SUBNETS.PRIVATE_10]
+  if (config.telnet !== undefined) {
+    config.telnet.allowedSubnets = [TEST_SUBNETS.PRIVATE_10]
+  }
+  return config
+}
+
+describe('auditSecurityPosture', () => {
+  it('flags host key verification and ssh subnets on the default config', () => {
+    const warnings = auditSecurityPosture(createDefaultConfig())
+
+    expect(warnings).toHaveLength(2)
+    expect(findWarning(warnings, 'host_key_verification_disabled')).toBeDefined()
+    expect(findWarning(warnings, 'ssh_allowed_subnets_empty')).toBeDefined()
+  })
+
+  it('does not flag telnet subnets when telnet is disabled (default)', () => {
+    const warnings = auditSecurityPosture(createDefaultConfig())
+
+    expect(findWarning(warnings, 'telnet_allowed_subnets_empty')).toBeUndefined()
+  })
+
+  it('flags telnet subnets when telnet is enabled with empty subnets', () => {
+    const config = createDefaultConfig()
+    if (config.telnet !== undefined) {
+      config.telnet.enabled = true
+    }
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(findWarning(warnings, 'telnet_allowed_subnets_empty')).toBeDefined()
+  })
+
+  it('does not flag telnet subnets when telnet is enabled with subnets configured', () => {
+    const config = createDefaultConfig()
+    if (config.telnet !== undefined) {
+      config.telnet.enabled = true
+      config.telnet.allowedSubnets = [TEST_SUBNETS.PRIVATE_192]
+    }
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(findWarning(warnings, 'telnet_allowed_subnets_empty')).toBeUndefined()
+  })
+
+  it('returns zero warnings for a fully hardened config', () => {
+    const warnings = auditSecurityPosture(createHardenedConfig())
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('returns zero warnings for a hardened config with telnet enabled', () => {
+    const config = createHardenedConfig()
+    if (config.telnet !== undefined) {
+      config.telnet.enabled = true
+    }
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('does not crash on a partial hand-built config', () => {
+    const partial = { ssh: {} } as unknown as Config
+
+    const warnings = auditSecurityPosture(partial)
+
+    expect(findWarning(warnings, 'host_key_verification_disabled')).toBeDefined()
+    expect(findWarning(warnings, 'ssh_allowed_subnets_empty')).toBeDefined()
+    expect(findWarning(warnings, 'telnet_allowed_subnets_empty')).toBeUndefined()
+  })
+
+  it('treats undefined telnet allowedSubnets as empty when telnet is enabled', () => {
+    const partial = { ssh: {}, telnet: { enabled: true } } as unknown as Config
+
+    const warnings = auditSecurityPosture(partial)
+
+    expect(findWarning(warnings, 'telnet_allowed_subnets_empty')).toBeDefined()
+  })
+
+  it('names the right config key in each warning', () => {
+    const config = createDefaultConfig()
+    if (config.telnet !== undefined) {
+      config.telnet.enabled = true
+    }
+
+    const warnings = auditSecurityPosture(config)
+
+    const hostKey = findWarning(warnings, 'host_key_verification_disabled')
+    expect(hostKey?.configKey).toBe('ssh.hostKeyVerification.enabled')
+    expect(hostKey?.message).toContain('host key verification')
+    expect(hostKey?.remediation).toContain('ssh.hostKeyVerification.enabled')
+
+    const sshSubnets = findWarning(warnings, 'ssh_allowed_subnets_empty')
+    expect(sshSubnets?.configKey).toBe('ssh.allowedSubnets')
+    expect(sshSubnets?.message).toContain('ssh.allowedSubnets')
+    expect(sshSubnets?.remediation).toContain('ssh.allowedSubnets')
+
+    const telnetSubnets = findWarning(warnings, 'telnet_allowed_subnets_empty')
+    expect(telnetSubnets?.configKey).toBe('telnet.allowedSubnets')
+    expect(telnetSubnets?.message).toContain('telnet.allowedSubnets')
+    expect(telnetSubnets?.remediation).toContain('telnet.allowedSubnets')
+  })
+})

--- a/tests/unit/security-posture.vitest.ts
+++ b/tests/unit/security-posture.vitest.ts
@@ -62,6 +62,38 @@ describe('auditSecurityPosture', () => {
     expect(findWarning(warnings, 'telnet_allowed_subnets_empty')).toBeUndefined()
   })
 
+  it('treats whitespace-only subnet entries as empty', () => {
+    const config = createDefaultConfig()
+    config.ssh.allowedSubnets = [' ']
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(findWarning(warnings, 'ssh_allowed_subnets_empty')).toBeDefined()
+  })
+
+  it('treats blank-string subnet entries as empty', () => {
+    const config = createDefaultConfig()
+    config.ssh.allowedSubnets = ['']
+    if (config.telnet !== undefined) {
+      config.telnet.enabled = true
+      config.telnet.allowedSubnets = ['', ' ']
+    }
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(findWarning(warnings, 'ssh_allowed_subnets_empty')).toBeDefined()
+    expect(findWarning(warnings, 'telnet_allowed_subnets_empty')).toBeDefined()
+  })
+
+  it('does not treat a real subnet alongside a blank entry as empty', () => {
+    const config = createDefaultConfig()
+    config.ssh.allowedSubnets = ['', TEST_SUBNETS.PRIVATE_10]
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(findWarning(warnings, 'ssh_allowed_subnets_empty')).toBeUndefined()
+  })
+
   it('returns zero warnings for a fully hardened config', () => {
     const warnings = auditSecurityPosture(createHardenedConfig())
 


### PR DESCRIPTION
## Summary

Implements the mitigation scoped in #539: the two permissive defaults (host key verification disabled; empty `allowedSubnets`) are **unchanged**, but the gateway now makes the weakened posture impossible to miss.

- New pure `app/security-posture.ts`: `auditSecurityPosture(config)` returns structured warnings for three checks — host key verification disabled, `ssh.allowedSubnets` empty, and `telnet.allowedSubnets` empty (only when telnet is enabled, to avoid noise). Blank/whitespace-only subnet entries count as empty so a junk entry can't suppress the warning. Extensible for future posture checks.
- New `security_posture` event in the typed log catalog; `logSecurityPostureWarning` emitter follows the existing `logThemingConfigWarning` pattern (structured warn + `console.warn` fallback). Warnings fire once in `initializeServerAsync` right after logging is configured — the stdout transport is on by default, so they're visible without `DEBUG`.
- Each warning names the exact config key, env var (`WEBSSH2_SSH_HOSTKEY_ENABLED`, `WEBSSH2_SSH_ALLOWED_SUBNETS`, `WEBSSH2_TELNET_ALLOWED_SUBNETS`), and remediation.
- `SECURITY.md` gains a "Default security posture" section covering both exposures (MITM; open proxy/SSRF), hardening steps (`unknownKeyAction: 'prompt'`, `npm run hostkeys`, CIDR allowlists), and explicit caveats (non-socket paths skip the verifier even when enabled; validation is connect-time DNS-based, no rebinding pinning). Cross-linked from `DOCS/configuration/CONFIG-JSON.md` and `OVERVIEW.md`.

Note: the issue referenced `DOCS/CONFIG.md`, which doesn't exist — links target the real config docs instead.

## Verification

- `npm run lint` — 0 errors; `npm run typecheck` — clean
- `npm run test` — 1527 tests passing (13 new: audit logic incl. telnet gating, partial configs, blank-entry edge cases; emitter warn-level/event assertions)
- Live smoke test: default config startup emits both `security_posture` warn records

Fixes #539