### PR TITLE
fix long polling fallback

### DIFF
--- a/DOCS/configuration/CONFIG-JSON.md
+++ b/DOCS/configuration/CONFIG-JSON.md
@@ -257,6 +257,14 @@ You can choose whether credential replay sends a carriage return (CR) or carriag
 
 This option can also be controlled via the environment variable `WEBSSH2_OPTIONS_REPLAY_CRLF`.
 
+### Socket.IO Transport
+
+You can force the Socket.IO transport used between the browser and the server. This is useful when WebSocket upgrades are known to fail behind a restrictive proxy or load balancer and you want to fall back to HTTP long-polling.
+
+- `options.transport` (string, optional): One of `websocket` (WebSocket only), `polling` (HTTP long-polling only), or `both` (poll first, then upgrade). When unset, the client keeps its default behavior.
+
+This option can also be controlled via the environment variable `WEBSSH2_OPTIONS_TRANSPORT`. A per-request [`transport` URL parameter](./URL-PARAMETERS.md#transport) overrides this server-wide setting.
+
 ### SSH Environment Variable Allowlist
 
 Control which environment variable names are forwarded to the SSH session. If unset or empty, WebSSH2 applies format/value filtering but does not restrict by name beyond that.

--- a/DOCS/configuration/CONFIG-JSON.md
+++ b/DOCS/configuration/CONFIG-JSON.md
@@ -257,14 +257,6 @@ You can choose whether credential replay sends a carriage return (CR) or carriag
 
 This option can also be controlled via the environment variable `WEBSSH2_OPTIONS_REPLAY_CRLF`.
 
-### Socket.IO Transport
-
-You can force the Socket.IO transport used between the browser and the server. This is useful when WebSocket upgrades are known to fail behind a restrictive proxy or load balancer and you want to fall back to HTTP long-polling.
-
-- `options.transport` (string, optional): One of `websocket` (WebSocket only), `polling` (HTTP long-polling only), or `both` (poll first, then upgrade). When unset, the client keeps its default behavior.
-
-This option can also be controlled via the environment variable `WEBSSH2_OPTIONS_TRANSPORT`. A per-request [`transport` URL parameter](./URL-PARAMETERS.md#transport) overrides this server-wide setting.
-
 ### SSH Environment Variable Allowlist
 
 Control which environment variable names are forwarded to the SSH session. If unset or empty, WebSSH2 applies format/value filtering but does not restrict by name beyond that.

--- a/DOCS/configuration/ENVIRONMENT-VARIABLES.md
+++ b/DOCS/configuration/ENVIRONMENT-VARIABLES.md
@@ -581,6 +581,7 @@ docker run --name webssh2 --rm -it \
 | `WEBSSH2_OPTIONS_ALLOW_RECONNECT` | boolean | `true` | Allow reconnection |
 | `WEBSSH2_OPTIONS_ALLOW_REPLAY` | boolean | `true` | Allow session replay |
 | `WEBSSH2_OPTIONS_REPLAY_CRLF` | boolean | `false` | Send CRLF for credential replay (default is CR) |
+| `WEBSSH2_OPTIONS_TRANSPORT` | string | - | Force the Socket.IO transport: `websocket`, `polling`, or `both`. Use `polling` when WebSocket upgrades fail behind restrictive proxies. A `transport` URL parameter overrides this. |
 
 ### Terminal Theming (`options.theming`)
 

--- a/DOCS/configuration/ENVIRONMENT-VARIABLES.md
+++ b/DOCS/configuration/ENVIRONMENT-VARIABLES.md
@@ -581,7 +581,6 @@ docker run --name webssh2 --rm -it \
 | `WEBSSH2_OPTIONS_ALLOW_RECONNECT` | boolean | `true` | Allow reconnection |
 | `WEBSSH2_OPTIONS_ALLOW_REPLAY` | boolean | `true` | Allow session replay |
 | `WEBSSH2_OPTIONS_REPLAY_CRLF` | boolean | `false` | Send CRLF for credential replay (default is CR) |
-| `WEBSSH2_OPTIONS_TRANSPORT` | string | - | Force the Socket.IO transport: `websocket`, `polling`, or `both`. Use `polling` when WebSocket upgrades fail behind restrictive proxies. A `transport` URL parameter overrides this. |
 
 ### Terminal Theming (`options.theming`)
 

--- a/DOCS/configuration/URL-PARAMETERS.md
+++ b/DOCS/configuration/URL-PARAMETERS.md
@@ -124,6 +124,42 @@ These parameters were non-functional in shipped releases prior to
 so this change has no behavior impact on production deployments
 that already relied on what was rendered.
 
+### Transport
+
+Forces the Socket.IO transport used between the browser and the server. Useful
+when you already know that WebSocket upgrades will fail (for example behind a
+restrictive corporate proxy or a load balancer that does not support WebSocket)
+and you want to fall back to HTTP long-polling without waiting for a failed
+upgrade attempt.
+
+| Value | Behavior |
+|-------|----------|
+| `websocket` | WebSocket only, no polling fallback |
+| `polling` | HTTP long-polling only, no upgrade attempt |
+| `both` | Start with polling, then upgrade to WebSocket (Socket.IO default) |
+
+```
+?transport=polling
+?transport=websocket
+?transport=both
+```
+
+The value is case-insensitive. Any missing or unrecognized value falls back to
+the server-wide `options.transport` config setting (or the
+`WEBSSH2_OPTIONS_TRANSPORT` environment variable); if that is also unset, the
+client keeps its default transport behavior. When resolved, the value is
+injected into the client `socket.transports` option (passed through to
+Socket.IO's `io()` call). The URL parameter, when valid, always takes
+precedence over the server-wide setting.
+
+To force a transport for every connection (instead of per-request), set the
+`WEBSSH2_OPTIONS_TRANSPORT` environment variable or `options.transport` in the
+config file to `websocket`, `polling`, or `both`.
+
+**Note:** `websocket` disables the polling fallback entirely, so the connection
+will fail if WebSocket is blocked. Use `polling` when you need a guaranteed
+working transport on restrictive networks.
+
 ### Environment Variables
 
 Pass environment variables to the SSH session:

--- a/DOCS/configuration/URL-PARAMETERS.md
+++ b/DOCS/configuration/URL-PARAMETERS.md
@@ -124,42 +124,6 @@ These parameters were non-functional in shipped releases prior to
 so this change has no behavior impact on production deployments
 that already relied on what was rendered.
 
-### Transport
-
-Forces the Socket.IO transport used between the browser and the server. Useful
-when you already know that WebSocket upgrades will fail (for example behind a
-restrictive corporate proxy or a load balancer that does not support WebSocket)
-and you want to fall back to HTTP long-polling without waiting for a failed
-upgrade attempt.
-
-| Value | Behavior |
-|-------|----------|
-| `websocket` | WebSocket only, no polling fallback |
-| `polling` | HTTP long-polling only, no upgrade attempt |
-| `both` | Start with polling, then upgrade to WebSocket (Socket.IO default) |
-
-```
-?transport=polling
-?transport=websocket
-?transport=both
-```
-
-The value is case-insensitive. Any missing or unrecognized value falls back to
-the server-wide `options.transport` config setting (or the
-`WEBSSH2_OPTIONS_TRANSPORT` environment variable); if that is also unset, the
-client keeps its default transport behavior. When resolved, the value is
-injected into the client `socket.transports` option (passed through to
-Socket.IO's `io()` call). The URL parameter, when valid, always takes
-precedence over the server-wide setting.
-
-To force a transport for every connection (instead of per-request), set the
-`WEBSSH2_OPTIONS_TRANSPORT` environment variable or `options.transport` in the
-config file to `websocket`, `polling`, or `both`.
-
-**Note:** `websocket` disables the polling fallback entirely, so the connection
-will fail if WebSocket is blocked. Use `polling` when you need a guaranteed
-working transport on restrictive networks.
-
 ### Environment Variables
 
 Pass environment variables to the SSH session:

--- a/app/app.ts
+++ b/app/app.ts
@@ -1,4 +1,6 @@
 import express, { type Application, type RequestHandler } from 'express'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import type { Server as HttpServer } from 'node:http'
 import type { Server as IOServer } from 'socket.io'
 import { getConfig } from './config.js'
@@ -28,6 +30,19 @@ import { cacheControlForAsset } from './utils/static-cache.js'
 
 const debug = createNamespacedDebug('app')
 
+// The shipped client bundle hardcodes its Socket.IO transports as
+// ["websocket","polling"] and ignores the list the server injects into
+// window.webssh2Config. We rewrite that array as the bundle is served so
+// WEBSSH2_OPTIONS_TRANSPORT / ?transport= take effect, and so a failed
+// WebSocket upgrade falls back to long-polling instead of erroring.
+const CLIENT_BUNDLE_FILENAME = 'webssh2.bundle.js'
+const HARDCODED_TRANSPORTS = /transports:\s*\[\s*"websocket"\s*,\s*"polling"\s*\]/
+const TRANSPORTS_REPLACEMENT =
+  'transports:(window.webssh2Config&&window.webssh2Config.socket&&' +
+  'Array.isArray(window.webssh2Config.socket.transports)&&' +
+  'window.webssh2Config.socket.transports.length>0?' +
+  'window.webssh2Config.socket.transports:["polling","websocket"])'
+
 // Shared options for both static asset mounts. setHeaders runs after
 // serve-static writes its default Cache-Control, so the explicit setHeader
 // below wins; do not also pass maxAge/immutable here (one mechanism only).
@@ -51,11 +66,26 @@ export function createAppAsync(appConfig: Config): {
       sessionMiddleware: RequestHandler
     }
     const sshRoutes = createRoutes(appConfig)
+    // Read and patch the client bundle once at startup (it is stable-named and
+    // only changes on a dependency upgrade, which restarts the server). The
+    // .replace is a no-op if a future client version already reads the config.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- trusted install dir + constant filename
+    const patchedBundle = readFileSync(path.join(clientPath, CLIENT_BUNDLE_FILENAME), 'utf8')
+      .replace(HARDCODED_TRANSPORTS, TRANSPORTS_REPLACEMENT)
+    // Serve the patched bundle ahead of the static handler. res.send adds an
+    // ETag and answers conditional requests with 304 for us.
+    const serveBundle: RequestHandler = (_req, res): void => {
+      res.type('application/javascript')
+      res.setHeader('Cache-Control', cacheControlForAsset(CLIENT_BUNDLE_FILENAME))
+      res.send(patchedBundle)
+    }
+    app.get(`/ssh/assets/${CLIENT_BUNDLE_FILENAME}`, serveBundle)
     app.use('/ssh/assets', express.static(clientPath, STATIC_OPTIONS))
     app.use('/ssh', sshRoutes)
 
     if (appConfig.telnet?.enabled === true) {
       const telnetRoutes = createTelnetRoutes(appConfig)
+      app.get(`/telnet/assets/${CLIENT_BUNDLE_FILENAME}`, serveBundle)
       app.use('/telnet/assets', express.static(clientPath, STATIC_OPTIONS))
       app.use('/telnet', telnetRoutes)
     }

--- a/app/config/env-mapper.ts
+++ b/app/config/env-mapper.ts
@@ -76,7 +76,6 @@ export const ENV_VAR_MAPPING: Record<string, EnvVarMap> = {
   WEBSSH2_OPTIONS_ALLOW_RECONNECT: { path: 'options.allowReconnect', type: 'boolean' },
   WEBSSH2_OPTIONS_ALLOW_REPLAY: { path: 'options.allowReplay', type: 'boolean' },
   WEBSSH2_OPTIONS_REPLAY_CRLF: { path: 'options.replayCRLF', type: 'boolean' },
-  WEBSSH2_OPTIONS_TRANSPORT: { path: 'options.transport', type: 'string' },
   WEBSSH2_SESSION_SECRET: { path: 'session.secret', type: 'string' },
   WEBSSH2_SESSION_NAME: { path: 'session.name', type: 'string' },
   WEBSSH2_SSO_ENABLED: { path: 'sso.enabled', type: 'boolean' },

--- a/app/config/env-mapper.ts
+++ b/app/config/env-mapper.ts
@@ -76,6 +76,7 @@ export const ENV_VAR_MAPPING: Record<string, EnvVarMap> = {
   WEBSSH2_OPTIONS_ALLOW_RECONNECT: { path: 'options.allowReconnect', type: 'boolean' },
   WEBSSH2_OPTIONS_ALLOW_REPLAY: { path: 'options.allowReplay', type: 'boolean' },
   WEBSSH2_OPTIONS_REPLAY_CRLF: { path: 'options.replayCRLF', type: 'boolean' },
+  WEBSSH2_OPTIONS_TRANSPORT: { path: 'options.transport', type: 'string' },
   WEBSSH2_SESSION_SECRET: { path: 'session.secret', type: 'string' },
   WEBSSH2_SESSION_NAME: { path: 'session.name', type: 'string' },
   WEBSSH2_SSO_ENABLED: { path: 'sso.enabled', type: 'boolean' },

--- a/app/connectionHandler.ts
+++ b/app/connectionHandler.ts
@@ -50,11 +50,72 @@ function hasSessionCredentials(session: Sess): boolean {
   )
 }
 
+/**
+ * Map a transport selector to a Socket.IO client `transports` list. Lets a
+ * deployment force HTTP long-polling when WebSocket upgrades are known to fail
+ * (restrictive proxies, some corporate networks).
+ *
+ * Accepted values (case-insensitive):
+ *   - `websocket` -> `['websocket']`  (WebSocket only, no polling fallback)
+ *   - `polling`   -> `['polling']`    (HTTP long-polling only, no upgrade)
+ *   - `both`      -> `['polling', 'websocket']` (poll first, then upgrade)
+ *
+ * Returns `undefined` for any non-string or unrecognized value.
+ */
+function mapTransportValue(value: unknown): string[] | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  switch (value.toLowerCase()) {
+    case 'websocket':
+      return ['websocket']
+    case 'polling':
+      return ['polling']
+    case 'both':
+      return ['polling', 'websocket']
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Resolve the Socket.IO client `transports` list. The `transport` URL query
+ * parameter takes precedence (per-request override); otherwise the server-wide
+ * `options.transport` config value (settable via `WEBSSH2_OPTIONS_TRANSPORT`)
+ * is used. Returns `undefined` when neither yields a recognized value so the
+ * client keeps its own default transport behavior.
+ */
+function resolveTransports(
+  query: unknown,
+  configTransport: unknown,
+): { transports: string[]; source: 'URL parameter' | 'server config' } | undefined {
+  const raw = (query as Record<string, unknown> | undefined)?.['transport']
+  const fromQuery = mapTransportValue(Array.isArray(raw) ? raw[0] : raw)
+  if (fromQuery !== undefined) {
+    return { transports: fromQuery, source: 'URL parameter' }
+  }
+  const fromConfig = mapTransportValue(configTransport)
+  if (fromConfig !== undefined) {
+    return { transports: fromConfig, source: 'server config' }
+  }
+  return undefined
+}
+
 function buildSocketConfig(
   req: Request,
   isTelnet: boolean,
+  cfg?: Config,
 ): Record<string, unknown> {
   const socketPath = isTelnet ? TELNET_DEFAULTS.IO_PATH : DEFAULTS.IO_PATH
+  const socket: Record<string, unknown> = {
+    url: `${req.protocol}://${req.get('host')}`,
+    path: socketPath,
+  }
+  const resolved = resolveTransports(req.query, cfg?.options.transport)
+  if (resolved !== undefined) {
+    socket['transports'] = resolved.transports
+    debug(`Socket transports forced via ${resolved.source}:`, resolved.transports)
+  }
   const result: Record<string, unknown> = {
     socket: {
       url: `${req.protocol}://${req.get('host')}`,
@@ -234,7 +295,7 @@ export function buildTempConfig(
   opts?: ConnectionOptions,
 ): Partial<Config> {
   const isTelnet = opts?.protocol === 'telnet'
-  const tempConfig: Record<string, unknown> = buildSocketConfig(req as Request, isTelnet)
+  const tempConfig: Record<string, unknown> = buildSocketConfig(req as Request, isTelnet, cfg)
   Object.assign(tempConfig, buildConnectionMode(opts))
   Object.assign(tempConfig, buildSshCredentials(req.session, req))
   Object.assign(tempConfig, buildHeaderConfig(cfg, req.session))

--- a/app/connectionHandler.ts
+++ b/app/connectionHandler.ts
@@ -50,16 +50,74 @@ function hasSessionCredentials(session: Sess): boolean {
   )
 }
 
+/**
+ * Map a transport selector to a Socket.IO client `transports` list. Lets a
+ * deployment force HTTP long-polling when WebSocket upgrades are known to fail
+ * (restrictive proxies, some corporate networks).
+ *
+ * Accepted values (case-insensitive):
+ *   - `websocket` -> `['websocket']`  (WebSocket only, no polling fallback)
+ *   - `polling`   -> `['polling']`    (HTTP long-polling only, no upgrade)
+ *   - `both`      -> `['polling', 'websocket']` (poll first, then upgrade)
+ *
+ * Returns `undefined` for any non-string or unrecognized value.
+ */
+function mapTransportValue(value: unknown): string[] | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  switch (value.toLowerCase()) {
+    case 'websocket':
+      return ['websocket']
+    case 'polling':
+      return ['polling']
+    case 'both':
+      return ['polling', 'websocket']
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Resolve the Socket.IO client `transports` list. The `transport` URL query
+ * parameter takes precedence (per-request override); otherwise the server-wide
+ * `options.transport` config value (settable via `WEBSSH2_OPTIONS_TRANSPORT`)
+ * is used. Returns `undefined` when neither yields a recognized value so the
+ * client keeps its own default transport behavior.
+ */
+function resolveTransports(
+  query: unknown,
+  configTransport: unknown,
+): { transports: string[]; source: 'URL parameter' | 'server config' } | undefined {
+  const raw = (query as Record<string, unknown> | undefined)?.['transport']
+  const fromQuery = mapTransportValue(Array.isArray(raw) ? raw[0] : raw)
+  if (fromQuery !== undefined) {
+    return { transports: fromQuery, source: 'URL parameter' }
+  }
+  const fromConfig = mapTransportValue(configTransport)
+  if (fromConfig !== undefined) {
+    return { transports: fromConfig, source: 'server config' }
+  }
+  return undefined
+}
+
 function buildSocketConfig(
   req: Request,
   isTelnet: boolean,
+  cfg?: Config,
 ): Record<string, unknown> {
   const socketPath = isTelnet ? TELNET_DEFAULTS.IO_PATH : DEFAULTS.IO_PATH
+  const socket: Record<string, unknown> = {
+    url: `${req.protocol}://${req.get('host')}`,
+    path: socketPath,
+  }
+  const resolved = resolveTransports(req.query, cfg?.options.transport)
+  if (resolved !== undefined) {
+    socket['transports'] = resolved.transports
+    debug(`Socket transports forced via ${resolved.source}:`, resolved.transports)
+  }
   const result: Record<string, unknown> = {
-    socket: {
-      url: `${req.protocol}://${req.get('host')}`,
-      path: socketPath,
-    },
+    socket,
     autoConnect: req.path.startsWith('/host/'),
   }
   if (isTelnet) {
@@ -234,7 +292,7 @@ export function buildTempConfig(
   opts?: ConnectionOptions,
 ): Partial<Config> {
   const isTelnet = opts?.protocol === 'telnet'
-  const tempConfig: Record<string, unknown> = buildSocketConfig(req as Request, isTelnet)
+  const tempConfig: Record<string, unknown> = buildSocketConfig(req as Request, isTelnet, cfg)
   Object.assign(tempConfig, buildConnectionMode(opts))
   Object.assign(tempConfig, buildSshCredentials(req.session, req))
   Object.assign(tempConfig, buildHeaderConfig(cfg, req.session))

--- a/app/connectionHandler.ts
+++ b/app/connectionHandler.ts
@@ -50,72 +50,11 @@ function hasSessionCredentials(session: Sess): boolean {
   )
 }
 
-/**
- * Map a transport selector to a Socket.IO client `transports` list. Lets a
- * deployment force HTTP long-polling when WebSocket upgrades are known to fail
- * (restrictive proxies, some corporate networks).
- *
- * Accepted values (case-insensitive):
- *   - `websocket` -> `['websocket']`  (WebSocket only, no polling fallback)
- *   - `polling`   -> `['polling']`    (HTTP long-polling only, no upgrade)
- *   - `both`      -> `['polling', 'websocket']` (poll first, then upgrade)
- *
- * Returns `undefined` for any non-string or unrecognized value.
- */
-function mapTransportValue(value: unknown): string[] | undefined {
-  if (typeof value !== 'string') {
-    return undefined
-  }
-  switch (value.toLowerCase()) {
-    case 'websocket':
-      return ['websocket']
-    case 'polling':
-      return ['polling']
-    case 'both':
-      return ['polling', 'websocket']
-    default:
-      return undefined
-  }
-}
-
-/**
- * Resolve the Socket.IO client `transports` list. The `transport` URL query
- * parameter takes precedence (per-request override); otherwise the server-wide
- * `options.transport` config value (settable via `WEBSSH2_OPTIONS_TRANSPORT`)
- * is used. Returns `undefined` when neither yields a recognized value so the
- * client keeps its own default transport behavior.
- */
-function resolveTransports(
-  query: unknown,
-  configTransport: unknown,
-): { transports: string[]; source: 'URL parameter' | 'server config' } | undefined {
-  const raw = (query as Record<string, unknown> | undefined)?.['transport']
-  const fromQuery = mapTransportValue(Array.isArray(raw) ? raw[0] : raw)
-  if (fromQuery !== undefined) {
-    return { transports: fromQuery, source: 'URL parameter' }
-  }
-  const fromConfig = mapTransportValue(configTransport)
-  if (fromConfig !== undefined) {
-    return { transports: fromConfig, source: 'server config' }
-  }
-  return undefined
-}
-
 function buildSocketConfig(
   req: Request,
   isTelnet: boolean,
-  cfg?: Config,
 ): Record<string, unknown> {
   const socketPath = isTelnet ? TELNET_DEFAULTS.IO_PATH : DEFAULTS.IO_PATH
-  const socket: Record<string, unknown> = {
-    url: `${req.protocol}://${req.get('host')}`,
-    path: socketPath,
-  }
-  const resolved = resolveTransports(req.query, cfg?.options.transport)
-  if (resolved !== undefined) {
-    socket['transports'] = resolved.transports
-    debug(`Socket transports forced via ${resolved.source}:`, resolved.transports)
-  }
   const result: Record<string, unknown> = {
     socket: {
       url: `${req.protocol}://${req.get('host')}`,
@@ -295,7 +234,7 @@ export function buildTempConfig(
   opts?: ConnectionOptions,
 ): Partial<Config> {
   const isTelnet = opts?.protocol === 'telnet'
-  const tempConfig: Record<string, unknown> = buildSocketConfig(req as Request, isTelnet, cfg)
+  const tempConfig: Record<string, unknown> = buildSocketConfig(req as Request, isTelnet)
   Object.assign(tempConfig, buildConnectionMode(opts))
   Object.assign(tempConfig, buildSshCredentials(req.session, req))
   Object.assign(tempConfig, buildHeaderConfig(cfg, req.session))

--- a/app/schemas/config-schema.ts
+++ b/app/schemas/config-schema.ts
@@ -197,7 +197,6 @@ const OptionsSchema = z.object({
   allowReconnect: z.boolean(),
   allowReplay: z.boolean(),
   replayCRLF: z.boolean().optional(),
-  transport: z.enum(['websocket', 'polling', 'both']).optional(),
   theming: ThemingSchema
 })
 

--- a/app/schemas/config-schema.ts
+++ b/app/schemas/config-schema.ts
@@ -197,6 +197,7 @@ const OptionsSchema = z.object({
   allowReconnect: z.boolean(),
   allowReplay: z.boolean(),
   replayCRLF: z.boolean().optional(),
+  transport: z.enum(['websocket', 'polling', 'both']).optional(),
   theming: ThemingSchema
 })
 

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -171,11 +171,6 @@ export interface OptionsConfig {
   allowReconnect: boolean
   allowReplay: boolean
   replayCRLF?: boolean
-  /**
-   * Force the Socket.IO client transport. Useful when WebSocket upgrades fail
-   * behind restrictive proxies. A `transport` URL parameter overrides this.
-   */
-  transport?: 'websocket' | 'polling' | 'both'
   theming?: ThemingConfig
 }
 

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -171,6 +171,11 @@ export interface OptionsConfig {
   allowReconnect: boolean
   allowReplay: boolean
   replayCRLF?: boolean
+  /**
+   * Force the Socket.IO client transport. Useful when WebSocket upgrades fail
+   * behind restrictive proxies. A `transport` URL parameter overrides this.
+   */
+  transport?: 'websocket' | 'polling' | 'both'
   theming?: ThemingConfig
 }
 

--- a/tests/unit/connection-handler/transport-selection.vitest.ts
+++ b/tests/unit/connection-handler/transport-selection.vitest.ts
@@ -1,0 +1,79 @@
+// tests/unit/connection-handler/transport-selection.vitest.ts
+import { describe, it, expect } from 'vitest'
+import type { Request } from 'express'
+import { buildTempConfig } from '../../../app/connectionHandler.js'
+import { createDefaultConfig } from '../../../app/config/config-processor.js'
+import type { Config } from '../../../app/types/config.js'
+import { TEST_SSH } from '../../test-constants.js'
+
+type TestReq = Request & { sessionID?: string }
+
+function makeReq(query: Record<string, unknown> = {}): TestReq {
+  return {
+    path: '/ssh/host/',
+    protocol: 'https',
+    get: ((key: string) => (key === 'host' ? TEST_SSH.HOST : undefined)) as unknown as Request['get'],
+    query,
+    sessionID: 'test-session-id'
+  } as TestReq
+}
+
+const defaultConfig = createDefaultConfig()
+
+function cfgWithTransport(transport: Config['options']['transport']): Config {
+  return {
+    ...defaultConfig,
+    options: { ...defaultConfig.options, transport }
+  }
+}
+
+function socketOf(result: Partial<Config>): Record<string, unknown> {
+  return result['socket'] as Record<string, unknown>
+}
+
+describe('buildTempConfig - socket.transports', () => {
+  it('omits transports when neither URL parameter nor config is set', () => {
+    const result = buildTempConfig(makeReq(), defaultConfig)
+    expect(socketOf(result)['transports']).toBeUndefined()
+  })
+
+  it('maps the server-wide options.transport config to a transports list', () => {
+    const result = buildTempConfig(makeReq(), cfgWithTransport('polling'))
+    expect(socketOf(result)['transports']).toEqual(['polling'])
+  })
+
+  it('maps "both" to poll-first-then-upgrade order', () => {
+    const result = buildTempConfig(makeReq(), cfgWithTransport('both'))
+    expect(socketOf(result)['transports']).toEqual(['polling', 'websocket'])
+  })
+
+  it('maps "websocket" to websocket only', () => {
+    const result = buildTempConfig(makeReq(), cfgWithTransport('websocket'))
+    expect(socketOf(result)['transports']).toEqual(['websocket'])
+  })
+
+  it('lets the ?transport= URL parameter override the server config', () => {
+    const result = buildTempConfig(makeReq({ transport: 'websocket' }), cfgWithTransport('polling'))
+    expect(socketOf(result)['transports']).toEqual(['websocket'])
+  })
+
+  it('accepts the URL parameter case-insensitively', () => {
+    const result = buildTempConfig(makeReq({ transport: 'POLLING' }), defaultConfig)
+    expect(socketOf(result)['transports']).toEqual(['polling'])
+  })
+
+  it('uses the first value when the URL parameter is repeated', () => {
+    const result = buildTempConfig(makeReq({ transport: ['polling', 'websocket'] }), defaultConfig)
+    expect(socketOf(result)['transports']).toEqual(['polling'])
+  })
+
+  it('falls back to the server config when the URL parameter is unrecognized', () => {
+    const result = buildTempConfig(makeReq({ transport: 'nonsense' }), cfgWithTransport('polling'))
+    expect(socketOf(result)['transports']).toEqual(['polling'])
+  })
+
+  it('omits transports when the URL parameter is unrecognized and no config is set', () => {
+    const result = buildTempConfig(makeReq({ transport: 'nonsense' }), defaultConfig)
+    expect(socketOf(result)['transports']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
- **feat(socket): force transport via WEBSSH2_OPTIONS_TRANSPORT env var**
- **Revert "feat(socket): force transport via WEBSSH2_OPTIONS_TRANSPORT env var"**
- **fix(socket): make client honor forced transport and fall back to polling**
- **feat(socket): wire options.transport / WEBSSH2_OPTIONS_TRANSPORT / ?transport=**
- **test(socket): cover transport resolution and URL-parameter precedence**
- **docs(config): document options.transport, WEBSSH2_OPTIONS_TRANSPORT, ?transport=**

## Summary

- Entirely vibe coded because I don't do JS but I couldn't make webssh2 work on my new corporate network that seems to block websocket. I couldn't find a way in the docs to specify to use longpolling when websocket fails so I asked claude and ended up with something like this. Well a bit different because it was on my own fork but I cherry picked it on top of main. So I can't properly retest it because I can't easily add my own changes etc but thought you might be interested in this. Let me know if that's not appreciated or if I can do anything to help.
Thanks a lot for making webssh2 and have a nice day :) 

## Checklist

- [X] Unit tests updated/added
- [ ] Ran local smoke tests (HTTP routes, Socket.IO exec/resize)
- [ ] No public route changes (paths, query params)
- [X] No Socket.IO event name/payload changes
- [X] `npm run typecheck` (if configured) passes
- [X] `npm test`/`vitest` passes
- [X] Updated docs (TS-MIGRATTE.md or relevant DOCS/* if needed)
