### PR TITLE
feat(security): JSON config-block injection + tightened CSP (#546)

### DIFF
--- a/DOCS/architecture/CLIENT.md
+++ b/DOCS/architecture/CLIENT.md
@@ -32,30 +32,43 @@ The client module provides:
 The server integrates with the client module by:
 
 1. **Serving static files** from `/client/public`
-2. **Injecting configuration** into the client via `window.webssh2Config`
+2. **Injecting configuration** via an inert JSON `<script type="application/json">` block (with legacy `window.webssh2Config` fallback)
 3. **Managing WebSocket connections** for terminal I/O
 4. **Handling authentication** and session management
 
 ### Configuration Injection
 
-The server passes configuration to the client through a global object:
+The server passes runtime configuration to the client by injecting an inert JSON
+data block into the served HTML page. This is the **primary mechanism** and is
+fully CSP-compatible — it survives a strict `script-src 'self'` policy because
+the element is not an executable script:
 
-```javascript
-window.webssh2Config = {
-  socket: {
-    path: '/ssh/socket.io'
-  },
-  ssh: {
-    host: 'example.com',
-    port: 22,
-    username: 'user'
-  },
-  header: {
-    text: 'WebSSH2',
-    background: 'green'
-  }
+```html
+<script type="application/json" id="webssh2-config">
+{
+  "socket": { "path": "/ssh/socket.io" },
+  "ssh": { "host": "example.com", "port": 22, "username": "user" },
+  "header": { "text": "WebSSH2", "background": "green" }
 }
+</script>
 ```
+
+The client reads this block at startup via `readInjectedConfig()` by looking up
+`document.getElementById('webssh2-config')` and parsing its text content.
+
+For backward compatibility, the gateway also injects the same configuration
+values into a conventional executable script block immediately after:
+
+```html
+<script>window.webssh2Config = { /* same config */ };</script>
+```
+
+> **Deprecated:** The `window.webssh2Config` inline-script method is deprecated
+> and will be removed in a future major release. Integrators who currently set
+> `window.webssh2Config` from their own inline scripts should migrate to reading
+> the JSON data block (`<script type="application/json" id="webssh2-config">`).
+> See [billchurch/webssh2_client#125](https://github.com/billchurch/webssh2_client/issues/125)
+> for migration details.
 
 ### WebSocket Protocol
 

--- a/DOCS/configuration/CONFIG-JSON.md
+++ b/DOCS/configuration/CONFIG-JSON.md
@@ -108,13 +108,13 @@ Renamed and expanded options:
 
 ### 2a. Security Headers (New Default)
 
-- The server now applies a secure set of HTTP response headers by default via `app/security-headers.js`.
-- A Content Security Policy (CSP) is included and tuned for xterm.js and terminal styling. It purposely allows `'unsafe-inline'` for scripts/styles required by the client-side terminal rendering.
-- These headers are applied before session middleware in `app/middleware.js`.
+- The server now applies a secure set of HTTP response headers by default via `app/security-headers.ts`.
+- A Content Security Policy (CSP) is included and tightened for xterm.js. `script-src` no longer allows `'unsafe-inline'` (removed in Phase 2 via JSON config-block injection); `style-src` retains `'unsafe-inline'` for xterm.js inline styles.
+- These headers are applied before session middleware in `app/middleware.ts`.
 
 Notes:
 
-- There is no config.json or environment toggle for CSP or headers at this time. To customize, adjust `app/security-headers.js` (or add a route-specific CSP using `createCSPMiddleware`).
+- The CSP mode and key directives are controlled via the `csp` config block and `WEBSSH2_CSP_*` environment variables — see [Security Headers & CSP](#security-headers--csp-reference).
 - HSTS (`Strict-Transport-Security`) is set only when the request is HTTPS (`req.secure`).
 
 ### 3. Terminal Configuration
@@ -229,17 +229,94 @@ These settings are now managed client-side.
 
 ## Security Headers & CSP (Reference)
 
-The default CSP and headers are defined in `app/security-headers.ts`. Header names and common defaults are centralized in `app/constants.ts` (`HEADERS`, `DEFAULTS`).
+The security-headers middleware applies a set of standard headers on every response. Header names and common defaults are centralized in `app/constants.ts` (`HEADERS`, `DEFAULTS`).
 
-- `Content-Security-Policy`: restricts sources; allows WebSocket (`ws:`/`wss:`) connections and inline script/style needed by the terminal.
 - `X-Content-Type-Options`: `nosniff`
-- `X-Frame-Options`: `DENY`
 - `X-XSS-Protection`: `1; mode=block`
 - `Referrer-Policy`: `strict-origin-when-cross-origin`
 - `Permissions-Policy`: disables geolocation, microphone, camera
 - `Strict-Transport-Security`: 1 year (HTTPS requests only); max-age is `DEFAULTS.HSTS_MAX_AGE_SECONDS`.
+- `X-Frame-Options`: derived from `csp.frameAncestors` — see below.
+- `Content-Security-Policy` / `Content-Security-Policy-Report-Only`: controlled by the `csp` config block — see below.
 
-To customize globally, edit `CSP_CONFIG` or `SECURITY_HEADERS` in `app/security-headers.ts`. For per-route CSP, use `createCSPMiddleware(customCSP)` in your route setup.
+### Content Security Policy (CSP)
+
+The CSP is config-toggled and tightened. The `csp` block in `config.json` controls the mode, reporting endpoint, and the two operator-adjustable directive values:
+
+```json
+"csp": {
+  "mode": "report-only",
+  "reportUri": "/ssh/csp-report",
+  "connectSrc": [],
+  "frameAncestors": ["none"]
+}
+```
+
+#### `csp.mode`
+
+| Value | Behaviour |
+| --- | --- |
+| `off` | No CSP header is sent |
+| `report-only` | `Content-Security-Policy-Report-Only` header — browsers report violations but are **not** blocked. A `security_posture` warn is logged at startup |
+| `enforce` | `Content-Security-Policy` header — browsers block policy violations. A `security_posture` warn is logged when combined with wildcard `http.origins` |
+
+`report-only` is the default. It is the recommended starting posture: deploy, collect `csp_violation` events, verify the policy is clean, then switch to `enforce`.
+
+#### Tightened directive set
+
+The policy shipped in Phase 2 removes `'unsafe-inline'` from `script-src` (made possible by the JSON config-block injection, which eliminated the legacy inline script):
+
+- `script-src 'self'` — no inline scripts permitted
+- `style-src 'self' 'unsafe-inline'` — inline styles required by xterm.js
+- `object-src 'none'`
+- `base-uri 'none'`
+- `connect-src` — derived (see below)
+- `frame-ancestors` — derived from `csp.frameAncestors` (see below)
+- `report-uri` + `Reporting-Endpoints` / `report-to` — the value of `csp.reportUri`
+
+#### `csp.connectSrc` and `connect-src` derivation
+
+`connect-src` is built from three sources, merged at startup:
+
+1. `'self'` (always included)
+2. Entries from `http.origins` that are **not** wildcards — concrete origins such as `https://gw.example:8443` are safe CSP sources and are added automatically
+3. Entries from `csp.connectSrc` — the operator allowlist
+
+**Wildcard caveat**: The default `http.origins` value is `["*:*"]`. Wildcard patterns are not valid CSP source expressions and are silently dropped. With the default wildcard CORS setting, `connect-src` is therefore just `'self'`. For split client/gateway deployments where the browser connects to a different origin than the page origin, either add explicit socket gateway URLs to `csp.connectSrc` or replace `http.origins` with a concrete allowlist.
+
+```json
+{
+  "http": { "origins": ["https://gw.example:8443"] },
+  "csp": {
+    "mode": "enforce",
+    "connectSrc": ["wss://gw.example:8443"]
+  }
+}
+```
+
+#### `csp.frameAncestors` and `X-Frame-Options`
+
+`csp.frameAncestors` is an array of origins that may embed WebSSH2 in an `<iframe>`. It drives both the CSP `frame-ancestors` directive and the legacy `X-Frame-Options` header:
+
+| `frameAncestors` value | `frame-ancestors` directive | `X-Frame-Options` |
+| --- | --- | --- |
+| `["none"]` (default) | `frame-ancestors 'none'` | `DENY` |
+| `["self"]` | `frame-ancestors 'self'` | `SAMEORIGIN` |
+| explicit origin list | `frame-ancestors <origins>` | omitted (CSP alone) |
+
+#### CSP violation reporting
+
+`POST /ssh/csp-report` is an unauthenticated endpoint that receives browser violation reports. Key properties:
+
+- Per-IP rate-limited (default 60 reports/min) and body-capped at 8 KB
+- Logs a structured `csp_violation` event (see [logging.md](../logging.md))
+- Always returns `204 No Content`
+- The CSP header advertises the endpoint via `report-uri` and `report-to` / `Reporting-Endpoints`
+- Operators should also apply an upstream/reverse-proxy rate limit on `POST /ssh/csp-report`
+
+#### Legacy inline-script transition note
+
+During the deprecation window, the client HTML still contains a legacy `window.webssh2Config = null;` inline script. Under `enforce` mode this script is blocked harmlessly (the JSON config block supplies configuration instead), but it produces **one expected `csp_violation` report per page load**. This report is demoted to `debug` log level so operators do not mistake it for a regression. It will be removed in a future major release.
 
 ### Centralized Constants
 

--- a/DOCS/configuration/ENVIRONMENT-VARIABLES.md
+++ b/DOCS/configuration/ENVIRONMENT-VARIABLES.md
@@ -52,16 +52,34 @@ WEBSSH2_HTTP_ORIGINS="localhost:3000,*.example.com,api.test.com"
 WEBSSH2_HTTP_ORIGINS='["localhost:3000","*.example.com","api.test.com"]'
 ```
 
-### Security Headers & CSP
+### Content Security Policy
 
-The server applies security headers and a Content Security Policy (CSP) by default.
+| Variable | Type | Default | Description |
+| --- | --- | --- | --- |
+| `WEBSSH2_CSP_MODE` | string | `report-only` | CSP enforcement mode: `off` (no header), `report-only` (collect violations, enforce nothing), or `enforce` (block violations) |
+| `WEBSSH2_CSP_REPORT_URI` | string | `/ssh/csp-report` | URI advertised in the CSP `report-uri` / `report-to` directives where browsers POST violation reports |
+| `WEBSSH2_CSP_CONNECT_SRC` | array | `[]` | Extra origins added to `connect-src` (comma-separated). Use for explicit socket gateway URLs in split client/gateway deployments |
+| `WEBSSH2_CSP_FRAME_ANCESTORS` | array | `["none"]` | Origins that may embed WebSSH2 in an iframe (comma-separated). `none` → `DENY`, `self` → `SAMEORIGIN`, explicit origins → omits `X-Frame-Options` |
 
-- Configuration: Defined in code at `app/security-headers.js` and applied by `app/middleware.js`.
-- Environment variables: There are currently no `WEBSSH2_` environment variables to toggle or customize CSP/headers.
-- Customization options:
-  - Edit `CSP_CONFIG` and `SECURITY_HEADERS` in `app/security-headers.js` for global changes.
-  - Use `createCSPMiddleware(customCSP)` for route-specific CSP overrides.
-  - HSTS (`Strict-Transport-Security`) is only added on HTTPS requests.
+#### CSP Array Format Examples
+
+```bash
+# Extra WebSocket origins for split deployments
+WEBSSH2_CSP_CONNECT_SRC="wss://gw.example:8443,https://gw.example:8443"
+
+# Allow same-origin embedding only
+WEBSSH2_CSP_FRAME_ANCESTORS="self"
+
+# Allow specific origin to embed
+WEBSSH2_CSP_FRAME_ANCESTORS="https://dashboard.example.com"
+```
+
+#### CSP Mode Notes
+
+- `report-only` is the default and does **not** enforce the policy — browsers send reports but are not blocked. A `security_posture` warning is logged at startup when mode is not `enforce`.
+- `enforce` activates blocking. Combine with a concrete `http.origins` allowlist rather than the default wildcard `*:*`; a `security_posture` warning is logged when `enforce` is used with wildcard origins.
+- `off` suppresses the CSP header entirely (not recommended for production).
+- See [CONFIG-JSON.md](./CONFIG-JSON.md#content-security-policy-csp) for the full `csp` config block and rollout guidance.
 
 ### User Defaults
 

--- a/DOCS/configuration/OVERVIEW.md
+++ b/DOCS/configuration/OVERVIEW.md
@@ -290,6 +290,14 @@ Environment variables are strings. WebSSH2 automatically converts:
 - `'["a","b"]'` → array
 - `'{"a":"b"}'` → object
 
+## Runtime Config Injection (Client)
+
+Server-side configuration is also delivered to the browser at page-load time via
+an inert `<script type="application/json" id="webssh2-config">` block (CSP-safe).
+The legacy `window.webssh2Config` inline-script method is deprecated. See
+[Client Architecture — Configuration Injection](../architecture/CLIENT.md#configuration-injection)
+for the full contract.
+
 ## Related Documentation
 
 - [Security Policy — Default security posture](../../SECURITY.md#default-security-posture)

--- a/DOCS/logging.md
+++ b/DOCS/logging.md
@@ -88,6 +88,7 @@ The `connection_failure` event includes an `errorType` field with one of:
 | Event | Description |
 | --- | --- |
 | `policy_block` | Action denied by security policy |
+| `csp_violation` | Content-Security-Policy violation report received at `/ssh/csp-report` (report-only or enforce mode); rate-limited; the expected legacy-inline-script violation is demoted to debug during the deprecation window |
 | `error` | Unexpected system failure (include `error_code` and `reason`) |
 
 #### SFTP Events

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # (see .github/renovate.json). Docker resolves the pull via the digest;
 # the tag is documentation + Renovate metadata. The Sonar rule
 # docker:S8431 is suppressed for this file in sonar-project.properties.
-ARG BASE_IMAGE=node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f
+ARG BASE_IMAGE=node:22-alpine@sha256:e58326d0d441090181ac150dc2078d3e2cf6a0d42e809aebba3ef5880935ffdd
 
 # =============================================================================
 # Stage 1: Dependencies

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,6 +92,44 @@ Additional notes:
 - Full option reference:
   [Host Key Verification](DOCS/configuration/CONFIG-JSON.md#host-key-verification)
 
+### Content-Security-Policy is report-only by default
+
+| Config key | Default | Exposure |
+| --- | --- | --- |
+| `csp.mode` | `report-only` | The CSP header is sent as `Content-Security-Policy-Report-Only` — browsers report violations but do **not** enforce the policy. A `security_posture` warning is logged at startup when mode is not `enforce` |
+
+The CSP is configured through the `csp` block in `config.json` (or the `WEBSSH2_CSP_*` environment variables). Full reference: [CONFIG-JSON.md](DOCS/configuration/CONFIG-JSON.md#content-security-policy-csp) and [ENVIRONMENT-VARIABLES.md](DOCS/configuration/ENVIRONMENT-VARIABLES.md#content-security-policy).
+
+**The three modes:**
+
+- `off` — no CSP header is sent (not recommended)
+- `report-only` (default) — `Content-Security-Policy-Report-Only` header collects violations without blocking anything; safe for rollout
+- `enforce` — `Content-Security-Policy` header actively blocks violations
+
+**Recommended rollout:**
+
+1. Deploy with the default `report-only` mode
+2. Monitor the structured `csp_violation` log events at `/ssh/csp-report`
+3. Confirm only the expected legacy-inline-script violation appears (see below)
+4. Set `csp.mode` to `enforce` (or `WEBSSH2_CSP_MODE=enforce`)
+
+**`connect-src` derivation and the wildcard `http.origins` caveat:**
+
+The CSP `connect-src` directive is built from `'self'`, concrete entries in `http.origins`, and the `csp.connectSrc` allowlist. The default `http.origins` value is `["*:*"]` — wildcards are not valid CSP source expressions and are dropped. With the default configuration, `connect-src` is therefore `'self'` only. For split client/gateway deployments (browser origin differs from the gateway origin), either:
+
+- Set a concrete `http.origins` list: `["https://gw.example:8443"]`, or
+- Add explicit socket URLs via `csp.connectSrc`: `["wss://gw.example:8443"]`
+
+A `security_posture` warning is also logged when `enforce` mode is combined with wildcard `http.origins`.
+
+**Violation reporting endpoint:**
+
+`POST /ssh/csp-report` receives violation reports from browsers. It is intentionally unauthenticated so browsers can reach it without session cookies. The endpoint is per-IP rate-limited (default 60/min), body-capped at 8 KB, logs a structured `csp_violation` event, and always returns `204`. Operators should additionally rate-limit `POST /ssh/csp-report` at the reverse proxy or load balancer.
+
+**Expected legacy-inline-script violation:**
+
+During the current deprecation window, the client HTML contains a legacy `window.webssh2Config = null;` inline script. Under `enforce` mode this script is blocked harmlessly (the JSON config block supplies the configuration), but it generates **one `csp_violation` report per page load**. This report is demoted to `debug` log level — it is not a regression and does not indicate an attack. It will be removed in a future major release.
+
 ### No target-host restrictions by default
 
 | Config key | Default | Exposure |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -124,7 +124,7 @@ A `security_posture` warning is also logged when `enforce` mode is combined with
 
 **Violation reporting endpoint:**
 
-`POST /ssh/csp-report` receives violation reports from browsers. It is intentionally unauthenticated so browsers can reach it without session cookies. The endpoint is per-IP rate-limited (default 60/min), body-capped at 8 KB, logs a structured `csp_violation` event, and always returns `204`. Operators should additionally rate-limit `POST /ssh/csp-report` at the reverse proxy or load balancer.
+`POST /ssh/csp-report` receives violation reports from browsers. It is intentionally unauthenticated so browsers can reach it without session cookies. The endpoint is per-IP intake rate-limited (default burst 10, steady-state ~10 requests/minute, throttled before the body is parsed), body-capped at 8 KB, and always returns `204`. It logs a structured `csp_violation` event, which is itself additionally rate-limited to 60 events/minute by the default logging controls. Operators should additionally rate-limit `POST /ssh/csp-report` at the reverse proxy or load balancer.
 
 **Expected legacy-inline-script violation:**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -422,6 +422,56 @@ For reference, the following IOCs were published by Snyk:
 
 ---
 
-**Last updated:** 2026-06-10
+## esbuild RCE via Deno module (GHSA-gv7w-rqvm-qjhr)
 
-**Next review:** 2026-09-10
+As of 2026-06-16, we evaluated GHSA-gv7w-rqvm-qjhr, a remote code execution
+flaw in esbuild's Deno module (`lib/deno/mod.ts`) that downloads native
+binaries and writes them to disk with executable permissions without integrity
+verification when `NPM_CONFIG_REGISTRY` is attacker-controlled.
+
+### Exposure assessment
+
+| Aspect | Status |
+| --- | --- |
+| Affected versions | esbuild 0.17.0 - < 0.28.1 |
+| Severity | HIGH (CVSS 8.1) |
+| Our version | esbuild@0.28.1 (was 0.27.2) |
+| Dependency path | dev-only: `vitest` / `tsx` → `vite` → esbuild |
+| Status | **Patched** - pinned to 0.28.1 via `overrides` |
+
+### Exposure context
+
+- esbuild is a **dev-only** dependency. webssh2 builds with `tsc`, dev-runs
+  with `tsx`, and tests with Vitest; esbuild never ships in a production
+  artifact. There is no `vite.config` and no `import 'vite'` in source — Vite
+  is present only as Vitest's internal engine.
+- The vulnerable code is in esbuild's **Deno** module. webssh2 runs under
+  **Node.js** (its install path uses npm `optionalDependencies` with integrity
+  hashes), and there is no Deno usage anywhere in the repo, so the affected
+  code path was never reachable. We were therefore not exploitable even before
+  the patch.
+
+### Action taken
+
+- Added `overrides.esbuild: "^0.28.1"` (resolves esbuild 0.28.1, the fixed
+  release) and bumped the `vite` override 7.3.2 → 7.3.5,
+  `vitest` / `@vitest/coverage-v8` 4.1.4 → 4.1.9, and `tsx` → `^4.22.4`.
+- The same bump also resolves the related esbuild dev-server advisory
+  GHSA-g7r4-m6w7-qqqr.
+- After the dependency bump, `npm audit --audit-level=high` reports 0
+  vulnerabilities; the patch commit (`40b8a7c`) landed with its full test run
+  passing.
+- esbuild 0.28.1 was published 2026-06-11, within the 14-day quarantine window;
+  the quarantine exception for HIGH-severity advisories was applied.
+
+### Follow-up
+
+- [#550](https://github.com/billchurch/webssh2/issues/550) tracks the optional
+  cleanup of moving Vitest to Vite 8, which drops esbuild from the tree
+  entirely and lets the override be removed.
+
+---
+
+**Last updated:** 2026-06-16
+
+**Next review:** 2026-09-16

--- a/app/config/default-config.ts
+++ b/app/config/default-config.ts
@@ -163,6 +163,11 @@ export const DEFAULT_CONFIG_BASE: Omit<Config, 'session'> & { session: Omit<Conf
     minimumLevel: 'info',
     stdout: {
       enabled: true
+    },
+    controls: {
+      rateLimit: {
+        rules: [{ target: 'csp_violation', limit: 60, intervalMs: 60000 }]
+      }
     }
   },
   telnet: {

--- a/app/config/default-config.ts
+++ b/app/config/default-config.ts
@@ -152,6 +152,12 @@ export const DEFAULT_CONFIG_BASE: Omit<Config, 'session'> & { session: Omit<Conf
       session: DEFAULTS.SSO_HEADERS.SESSION,
     },
   },
+  csp: {
+    mode: 'report-only',
+    reportUri: '/ssh/csp-report',
+    connectSrc: [],
+    frameAncestors: ['none'],
+  },
   logging: {
     namespace: 'webssh2:app',
     minimumLevel: 'info',
@@ -244,6 +250,11 @@ export function createCompleteDefaultConfig(sessionSecret?: string): Config {
       ...DEFAULT_CONFIG_BASE.sso,
       trustedProxies: [...DEFAULT_CONFIG_BASE.sso.trustedProxies],
       headerMapping: { ...DEFAULT_CONFIG_BASE.sso.headerMapping },
+    },
+    csp: {
+      ...DEFAULT_CONFIG_BASE.csp,
+      connectSrc: [...DEFAULT_CONFIG_BASE.csp.connectSrc],
+      frameAncestors: [...DEFAULT_CONFIG_BASE.csp.frameAncestors],
     },
     ...(loggingConfig === undefined ? {} : { logging: loggingConfig }),
     ...(telnetConfig === undefined ? {} : { telnet: telnetConfig }),

--- a/app/config/env-mapper.ts
+++ b/app/config/env-mapper.ts
@@ -196,6 +196,11 @@ export const ENV_VAR_MAPPING: Record<string, EnvVarMap> = {
   // Terminal theming configuration
   WEBSSH2_THEMING_ENABLED: { path: 'options.theming.enabled', type: 'boolean' },
   WEBSSH2_THEMING_ALLOW_CUSTOM: { path: 'options.theming.allowCustom', type: 'boolean' },
+  // Content Security Policy configuration
+  WEBSSH2_CSP_MODE: { path: 'csp.mode', type: 'string' },
+  WEBSSH2_CSP_REPORT_URI: { path: 'csp.reportUri', type: 'string' },
+  WEBSSH2_CSP_CONNECT_SRC: { path: 'csp.connectSrc', type: 'array' },
+  WEBSSH2_CSP_FRAME_ANCESTORS: { path: 'csp.frameAncestors', type: 'array' },
 }
 
 /** Built-in theme names used to block collisions when loading additional themes */

--- a/app/constants/core.ts
+++ b/app/constants/core.ts
@@ -118,8 +118,8 @@ export const TELNET_DEFAULTS = {
   TERM: 'vt100',
   EXPECT_TIMEOUT_MS: 10_000,
   IO_PATH: '/telnet/socket.io',
-  LOGIN_PROMPT: 'login:\\s*$',
-  PASSWORD_PROMPT: '[Pp]assword:\\s*$',
+  LOGIN_PROMPT: String.raw`login:\s*$`,
+  PASSWORD_PROMPT: String.raw`[Pp]assword:\s*$`,
   FAILURE_PATTERN: 'Login incorrect|Access denied|Login failed',
 } as const
 

--- a/app/constants/core.ts
+++ b/app/constants/core.ts
@@ -102,6 +102,8 @@ export const TERMINAL_LIMITS = {
 
 export const HEADERS = {
   CONTENT_SECURITY_POLICY: 'Content-Security-Policy',
+  CONTENT_SECURITY_POLICY_REPORT_ONLY: 'Content-Security-Policy-Report-Only',
+  REPORTING_ENDPOINTS: 'Reporting-Endpoints',
   X_CONTENT_TYPE_OPTIONS: 'X-Content-Type-Options',
   X_FRAME_OPTIONS: 'X-Frame-Options',
   X_XSS_PROTECTION: 'X-XSS-Protection',

--- a/app/logger.ts
+++ b/app/logger.ts
@@ -14,6 +14,7 @@ import { createSyslogTransport } from './logging/syslog-transport.js'
 import type { LogContext } from './logging/log-context.js'
 import type { Config, LoggingConfig } from './types/config.js'
 import type { SecurityPostureWarning } from './security-posture.js'
+import type { ExtractedCspReport } from './security/csp-report.js'
 
 let defaultStructuredLogger = createStructuredLogger({
   namespace: 'webssh2:app',
@@ -99,6 +100,34 @@ export function logSecurityPostureWarning(warning: SecurityPostureWarning): void
 
   if (!result.ok) {
     console.warn('Failed to emit security posture warning log:', result.error)
+  }
+}
+
+export interface CspViolationMeta {
+  readonly clientIp?: string
+  readonly userAgent?: string
+  readonly isLegacy: boolean
+}
+
+export function logCspViolation(report: ExtractedCspReport, meta: CspViolationMeta): void {
+  const message = `CSP violation: ${report.directive ?? 'unknown'} blocked ${report.blockedUri ?? 'unknown'}`
+  const context: LogContext = {
+    subsystem: 'security',
+    ...(meta.clientIp === undefined ? {} : { clientIp: meta.clientIp }),
+    ...(meta.userAgent === undefined ? {} : { userAgent: meta.userAgent }),
+    ...(report.directive === undefined ? {} : { reason: report.directive })
+  }
+  const entry = {
+    event: 'csp_violation' as const,
+    message,
+    context,
+    data: { ...report } as Record<string, unknown>
+  }
+  const result = meta.isLegacy
+    ? defaultStructuredLogger.debug(entry)
+    : defaultStructuredLogger.warn(entry)
+  if (!result.ok) {
+    console.warn('Failed to emit csp_violation log:', result.error)
   }
 }
 

--- a/app/logging/event-catalog.ts
+++ b/app/logging/event-catalog.ts
@@ -13,6 +13,7 @@ export const LOG_EVENT_NAMES = [
   'pty_resize',
   'idle_timeout',
   'policy_block',
+  'csp_violation',
   'error',
   'credential_replay',
   // SFTP events

--- a/app/logging/formatter.ts
+++ b/app/logging/formatter.ts
@@ -47,7 +47,7 @@ const AUTH_METHODS = new Set([
   'gssapi'
 ])
 const PROTOCOLS = new Set(['ssh', 'sftp', 'scp'])
-const SUBSYSTEMS = new Set(['shell', 'sftp', 'scp', 'exec', 'prompt'])
+const SUBSYSTEMS = new Set(['shell', 'sftp', 'scp', 'exec', 'prompt', 'security'])
 const STATUSES = new Set(['success', 'failure'])
 const CONTEXT_FIELD_KEY_SET = new Set(Object.keys(CONTEXT_FIELD_MAP))
 const CONTEXT_VALIDATORS = createContextValidators()

--- a/app/logging/log-context.ts
+++ b/app/logging/log-context.ts
@@ -2,7 +2,7 @@
 // Context metadata accepted by structured logging events
 
 export type LogProtocol = 'ssh' | 'sftp' | 'scp'
-export type LogSubsystem = 'shell' | 'sftp' | 'scp' | 'exec' | 'prompt'
+export type LogSubsystem = 'shell' | 'sftp' | 'scp' | 'exec' | 'prompt' | 'security'
 export type LogStatus = 'success' | 'failure'
 export type LogAuthMethod =
   | 'publickey'

--- a/app/routes/handlers/csp-report-handler.ts
+++ b/app/routes/handlers/csp-report-handler.ts
@@ -1,0 +1,108 @@
+// app/routes/handlers/csp-report-handler.ts
+// Hardened unauthenticated endpoint for receiving CSP violation reports.
+// Security properties:
+//   - Rate-limits per IP BEFORE body parsing (DoW1)
+//   - Caps body at 8 kb (A1)
+//   - Delegates to extractCspReport for whitelist/sanitise (S6)
+//   - Always returns 204 + Cache-Control: no-store (P2)
+//   - Never leaks server info in the response (A3)
+//
+// Global-parser residual (A3/DoW1): the app-level json() parser (~100 kb, no
+// per-route limit) parses `application/json` bodies BEFORE this route's throttle
+// runs, so an attacker sending `Content-Type: application/json` bypasses this
+// route's 8 kb cap and per-IP throttle. This is a pre-existing property of the
+// global parser shared by ALL /ssh POST routes (e.g. the auth POST), not unique
+// to csp-report, so it is NOT refactored here. Real browsers send
+// `application/csp-report` or `application/reports+json`, which the global parser
+// ignores — those bodies ARE throttled-before-parse and capped at 8 kb. Operators
+// should additionally enforce an upstream/reverse-proxy body-size + rate limit in
+// front of /ssh to defend against the application/json path.
+
+import bodyParser from 'body-parser'
+import type { Router, Request, Response, NextFunction } from 'express'
+import { extractCspReport, type ExtractedCspReport } from '../../security/csp-report.js'
+import { createRateLimiter, type RateLimiterOptions } from '../../security/rate-limiter.js'
+import { createNamespacedDebug } from '../../logger.js'
+
+const { json } = bodyParser
+const debug = createNamespacedDebug('security:csp-report')
+
+const CSP_TYPES = ['application/csp-report', 'application/reports+json', 'application/json']
+const LEGACY_INLINE_SAMPLE = 'window.webssh2Config'
+
+export interface CspReportRouteOptions {
+  readonly rateLimit: RateLimiterOptions
+  /** Emits the violation. Production wires this to logCspViolation. */
+  readonly onViolation: (
+    report: ExtractedCspReport,
+    meta: { clientIp?: string; userAgent?: string; isLegacy: boolean }
+  ) => void
+  /** Injectable clock (ms) for deterministic tests. Defaults to Date.now. */
+  readonly now?: () => number
+}
+
+function isLegacyInlineViolation(report: ExtractedCspReport): boolean {
+  const hasSample = report.scriptSample?.includes(LEGACY_INLINE_SAMPLE) === true
+  const isInlineUri = report.blockedUri === 'inline'
+  return hasSample || isInlineUri
+}
+
+function buildMeta(
+  req: Request,
+  isLegacy: boolean
+): { clientIp?: string; userAgent?: string; isLegacy: boolean } {
+  const meta: { clientIp?: string; userAgent?: string; isLegacy: boolean } = { isLegacy }
+  if (req.ip !== undefined) {
+    meta.clientIp = req.ip
+  }
+  const ua = req.get('user-agent')
+  if (ua !== undefined) {
+    meta.userAgent = ua
+  }
+  return meta
+}
+
+/** Register POST /csp-report on the given router (path is relative to the router mount). */
+export function registerCspReportRoute(router: Router, options: CspReportRouteOptions): void {
+  const limiter = createRateLimiter(options.rateLimit)
+  const parser = json({ type: CSP_TYPES, limit: '8kb' })
+  const clock = options.now ?? Date.now
+
+  const throttle = (req: Request, res: Response, next: NextFunction): void => {
+    const ip = req.ip ?? 'unknown'
+    if (!limiter.allow(ip, clock())) {
+      res.setHeader('Cache-Control', 'no-store')
+      res.status(204).end()
+      return
+    }
+    next()
+  }
+
+  const handleReport = (req: Request, res: Response): void => {
+    const report = extractCspReport(req.body)
+    const isLegacy = isLegacyInlineViolation(report)
+    debug('csp violation (legacy=%s): %o', isLegacy, report)
+    const meta = buildMeta(req, isLegacy)
+    options.onViolation(report, meta)
+    res.setHeader('Cache-Control', 'no-store')
+    res.status(204).end()
+  }
+
+  router.post('/csp-report', throttle, parser, handleReport)
+
+  // Path-scoped error middleware: the 8 kb json() parser throws
+  // PayloadTooLargeError on oversized bodies. Registering this immediately after
+  // the route — and scoped to /csp-report — guarantees a 204 + no-store response
+  // regardless of where this router sits relative to any app-level error handler,
+  // preserving the "always 204, never leak an error page" guarantee (P2/A1).
+  router.use(
+    '/csp-report',
+    (err: Error, _req: Request, res: Response, _next: NextFunction): void => {
+      debug('csp-report parser error: %s', err.message)
+      if (!res.headersSent) {
+        res.setHeader('Cache-Control', 'no-store')
+        res.status(204).end()
+      }
+    }
+  )
+}

--- a/app/routes/routes-v2.ts
+++ b/app/routes/routes-v2.ts
@@ -169,11 +169,7 @@ async function handleSshGetRoute(
         connectionMode: 'full' as const
       }
 
-  await handleConnection(
-    expressReq as unknown as Request & { session?: AuthSession; sessionID?: string },
-    res,
-    connectionOptions
-  )
+  await handleConnection(expressReq, res, connectionOptions)
 }
 
 /**
@@ -249,11 +245,9 @@ async function handlePostAuthRoute(
   processAuthParameters(source, expressReq.session)
 
   // Serve the client page
-  await handleConnection(
-    expressReq as unknown as Request & { session?: AuthSession; sessionID?: string },
-    res,
-    { host: authResult.value.connection.host }
-  )
+  await handleConnection(expressReq, res, {
+    host: authResult.value.connection.host
+  })
 }
 
 /**
@@ -287,7 +281,7 @@ export function createRoutesV2(config: Config): Router {
     debug('GET / - Root route accessed')
     
     processAuthParameters(expressReq.query, expressReq.session)
-    await handleConnection(expressReq as unknown as Request & { session?: AuthSession; sessionID?: string }, res)
+    await handleConnection(expressReq, res)
   }))
 
   /**

--- a/app/routes/routes-v2.ts
+++ b/app/routes/routes-v2.ts
@@ -3,7 +3,7 @@
 
 import express, { type Router, type Request, type Response } from 'express'
 import handleConnection from '../connectionHandler.js'
-import { createNamespacedDebug } from '../logger.js'
+import { createNamespacedDebug, logCspViolation } from '../logger.js'
 import { createAuthMiddleware } from '../middleware.js'
 import { processAuthParameters, type AuthSession } from '../auth/auth-utils.js'
 import { HTTP } from '../constants/index.js'
@@ -23,6 +23,7 @@ import {
   type SshConnectionParams
 } from './handlers/ssh-handler.js'
 import { createSshConfigResponse } from './handlers/ssh-config-handler.js'
+import { registerCspReportRoute } from './handlers/csp-report-handler.js'
 
 // Import adapters
 import {
@@ -264,6 +265,19 @@ export function createRoutesV2(config: Config): Router {
   
   // Add error handler
   router.use(createErrorHandler())
+
+  /**
+   * CSP violation report endpoint — unauthenticated, rate-limited, 8 kb cap.
+   * Registered only when CSP is active (mode != 'off').
+   * Always at the canonical path /csp-report regardless of config.csp.reportUri
+   * (A3: only the emitted directive follows reportUri; the handler is fixed).
+   */
+  if (config.csp.mode !== 'off') {
+    registerCspReportRoute(router, {
+      rateLimit: { capacity: 10, refillPerSec: 10 / 60, maxKeys: 5000 },
+      onViolation: (report, meta) => { logCspViolation(report, meta) }
+    })
+  }
 
   /**
    * Root route - uses default config

--- a/app/schemas/config-schema.ts
+++ b/app/schemas/config-schema.ts
@@ -234,6 +234,21 @@ const SsoSchema = z.object({
 })
 
 /**
+ * CSP (Content-Security-Policy) configuration schema
+ */
+const CspSchema = z.object({
+  mode: z.enum(['off', 'report-only', 'enforce']),
+  reportUri: z
+    .string()
+    .transform((uri) => {
+      const trimmed = uri.trim()
+      return trimmed.length > 1 && trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed
+    }),
+  connectSrc: z.array(z.string()),
+  frameAncestors: z.array(z.string()),
+})
+
+/**
  * Terminal configuration schema (optional)
  */
 const TerminalSchema = z.object({
@@ -372,6 +387,7 @@ export const ConfigSchema = z.object({
   options: OptionsSchema,
   session: SessionSchema,
   sso: SsoSchema,
+  csp: CspSchema,
   telnet: TelnetSchema,
   terminal: TerminalSchema,
   logging: LoggingSchema,

--- a/app/schemas/config-schema.ts
+++ b/app/schemas/config-schema.ts
@@ -242,6 +242,9 @@ const CspSchema = z.object({
     .string()
     .transform((uri) => {
       const trimmed = uri.trim()
+      if (trimmed === '') {
+        return '/ssh/csp-report'
+      }
       return trimmed.length > 1 && trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed
     }),
   connectSrc: z.array(z.string()),

--- a/app/security-headers.ts
+++ b/app/security-headers.ts
@@ -1,84 +1,214 @@
+// app/security-headers.ts
+// Tightened, config-driven, memoized CSP builder and security-headers middleware.
+
 import type { RequestHandler } from 'express'
 import createDebug from 'debug'
-import type { Config } from './types/config.js'
+import type { Config, CspMode } from './types/config.js'
 import { DEFAULTS, HEADERS } from './constants/index.js'
+import { deriveConnectSrc } from './security/connect-src.js'
 
 const debug = createDebug('webssh2:security')
 
-export const CSP_CONFIG: Record<string, string[]> = {
-  'default-src': ["'self'"],
-  'script-src': ["'self'", "'unsafe-inline'"],
-  'style-src': ["'self'", "'unsafe-inline'"],
-  'img-src': ["'self'", 'data:'],
-  'font-src': ["'self'"],
-  'connect-src': ["'self'", 'ws:', 'wss:'],
-  'frame-src': ["'none'"],
-  'object-src': ["'none'"],
-  'base-uri': ["'self'"],
-  'form-action': ["'self'", 'https:'],
+// xterm.js injects inline style attributes at runtime; unsafe-inline is
+// unavoidable for style-src until a nonce/hash approach is added.
+const STYLE_SRC = ["'self'", "'unsafe-inline'"] as const
+
+// ---------------------------------------------------------------------------
+// Pure CSP building helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a frame-ancestors token: bare 'none' and 'self' get quoted;
+ * fully-qualified URLs are passed through verbatim.
+ */
+function normalizeAncestor(value: string): string {
+  return value === 'none' || value === 'self' ? `'${value}'` : value
 }
 
-export function generateCSPHeader(): string {
-  return Object.entries(CSP_CONFIG)
-    .map(([directive, values]) => (values.length > 0 ? `${directive} ${values.join(' ')}` : directive))
-    .join('; ')
-}
+/**
+ * Build the ordered CSP directive map from config + TLS context.
+ * Pure function — safe to call once and cache.
+ */
+export function buildCspDirectives(
+  config: Pick<Config, 'http' | 'csp'>,
+  secure: boolean
+): Record<string, string[]> {
+  const csp = config.csp
+  const connect = deriveConnectSrc(config.http.origins, csp.connectSrc, secure)
 
-export const SECURITY_HEADERS: Record<string, string> = {
-  [HEADERS.CONTENT_SECURITY_POLICY]: generateCSPHeader(),
-  [HEADERS.X_CONTENT_TYPE_OPTIONS]: 'nosniff',
-  [HEADERS.X_FRAME_OPTIONS]: 'DENY',
-  [HEADERS.X_XSS_PROTECTION]: '1; mode=block',
-  [HEADERS.REFERRER_POLICY]: 'strict-origin-when-cross-origin',
-  [HEADERS.PERMISSIONS_POLICY]: 'geolocation=(), microphone=(), camera=()',
-  [HEADERS.STRICT_TRANSPORT_SECURITY]: `max-age=${DEFAULTS.HSTS_MAX_AGE_SECONDS}; includeSubDomains`,
-}
+  // Fail safe: an empty frame-ancestors list would serialize to a bare
+  // directive name that browsers reject, silently disabling framing
+  // protection. Fall back to the most restrictive value instead.
+  const frameAncestors = csp.frameAncestors.length > 0 ? csp.frameAncestors : ['none']
 
-function generateCSPHeaderFromConfig(csp: Record<string, string[]>): string {
-  return Object.entries(csp)
-    .map(([directive, values]) => (values.length > 0 ? `${directive} ${values.join(' ')}` : directive))
-    .join('; ')
-}
-
-export function createSecurityHeadersMiddleware(config: Partial<Config> = {}): RequestHandler {
-  return (req, res, next) => {
-    const headers = { ...SECURITY_HEADERS }
-
-    const trusted = config.sso?.trustedProxies
-    if (config.sso?.enabled === true && Array.isArray(trusted) && trusted.length > 0) {
-      const cspConfig: Record<string, string[]> = { ...CSP_CONFIG }
-      const fa = cspConfig['form-action'] as string[]
-      if (!fa.includes('https:')) {
-        fa.push('https:')
-      }
-      headers[HEADERS.CONTENT_SECURITY_POLICY] = generateCSPHeaderFromConfig(cspConfig)
-      debug('SSO mode: Adjusted CSP for trusted proxies')
-    }
-
-    for (const [header, value] of Object.entries(headers)) {
-      if (header === HEADERS.STRICT_TRANSPORT_SECURITY && !req.secure) {
-        continue
-      }
-      res.setHeader(header, value)
-    }
-    debug('Security headers applied to %s %s', req.method, req.url)
-    next()
+  const directives: Record<string, string[]> = {
+    'default-src': ["'self'"],
+    'script-src': ["'self'"],
+    'style-src': [...STYLE_SRC],
+    'img-src': ["'self'", 'data:'],
+    'font-src': ["'self'"],
+    'connect-src': connect.sources,
+    'object-src': ["'none'"],
+    'base-uri': ["'none'"],
+    'frame-ancestors': frameAncestors.map(normalizeAncestor),
+    'form-action': ["'self'"],
   }
+
+  if (csp.mode !== 'off') {
+    directives['report-uri'] = [csp.reportUri]
+    directives['report-to'] = ['csp-endpoint']
+  }
+
+  return directives
 }
 
-export function createCSPMiddleware(
-  customCSP: Partial<Record<keyof typeof CSP_CONFIG, string[]>> = {}
-): RequestHandler {
-  const merged: Record<string, string[]> = {
-    ...CSP_CONFIG,
-    ...(customCSP as Record<string, string[]>),
-  }
-  const header = Object.entries(merged)
+/**
+ * Serialize a directive map to a header value string.
+ * Directives appear in insertion order, values joined with spaces.
+ */
+export function cspHeaderValue(directives: Record<string, string[]>): string {
+  return Object.entries(directives)
     .map(([d, v]) => (v.length > 0 ? `${d} ${v.join(' ')}` : d))
     .join('; ')
+}
+
+// ---------------------------------------------------------------------------
+// Static-header derivation helpers
+// ---------------------------------------------------------------------------
+
+/** Determine X-Frame-Options from frame-ancestors config (may return null). */
+function resolveFrameOptions(frameAncestors: string[]): string | null {
+  // Fail safe: an empty list means buildCspDirectives falls back to 'none', so
+  // mirror that here and deny framing outright.
+  if (frameAncestors.length === 0) {
+    return 'DENY'
+  }
+  if (frameAncestors.length === 1 && frameAncestors[0] === 'none') {
+    return 'DENY'
+  }
+  if (frameAncestors.length === 1 && frameAncestors[0] === 'self') {
+    return 'SAMEORIGIN'
+  }
+  // Explicit origin list — X-Frame-Options cannot express this; omit it.
+  return null
+}
+
+interface StaticHeaders {
+  readonly noSniff: string
+  readonly xssProtection: string
+  readonly referrerPolicy: string
+  readonly permissionsPolicy: string
+  readonly hsts: string
+  readonly xFrameOptions: string | null
+}
+
+function buildStaticHeaders(config: Config): StaticHeaders {
+  const fa = config.csp.frameAncestors
+  return {
+    noSniff: 'nosniff',
+    xssProtection: '1; mode=block',
+    referrerPolicy: 'strict-origin-when-cross-origin',
+    permissionsPolicy: 'geolocation=(), microphone=(), camera=()',
+    hsts: `max-age=${DEFAULTS.HSTS_MAX_AGE_SECONDS}; includeSubDomains`,
+    xFrameOptions: resolveFrameOptions(fa),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CSP string precomputation
+// ---------------------------------------------------------------------------
+
+interface PrecomputedCsp {
+  readonly headerName: string | null
+  /** CSP value for TLS connections (wss://, https:// only). */
+  readonly secureValue: string
+  /** CSP value for plain-HTTP connections (adds ws://, http://). */
+  readonly insecureValue: string
+  readonly reportingEndpoints: string | null
+}
+
+function appendSsoFormAction(directives: Record<string, string[]>): Record<string, string[]> {
+  const fa = directives['form-action'] as string[]
+  const updated = fa.includes('https:') ? fa : [...fa, 'https:']
+  return { ...directives, 'form-action': updated }
+}
+
+function precomputeCspStrings(config: Config): PrecomputedCsp {
+  const mode: CspMode = config.csp.mode
+
+  if (mode === 'off') {
+    return { headerName: null, secureValue: '', insecureValue: '', reportingEndpoints: null }
+  }
+
+  const headerName =
+    mode === 'report-only'
+      ? HEADERS.CONTENT_SECURITY_POLICY_REPORT_ONLY
+      : HEADERS.CONTENT_SECURITY_POLICY
+
+  const isSso =
+    config.sso.enabled === true &&
+    Array.isArray(config.sso.trustedProxies) &&
+    config.sso.trustedProxies.length > 0
+
+  function buildValue(secure: boolean): string {
+    let directives = buildCspDirectives(config, secure)
+    if (isSso) {
+      directives = appendSsoFormAction(directives)
+    }
+    return cspHeaderValue(directives)
+  }
+
+  const reportUri = config.csp.reportUri
+
+  return {
+    headerName,
+    secureValue: buildValue(true),
+    insecureValue: buildValue(false),
+    reportingEndpoints: `csp-endpoint="${reportUri}"`,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public middleware factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build and return a security-headers middleware.
+ *
+ * The CSP directive string is precomputed ONCE at construction time (for both
+ * TLS and plain-HTTP variants) so that the per-request path does no allocation.
+ * All other headers are constant strings resolved from config here as well.
+ */
+export function createSecurityHeadersMiddleware(config: Config): RequestHandler {
+  const precomputed = precomputeCspStrings(config)
+  const staticHeaders = buildStaticHeaders(config)
+
   return (req, res, next) => {
-    res.setHeader(HEADERS.CONTENT_SECURITY_POLICY, header)
-    debug('Custom CSP applied to %s %s', req.method, req.url)
+    // Static headers (no per-request logic needed)
+    res.setHeader(HEADERS.X_CONTENT_TYPE_OPTIONS, staticHeaders.noSniff)
+    res.setHeader(HEADERS.X_XSS_PROTECTION, staticHeaders.xssProtection)
+    res.setHeader(HEADERS.REFERRER_POLICY, staticHeaders.referrerPolicy)
+    res.setHeader(HEADERS.PERMISSIONS_POLICY, staticHeaders.permissionsPolicy)
+
+    if (staticHeaders.xFrameOptions !== null) {
+      res.setHeader(HEADERS.X_FRAME_OPTIONS, staticHeaders.xFrameOptions)
+    }
+
+    if (req.secure) {
+      res.setHeader(HEADERS.STRICT_TRANSPORT_SECURITY, staticHeaders.hsts)
+    }
+
+    // CSP (pick precomputed value by TLS context)
+    const { headerName, secureValue, insecureValue, reportingEndpoints } = precomputed
+    if (headerName !== null) {
+      const cspValue = req.secure ? secureValue : insecureValue
+      res.setHeader(headerName, cspValue)
+      if (reportingEndpoints !== null) {
+        res.setHeader(HEADERS.REPORTING_ENDPOINTS, reportingEndpoints)
+      }
+    }
+
+    debug('Security headers applied to %s %s', req.method, req.url)
     next()
   }
 }

--- a/app/security-posture.ts
+++ b/app/security-posture.ts
@@ -9,6 +9,8 @@ export interface SecurityPostureWarning {
     | 'host_key_verification_disabled'
     | 'ssh_allowed_subnets_empty'
     | 'telnet_allowed_subnets_empty'
+    | 'csp_not_enforced'
+    | 'csp_connect_src_wildcard'
   readonly configKey: string
   readonly message: string
   readonly remediation: string
@@ -25,6 +27,8 @@ interface SecurityPostureView {
     readonly enabled?: boolean
     readonly allowedSubnets?: readonly string[]
   }
+  readonly csp?: { readonly mode?: string }
+  readonly http?: { readonly origins?: readonly string[] }
 }
 
 const HOST_KEY_WARNING: SecurityPostureWarning = {
@@ -60,6 +64,29 @@ const TELNET_SUBNETS_WARNING: SecurityPostureWarning = {
     "(WEBSSH2_TELNET_ALLOWED_SUBNETS, CIDR list). See SECURITY.md 'Default security posture'."
 }
 
+const CSP_NOT_ENFORCED_WARNING: SecurityPostureWarning = {
+  check: 'csp_not_enforced',
+  configKey: 'csp.mode',
+  message:
+    'SECURITY WARNING: Content-Security-Policy is not enforced (csp.mode != enforce). ' +
+    'The tightened policy is advertised but NOT blocking - inline scripts and injected ' +
+    'content still execute.',
+  remediation:
+    "Set csp.mode=enforce (WEBSSH2_CSP_MODE=enforce) after a clean report-only bake. " +
+    "See SECURITY.md 'Content-Security-Policy'."
+}
+
+const CSP_CONNECT_WILDCARD_WARNING: SecurityPostureWarning = {
+  check: 'csp_connect_src_wildcard',
+  configKey: 'http.origins',
+  message:
+    'SECURITY WARNING: csp.mode=enforce with wildcard http.origins (*:*). ' +
+    'connect-src cannot be tightened beyond self while CORS is wildcard.',
+  remediation:
+    'Set http.origins to an explicit allowlist (WEBSSH2_HTTP_ORIGINS) or add socket ' +
+    'origins to csp.connectSrc. See SECURITY.md.'
+}
+
 function isSubnetListEmpty(subnets: readonly string[] | undefined): boolean {
   return subnets === undefined || subnets.filter((s) => s.trim().length > 0).length === 0
 }
@@ -78,6 +105,15 @@ export function auditSecurityPosture(config: Config): SecurityPostureWarning[] {
 
   if (view.telnet?.enabled === true && isSubnetListEmpty(view.telnet.allowedSubnets)) {
     warnings.push(TELNET_SUBNETS_WARNING)
+  }
+
+  if (view.csp?.mode !== undefined && view.csp.mode !== 'enforce') {
+    warnings.push(CSP_NOT_ENFORCED_WARNING)
+  }
+
+  const origins = view.http?.origins ?? []
+  if (view.csp?.mode === 'enforce' && origins.some((o) => o.includes('*'))) {
+    warnings.push(CSP_CONNECT_WILDCARD_WARNING)
   }
 
   return warnings

--- a/app/security-posture.ts
+++ b/app/security-posture.ts
@@ -10,6 +10,7 @@ export interface SecurityPostureWarning {
     | 'ssh_allowed_subnets_empty'
     | 'telnet_allowed_subnets_empty'
     | 'csp_not_enforced'
+    | 'csp_disabled'
     | 'csp_connect_src_wildcard'
   readonly configKey: string
   readonly message: string
@@ -68,11 +69,23 @@ const CSP_NOT_ENFORCED_WARNING: SecurityPostureWarning = {
   check: 'csp_not_enforced',
   configKey: 'csp.mode',
   message:
-    'SECURITY WARNING: Content-Security-Policy is not enforced (csp.mode != enforce). ' +
-    'The tightened policy is advertised but NOT blocking - inline scripts and injected ' +
-    'content still execute.',
+    'SECURITY WARNING: Content-Security-Policy is in report-only mode (csp.mode=report-only). ' +
+    'The tightened policy is advertised and violations are reported, but NOT blocked - ' +
+    'inline scripts and injected content still execute.',
   remediation:
     "Set csp.mode=enforce (WEBSSH2_CSP_MODE=enforce) after a clean report-only bake. " +
+    "See SECURITY.md 'Content-Security-Policy'."
+}
+
+const CSP_DISABLED_WARNING: SecurityPostureWarning = {
+  check: 'csp_disabled',
+  configKey: 'csp.mode',
+  message:
+    'SECURITY WARNING: Content-Security-Policy is disabled (csp.mode=off). ' +
+    'No CSP header is sent, so the browser applies no script/connect/frame restrictions ' +
+    'to the served terminal page.',
+  remediation:
+    "Set csp.mode=report-only to begin a rollout, then enforce (WEBSSH2_CSP_MODE). " +
     "See SECURITY.md 'Content-Security-Policy'."
 }
 
@@ -107,7 +120,9 @@ export function auditSecurityPosture(config: Config): SecurityPostureWarning[] {
     warnings.push(TELNET_SUBNETS_WARNING)
   }
 
-  if (view.csp?.mode !== undefined && view.csp.mode !== 'enforce') {
+  if (view.csp?.mode === 'off') {
+    warnings.push(CSP_DISABLED_WARNING)
+  } else if (view.csp?.mode === 'report-only') {
     warnings.push(CSP_NOT_ENFORCED_WARNING)
   }
 

--- a/app/security/connect-src.ts
+++ b/app/security/connect-src.ts
@@ -24,7 +24,7 @@ function hasScheme(origin: string): boolean {
 
 function hasControlChars(value: string): boolean {
   for (const ch of value) {
-    const code = ch.charCodeAt(0)
+    const code = ch.codePointAt(0) ?? 0
     if (code <= 0x1f || code === 0x7f) {
       return true
     }

--- a/app/security/connect-src.ts
+++ b/app/security/connect-src.ts
@@ -1,0 +1,98 @@
+// app/security/connect-src.ts
+// Pure derivation of CSP connect-src sources from CORS origins.
+
+export interface ConnectSrcResult {
+  /** Ordered, de-duplicated CSP source list (always starts with 'self'). */
+  readonly sources: string[]
+  /** True if any CORS origin was a wildcard (and was therefore dropped). */
+  readonly wildcard: boolean
+}
+
+/** Concrete `host[:port]` (incl. IPv6 brackets); no whitespace, CR, LF, or junk. */
+const HOST_TOKEN_RE = /^[A-Za-z0-9.\-:[\]]+$/
+
+/** Network schemes permitted to pass through verbatim (matched case-insensitively). */
+const ALLOWED_SCHEMES = ['http://', 'https://', 'ws://', 'wss://']
+
+function isWildcard(origin: string): boolean {
+  return origin.includes('*')
+}
+
+function hasScheme(origin: string): boolean {
+  return origin.includes('://')
+}
+
+function hasControlChars(value: string): boolean {
+  for (const ch of value) {
+    const code = ch.charCodeAt(0)
+    if (code <= 0x1f || code === 0x7f) {
+      return true
+    }
+  }
+  return false
+}
+
+/** True if a scheme-bearing origin uses an allowed network scheme and has no junk. */
+function isAllowedSchemeOrigin(origin: string): boolean {
+  if (hasControlChars(origin)) {
+    return false
+  }
+  const lower = origin.toLowerCase()
+  return ALLOWED_SCHEMES.some((scheme) => lower.startsWith(scheme))
+}
+
+/** Expand a concrete `host[:port]` CORS token into valid CSP source expressions. */
+function expandHostToken(token: string, secure: boolean): string[] {
+  const out = [`https://${token}`, `wss://${token}`]
+  if (!secure) {
+    out.push(`http://${token}`, `ws://${token}`)
+  }
+  return out
+}
+
+/**
+ * Build connect-src from the CORS allowlist plus operator extras.
+ *
+ * Wildcard tokens in `corsOrigins` are dropped (never derived into CSP) and
+ * flagged via `wildcard`. Empty/whitespace and malformed CORS tokens (bad
+ * scheme, control chars, non-host junk) are silently dropped. `'self'` covers
+ * same-origin.
+ *
+ * `extras` are operator-controlled (from `csp.connectSrc`) and passed through
+ * verbatim, including any intentional CSP wildcards like `*.internal.example`;
+ * only empty/whitespace entries are skipped. The `wildcard` flag reflects
+ * `corsOrigins` only and is never set by `extras`.
+ */
+export function deriveConnectSrc(
+  corsOrigins: readonly string[],
+  extras: readonly string[],
+  secure: boolean
+): ConnectSrcResult {
+  const sources: string[] = ["'self'"]
+  let wildcard = false
+
+  for (const origin of corsOrigins) {
+    if (origin.trim() === '') {
+      continue
+    }
+    if (isWildcard(origin)) {
+      wildcard = true
+      continue
+    }
+    if (hasScheme(origin)) {
+      if (isAllowedSchemeOrigin(origin)) {
+        sources.push(origin)
+      }
+    } else if (HOST_TOKEN_RE.test(origin)) {
+      sources.push(...expandHostToken(origin, secure))
+    }
+  }
+
+  for (const extra of extras) {
+    if (extra.trim() !== '') {
+      sources.push(extra.trim())
+    }
+  }
+
+  return { sources: [...new Set(sources)], wildcard }
+}

--- a/app/security/csp-report.ts
+++ b/app/security/csp-report.ts
@@ -1,0 +1,81 @@
+// app/security/csp-report.ts
+// Pure, defensive extraction of a CSP violation report into a whitelisted,
+// length-bounded, control-char-stripped shape safe for structured logging.
+// The report body is attacker-controlled (unauthenticated endpoint), so we
+// extract ONLY known fields, truncate them, and strip CR/LF/control chars to
+// prevent log forging and log flooding.
+
+export interface ExtractedCspReport {
+  directive?: string
+  blockedUri?: string
+  disposition?: string
+  documentUri?: string
+  scriptSample?: string
+}
+
+const MAX_URI = 512
+const MAX_SAMPLE = 80
+const MAX_DISPOSITION = 32
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Strip control chars (incl. CR/LF) and truncate. Returns undefined for non-strings. */
+function sanitize(value: unknown, max: number): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  let stripped = ''
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0
+    if (code >= 0x20 && code !== 0x7f) {
+      stripped += ch
+    }
+  }
+  return stripped.slice(0, max)
+}
+
+function pickRaw(body: Record<string, unknown>): Record<string, unknown> {
+  if (isObject(body['csp-report'])) {
+    return body['csp-report']
+  }
+  if (isObject(body['body'])) {
+    return body['body']
+  }
+  return body
+}
+
+/**
+ * Accepts a legacy `{ "csp-report": {...} }` body, a Reporting-API
+ * `{ body: {...} }` shape, or a flat object, and returns whitelisted,
+ * sanitized fields. Never throws; returns `{}` for non-object input.
+ */
+export function extractCspReport(body: unknown): ExtractedCspReport {
+  if (!isObject(body)) {
+    return {}
+  }
+  const raw = pickRaw(body)
+  const result: ExtractedCspReport = {}
+  const directive = sanitize(raw['violated-directive'] ?? raw['effectiveDirective'], MAX_URI)
+  const blockedUri = sanitize(raw['blocked-uri'] ?? raw['blockedURL'], MAX_URI)
+  const disposition = sanitize(raw['disposition'], MAX_DISPOSITION)
+  const documentUri = sanitize(raw['document-uri'] ?? raw['documentURL'], MAX_URI)
+  const scriptSample = sanitize(raw['script-sample'] ?? raw['sample'], MAX_SAMPLE)
+  if (directive !== undefined) {
+    result.directive = directive
+  }
+  if (blockedUri !== undefined) {
+    result.blockedUri = blockedUri
+  }
+  if (disposition !== undefined) {
+    result.disposition = disposition
+  }
+  if (documentUri !== undefined) {
+    result.documentUri = documentUri
+  }
+  if (scriptSample !== undefined) {
+    result.scriptSample = scriptSample
+  }
+  return result
+}

--- a/app/security/rate-limiter.ts
+++ b/app/security/rate-limiter.ts
@@ -1,0 +1,75 @@
+// app/security/rate-limiter.ts
+// Minimal in-process token-bucket limiter keyed by an arbitrary string (e.g.
+// client IP). Dependency-free (honors the 14-day quarantine policy). Memory is
+// bounded via LRU-style eviction so spraying many distinct keys cannot grow the
+// map without bound. The clock is injected (`now`, ms) for deterministic tests.
+//
+// Clock-skew note: if `now` < `bucket.last` (negative elapsed), the refill
+// term is negative, so Math.min(capacity, tokens + negative) reduces or holds
+// tokens. This biases toward throttling — the safe direction.
+
+export interface RateLimiterOptions {
+  /** Max burst tokens per key. */
+  readonly capacity: number
+  /** Tokens regenerated per second. */
+  readonly refillPerSec: number
+  /** Max distinct keys tracked before oldest-eviction. */
+  readonly maxKeys: number
+}
+
+interface Bucket {
+  tokens: number
+  last: number
+}
+
+export interface RateLimiter {
+  /** Consume a token for `key` at time `now` (ms). Returns true if allowed. */
+  allow(key: string, now: number): boolean
+  size(): number
+}
+
+export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
+  const buckets = new Map<string, Bucket>()
+
+  const touch = (key: string, bucket: Bucket): void => {
+    // Re-insert to move the key to the most-recently-used end (Map preserves
+    // insertion order; deleting + setting refreshes recency).
+    buckets.delete(key)
+    buckets.set(key, bucket)
+  }
+
+  const evictIfNeeded = (): void => {
+    while (buckets.size > options.maxKeys) {
+      const oldest = buckets.keys().next().value
+      if (oldest === undefined) {
+        return
+      }
+      buckets.delete(oldest)
+    }
+  }
+
+  return {
+    allow(key: string, now: number): boolean {
+      const existing = buckets.get(key)
+      const bucket: Bucket = existing ?? { tokens: options.capacity, last: now }
+      if (existing !== undefined) {
+        const elapsedSec = (now - bucket.last) / 1000
+        bucket.tokens = Math.min(
+          options.capacity,
+          bucket.tokens + elapsedSec * options.refillPerSec,
+        )
+        bucket.last = now
+      }
+      touch(key, bucket)
+      evictIfNeeded()
+      if (bucket.tokens >= 1) {
+        bucket.tokens -= 1
+        return true
+      }
+      return false
+    },
+    size(): number {
+      return buckets.size
+    },
+  }
+}

--- a/app/services/theming/theming-injection.ts
+++ b/app/services/theming/theming-injection.ts
@@ -1,16 +1,15 @@
 /**
  * Theming injection helpers — build the client-facing theming payload from a
  * server `ThemingConfig`, then serialize it to a script-safe JSON string for
- * inline `<script>` injection. Mirrors the escape strategy used by
- * `injectConfig` in `app/utils/html-transformer.ts`:
- *   - `<` -> `\u003c`  (prevents `</script>` and `<!--` escapes)
- *   - U+2028 (line separator) -> `\u2028`
- *   - U+2029 (paragraph separator) -> `\u2029`
+ * inline `<script>` injection. Script-safe escaping is delegated to the
+ * canonical `serializeConfig` helper in `app/utils/html-transformer.ts`, which
+ * is the single XSS trust boundary for injected config.
  *
  * Pure functions; no I/O, no side effects.
  */
 
 import type { ThemeColors, ThemingConfig } from '../../types/config.js'
+import { serializeConfig } from '../../utils/html-transformer.js'
 
 export type ClientThemingPayload =
   | { readonly enabled: false }
@@ -58,8 +57,5 @@ export function buildClientThemingPayload(cfg: ThemingConfig): ClientThemingPayl
  * injection into an HTML `<script>` block. See module header for escape rules.
  */
 export function serializeThemingForInjection(cfg: ThemingConfig): string {
-  return JSON.stringify(buildClientThemingPayload(cfg))
-    .replaceAll('<', '\\u003c')
-    .replaceAll('\u2028', '\\u2028')
-    .replaceAll('\u2029', '\\u2029')
+  return serializeConfig(buildClientThemingPayload(cfg))
 }

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -299,6 +299,19 @@ export interface TelnetAuthConfig {
   expectTimeout: number
 }
 
+export type CspMode = 'off' | 'report-only' | 'enforce'
+
+export interface CspConfig {
+  /** Delivery mode for the Content-Security-Policy. */
+  mode: CspMode
+  /** Path/URL the violation-report directive points at. */
+  reportUri: string
+  /** Extra connect-src sources appended to the derived defaults. */
+  connectSrc: string[]
+  /** frame-ancestors policy: ['none'] | ['self'] | explicit origin list. */
+  frameAncestors: string[]
+}
+
 /**
  * Telnet protocol configuration
  */
@@ -328,6 +341,7 @@ export interface Config {
   options: OptionsConfig
   session: SessionConfig
   sso: SsoConfig
+  csp: CspConfig
   telnet?: TelnetConfig
   terminal?: TerminalConfig
   logging?: LoggingConfig

--- a/app/utils/html-transformer.ts
+++ b/app/utils/html-transformer.ts
@@ -32,9 +32,9 @@ const JSON_BLOCK_PLACEHOLDER =
  */
 function escapeForScript(json: string): string {
   return json
-    .replaceAll('<', '\\u003c')
-    .replaceAll('\u2028', '\\u2028')
-    .replaceAll('\u2029', '\\u2029')
+    .replaceAll('<', String.raw`\u003c`)
+    .replaceAll('\u2028', String.raw`\u2028`)
+    .replaceAll('\u2029', String.raw`\u2029`)
 }
 
 /** Serialize a config object to a script-safe JSON string. */

--- a/app/utils/html-transformer.ts
+++ b/app/utils/html-transformer.ts
@@ -1,9 +1,6 @@
 // app/utils/html-transformer.ts
 // Pure functions for HTML transformation
 
-/** Placeholder string in the client HTML that gets replaced with the runtime config. */
-const CONFIG_PLACEHOLDER = 'window.webssh2Config = null;'
-
 /**
  * Transform HTML by modifying asset paths
  * Pure function - no side effects
@@ -16,78 +13,82 @@ export function transformAssetPaths(html: string, basePath: string = '/ssh/asset
   return html.replaceAll(/(src|href)="(?!http|\/\/)/g, `$1="${basePath}`)
 }
 
+/** Placeholder string in the client HTML that gets replaced with the runtime config. */
+const CONFIG_PLACEHOLDER = 'window.webssh2Config = null;'
+
+/** Inert JSON data block placeholder (client >= 5.1.0); preferred injection point. */
+const JSON_BLOCK_PLACEHOLDER =
+  '<script type="application/json" id="webssh2-config">null</script>'
+
 /**
- * Inject configuration into HTML
- * Pure function - no side effects
- *
- * Script-safe: escapes characters that could break out of a `<script>` tag or
- * cause unintended JavaScript execution:
- *   - `<` → `<`  (prevents `</script>` and `<!--` injection)
- *   - U+2028 (line separator) → `\u2028` (valid JS line terminator)
- *   - U+2029 (paragraph separator) → `\u2029` (valid JS line terminator)
- *
- * @param html - HTML string to modify
- * @param config - Configuration object to inject
- * @returns HTML with injected configuration
+ * Script-safe escape for embedding JSON inside an HTML `<script>` element
+ * (executable or `type="application/json"`). Escapes the only sequences that
+ * can break out of a script element or terminate JS parsing:
+ *   - `<`        -> `<`  (prevents `</script>` and `<!--`; JSON.parse restores `<`)
+ *   - U+2028     -> `\u2028`
+ *   - U+2029     -> `\u2029`
+ * This is the single XSS trust boundary for injected config — every injection
+ * site MUST route through it.
  */
-export function injectConfig(html: string, config: unknown): string {
-  const safeJson = JSON.stringify(config)
+function escapeForScript(json: string): string {
+  return json
     .replaceAll('<', '\\u003c')
     .replaceAll('\u2028', '\\u2028')
     .replaceAll('\u2029', '\\u2029')
-  return html.replace(
-    CONFIG_PLACEHOLDER,
-    `window.webssh2Config = ${safeJson};`
-  )
+}
+
+/** Serialize a config object to a script-safe JSON string. */
+export function serializeConfig(config: unknown): string {
+  return escapeForScript(JSON.stringify(config))
+}
+
+/** Inject a pre-serialized, script-safe JSON string into both placeholders. */
+function injectSerialized(html: string, serialized: string): string {
+  return html
+    .replace(
+      JSON_BLOCK_PLACEHOLDER,
+      `<script type="application/json" id="webssh2-config">${serialized}</script>`
+    )
+    .replace(CONFIG_PLACEHOLDER, `window.webssh2Config = ${serialized};`)
 }
 
 /**
- * Transform HTML with asset paths and config injection
- * Composition of pure transformation functions
+ * Inject configuration into HTML. Pure function.
  *
- * @param html - HTML string to transform
- * @param config - Configuration object to inject
- * @param basePath - Base path for assets (default: '/ssh/assets/')
- * @returns Fully transformed HTML
+ * Replaces both the inert JSON data block (preferred by client >= 5.1.0) and
+ * the legacy `window.webssh2Config` inline script (transition fallback for
+ * older/custom client builds). On an old-client template lacking the JSON
+ * block, the block replacement is a harmless no-op.
  */
+export function injectConfig(html: string, config: unknown): string {
+  return injectSerialized(html, serializeConfig(config))
+}
+
 export function transformHtml(html: string, config: unknown, basePath?: string): string {
   const htmlWithAssetPaths = transformAssetPaths(html, basePath)
   return injectConfig(htmlWithAssetPaths, config)
 }
 
 /**
- * Inject configuration with a pre-serialized theming JSON slice.
+ * Inject configuration merged with a pre-serialized, script-safe theming JSON
+ * slice, into both placeholders. `configWithoutTheming` is narrowed to a plain
+ * object so it cannot serialize to a non-object form. Edge case: an empty base
+ * object yields `{"theming":<json>}` rather than `{,"theming":<json>}`.
  *
- * The base config object is stringified and script-safe-escaped using the same
- * rules as `injectConfig`. The provided `themingJson` (already script-safe)
- * is then spliced in as a `theming` property before the closing brace.
- *
- * Edge case: when `configWithoutTheming` serializes to `{}`, the result is
- * `{"theming":<json>}` rather than the malformed `{,"theming":<json>}`.
- *
- * The parameter is narrowed to `Record<string, unknown>` so callers cannot
- * accidentally pass `null`, an array, or a primitive - any of which would
- * stringify to a non-object form and produce malformed merged JSON.
- *
- * @param html - HTML string to modify
- * @param configWithoutTheming - Plain config object (must NOT contain a `theming` key)
- * @param themingJson - Pre-serialized, script-safe theming JSON string
- * @returns HTML with merged configuration injected
+ * SECURITY: `themingJson` MUST already be script-safe — every `<`, U+2028, and
+ * U+2029 escaped via `serializeConfig` (or `serializeThemingForInjection`,
+ * which delegates to it). It is spliced in verbatim WITHOUT re-escaping, so
+ * passing raw `JSON.stringify()` output here is a security bug (XSS).
  */
 export function injectConfigWithThemingString(
   html: string,
   configWithoutTheming: Record<string, unknown>,
   themingJson: string
 ): string {
-  const base = JSON.stringify(configWithoutTheming)
-    .replaceAll('<', '\\u003c')
-    .replaceAll('\u2028', '\\u2028')
-    .replaceAll('\u2029', '\\u2029')
-  const merged = base === '{}'
-    ? `{"theming":${themingJson}}`
-    : `${base.slice(0, -1)},"theming":${themingJson}}`
-  return html.replace(
-    CONFIG_PLACEHOLDER,
-    `window.webssh2Config = ${merged};`
-  )
+  const base = serializeConfig(configWithoutTheming)
+  const merged =
+    base === '{}'
+      ? `{"theming":${themingJson}}`
+      : `${base.slice(0, -1)},"theming":${themingJson}}`
+  return injectSerialized(html, merged)
 }

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -66,7 +66,8 @@ export {
 export {
   transformHtml,
   transformAssetPaths,
-  injectConfig
+  injectConfig,
+  serializeConfig
 } from './html-transformer.js'
 
 // ============================================================================

--- a/app/utils/static-cache.ts
+++ b/app/utils/static-cache.ts
@@ -1,13 +1,15 @@
 // app/utils/static-cache.ts
 // Pure Cache-Control policy for statically served client assets
 //
-// The bundled client (node_modules/webssh2_client/client/public) currently
-// ships only stable-named files (webssh2.bundle.js, webssh2.css, ...), whose
-// content changes between releases while the filename does not. Those must
-// NOT be marked immutable; they get a short public max-age with ETag
-// revalidation. Content-hashed filenames (Vite's `[name]-[hash].ext`) are
-// safe to cache for a year as immutable. HTML entry points are never cached
-// without revalidation.
+// The bundled client (node_modules/webssh2_client/client/public) may ship
+// either content-hashed filenames (Vite's `[name]-[hash].ext`, e.g.
+// `webssh2-<hash>.js`, current in 5.1.0+) or stable names (webssh2.bundle.js,
+// webssh2.css, ... in older builds). This policy handles each: content-hashed
+// files are safe to cache for a year as immutable, since a content change
+// yields a new filename. Stable-named files, whose content changes between
+// releases while the filename does not, must NOT be marked immutable; they get
+// a short public max-age with ETag revalidation. HTML entry points are never
+// cached without revalidation.
 
 const ONE_HOUR_SECONDS = 3600
 const ONE_YEAR_SECONDS = 31_536_000

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "8.58.2",
         "@typescript-eslint/parser": "8.58.2",
-        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/coverage-v8": "4.1.9",
         "baseline-browser-mapping": "^2.8.32",
         "eslint": "9.39.4",
         "eslint-config-prettier": "^10.1.8",
@@ -50,9 +50,9 @@
         "eslint-plugin-sonarjs": "^4.0.3",
         "eslint-plugin-unicorn": "^64.0.0",
         "supertest": "^7.1.4",
-        "tsx": "^4.21.0",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.3",
-        "vitest": "4.1.4"
+        "vitest": "4.1.9"
       },
       "engines": {
         "node": ">= 22"
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -241,9 +241,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -258,9 +258,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -360,9 +360,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -377,9 +377,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -394,9 +394,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -411,9 +411,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -428,9 +428,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -445,9 +445,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -462,9 +462,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -496,9 +496,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -513,9 +513,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -530,9 +530,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1723,14 +1723,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
-      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.9",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1744,8 +1744,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.4",
-        "vitest": "4.1.4"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1754,16 +1754,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1772,13 +1772,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1799,9 +1799,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1812,13 +1812,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1826,14 +1826,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1842,9 +1842,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1852,13 +1852,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2651,9 +2651,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.8",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
-      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
@@ -2665,7 +2665,7 @@
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.20.1"
+        "ws": "~8.21.0"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -2777,9 +2777,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2790,32 +2790,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -3575,17 +3575,17 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3724,19 +3724,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.1.tgz",
-      "integrity": "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -3820,9 +3807,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4080,10 +4067,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4443,15 +4440,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -4940,16 +4940,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -5277,13 +5267,13 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
-      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
-        "ws": "~8.20.1"
+        "ws": "~8.21.0"
       }
     },
     "node_modules/socket.io-parser": {
@@ -5545,9 +5535,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5604,14 +5594,13 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -5790,9 +5779,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5880,19 +5869,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5920,12 +5909,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -6031,9 +6020,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "socket.io": "^4.8.1",
         "ssh2": "1.17",
         "validator": "^13.15.35",
-        "webssh2_client": "^4.0.0",
+        "webssh2_client": "^5.1.0",
         "zod": "^4.1.12"
       },
       "bin": {
@@ -1865,12 +1865,6 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/@xterm/addon-search": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
-      "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
-      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -5976,13 +5970,10 @@
       }
     },
     "node_modules/webssh2_client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-4.0.0.tgz",
-      "integrity": "sha512-65fZbIwSHRDuppma+MT7kA7v/0WND3YtiUS37lMnOi4BRAtdPOy2Aqt933YDXfZqRkWUuvCbPr+75gmH2PuiIA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-5.1.0.tgz",
+      "integrity": "sha512-XeXGjmjSY1XyzZmR6Axo7gV+2Ct/vF1+xXht3xMM3JVM4USVF2FIDm+InSAXQPzqEO8LjoLdOx+PwnQqxjGWnQ==",
       "license": "MIT",
-      "dependencies": {
-        "@xterm/addon-search": "^0.16.0"
-      },
       "engines": {
         "node": ">= 22"
       },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "8.58.2",
     "@typescript-eslint/parser": "8.58.2",
-    "@vitest/coverage-v8": "4.1.4",
+    "@vitest/coverage-v8": "4.1.9",
     "baseline-browser-mapping": "^2.8.32",
     "eslint": "9.39.4",
     "eslint-config-prettier": "^10.1.8",
@@ -102,9 +102,9 @@
     "eslint-plugin-sonarjs": "^4.0.3",
     "eslint-plugin-unicorn": "^64.0.0",
     "supertest": "^7.1.4",
-    "tsx": "^4.21.0",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
-    "vitest": "4.1.4"
+    "vitest": "4.1.9"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -124,7 +124,8 @@
     "flatted": "3.4.2",
     "picomatch": "4.0.4",
     "path-to-regexp": "8.4.0",
-    "vite": "7.3.2",
+    "vite": "7.3.5",
+    "esbuild": "^0.28.1",
     "qs": "6.15.2"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "socket.io": "^4.8.1",
     "ssh2": "1.17",
     "validator": "^13.15.35",
-    "webssh2_client": "^4.0.0",
+    "webssh2_client": "^5.1.0",
     "zod": "^4.1.12"
   },
   "scripts": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,7 +43,8 @@ export default defineConfig({
       E2E_SSH_PASS: PASSWORD,
       WEBSSH2_SSH_READY_TIMEOUT: '10000', // Faster timeout for test suite
       WEBSSH2_THEMING_ENABLED: 'true',
-      WEBSSH2_THEMING_ALLOW_CUSTOM: 'true'
+      WEBSSH2_THEMING_ALLOW_CUSTOM: 'true',
+      WEBSSH2_CSP_MODE: process.env.E2E_CSP_MODE ?? 'enforce',
     },
   },
   // Always run global teardown to clean up config.json

--- a/tests/contracts/routes-stack.vitest.ts
+++ b/tests/contracts/routes-stack.vitest.ts
@@ -76,6 +76,10 @@ it('router registers expected paths and methods', () => {
   // POST endpoints
   assertRoute('/', 'post')
 
+  // CSP violation report endpoint — registered when csp.mode != 'off'.
+  // Guards against accidental removal of the gated registration in routes-v2.
+  assertRoute('/csp-report', 'post')
+
   // Utility endpoints
   assertRoute('/clear-credentials', 'get')
   assertRoute('/force-reconnect', 'get')

--- a/tests/contracts/routes-stack.vitest.ts
+++ b/tests/contracts/routes-stack.vitest.ts
@@ -17,6 +17,7 @@ const minimalConfig = {
   session: { secret: TEST_SECRET, name: 'y' },
   sso: { enabled: false, csrfProtection: false, trustedProxies: [], headerMapping: {} },
   options: { challengeButton: true, autoLog: false, allowReplay: true, allowReconnect: true, allowReauth: true },
+  csp: { mode: 'report-only', reportUri: '/ssh/csp-report', connectSrc: [], frameAncestors: ['none'] },
 }
 
 interface RouterLayer {

--- a/tests/integration/csp-headers.vitest.ts
+++ b/tests/integration/csp-headers.vitest.ts
@@ -1,0 +1,75 @@
+// tests/integration/csp-headers.vitest.ts
+// Verifies CSP middleware behavior end-to-end across routes and delivery modes.
+// Red-team coverage: S5 (CSP bypass) / A2 (security misconfiguration).
+
+import fs from 'node:fs'
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import type { Application } from 'express'
+import { createAppAsync } from '../../app/app.js'
+import { getClientPublicPath } from '../../app/client-path.js'
+import { createDefaultConfig } from '../../app/config/config-processor.js'
+import { TEST_SESSION_SECRET_VALID } from '@tests/test-constants.js'
+import type { Config } from '../../app/types/config.js'
+
+// Discover the content-hashed bundle filename at runtime so the test stays
+// correct regardless of which Vite build the installed client produces.
+const JS_BUNDLE_PATTERN = /^webssh2-.*\.js$/
+
+function findAsset(pattern: RegExp, fallback: string): string {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- app-resolved public dir
+  const files: string[] = fs.readdirSync(getClientPublicPath())
+  const match = files.find((file) => pattern.test(file))
+  return match ?? fallback
+}
+
+function appFor(mode: 'off' | 'report-only' | 'enforce'): Application {
+  const secret: string = TEST_SESSION_SECRET_VALID
+  const config: Config = createDefaultConfig(secret)
+  config.csp = { mode, reportUri: '/ssh/csp-report', connectSrc: [], frameAncestors: ['none'] }
+  return createAppAsync(config).app
+}
+
+/** Isolate the script-src directive from a full CSP header value. */
+function scriptSrcOf(csp: string): string {
+  return csp.split('; ').find((d) => d.startsWith('script-src ')) ?? ''
+}
+
+describe('CSP headers', () => {
+  // Express 5's built-in finalhandler adds its own `default-src 'none'` CSP on
+  // unmatched-route 404 responses, overwriting whatever app-level middleware set.
+  // The byte-identical assertion therefore covers only routes handled by the
+  // application routers, where the security-headers middleware output is preserved.
+  it('emits a byte-identical CSP across the asset and config routes (enforce)', async () => {
+    const app = appFor('enforce')
+    const bundle = findAsset(JS_BUNDLE_PATTERN, 'webssh2.bundle.js')
+    // Both paths are fast: the asset path returns a static file immediately;
+    // /ssh/config returns a JSON blob without initiating any SSH connection.
+    const paths = [`/ssh/assets/${bundle}`, '/ssh/config']
+    const headers = await Promise.all(
+      paths.map((p) =>
+        request(app)
+          .get(p)
+          .then((r) => r.headers['content-security-policy'])
+      )
+    )
+    const defined = headers.filter((h): h is string => h !== undefined)
+    expect(defined.length).toBe(paths.length)  // every app-handled route carries it
+    expect(new Set(defined).size).toBe(1)       // value is identical across routes
+    expect(scriptSrcOf(defined[0])).toBe("script-src 'self'")
+    expect(defined[0]).toContain("base-uri 'none'")
+  })
+
+  it("uses Report-Only header + Reporting-Endpoints in 'report-only' mode", async () => {
+    const res = await request(appFor('report-only')).get('/ssh/config')
+    expect(res.headers['content-security-policy-report-only']).toBeDefined()
+    expect(res.headers['content-security-policy']).toBeUndefined()
+    expect(res.headers['reporting-endpoints']).toContain('csp-endpoint="/ssh/csp-report"')
+  })
+
+  it("emits no CSP header when mode is 'off'", async () => {
+    const res = await request(appFor('off')).get('/ssh/config')
+    expect(res.headers['content-security-policy']).toBeUndefined()
+    expect(res.headers['content-security-policy-report-only']).toBeUndefined()
+  })
+})

--- a/tests/integration/csp-report.vitest.ts
+++ b/tests/integration/csp-report.vitest.ts
@@ -1,0 +1,181 @@
+// tests/integration/csp-report.vitest.ts
+// Integration tests for the hardened POST /ssh/csp-report endpoint.
+// Tests cover: content-type acceptance, legacy inline demotion flag, per-IP
+// throttling (runs BEFORE body parsing), application/reports+json shape, and
+// mode-gating via createRoutesV2.
+
+import { describe, it, expect } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { registerCspReportRoute } from '../../app/routes/handlers/csp-report-handler.js'
+import { createRoutesV2 } from '../../app/routes/routes-v2.js'
+import { createDefaultConfig } from '../../app/config/config-processor.js'
+import type { ExtractedCspReport } from '../../app/security/csp-report.js'
+import { TEST_SESSION_SECRET_VALID } from '@tests/test-constants.js'
+
+interface CapturedViolation {
+  report: ExtractedCspReport
+  meta: { isLegacy: boolean; clientIp?: string; userAgent?: string }
+}
+
+const makeApp = (
+  captured: CapturedViolation[],
+  rl = { capacity: 5, refillPerSec: 0, maxKeys: 100 }
+): express.Application => {
+  const app = express()
+  const router = express.Router()
+  registerCspReportRoute(router, {
+    rateLimit: rl,
+    onViolation: (report, meta) => {
+      captured.push({ report, meta })
+    }
+  })
+  app.use('/ssh', router)
+  return app
+}
+
+describe('POST /ssh/csp-report', () => {
+  it('accepts application/csp-report, returns 204 + no-store, emits a populated violation', async () => {
+    const captured: CapturedViolation[] = []
+    const res = await request(makeApp(captured))
+      .post('/ssh/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send(
+        JSON.stringify({
+          'csp-report': {
+            'violated-directive': 'script-src',
+            'blocked-uri': 'https://evil'
+          }
+        })
+      )
+    expect(res.status).toBe(204)
+    expect(res.headers['cache-control']).toBe('no-store')
+    expect(captured).toHaveLength(1)
+    expect(captured[0].report).toMatchObject({ directive: 'script-src', blockedUri: 'https://evil' })
+    expect(captured[0].meta.isLegacy).toBe(false)
+  })
+
+  it('flags legacy inline violation (blocked-uri inline) as isLegacy=true', async () => {
+    const captured: CapturedViolation[] = []
+    await request(makeApp(captured))
+      .post('/ssh/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send(
+        JSON.stringify({
+          'csp-report': {
+            'violated-directive': 'script-src',
+            'blocked-uri': 'inline',
+            'script-sample': 'window.webssh2Config = null;'
+          }
+        })
+      )
+    expect(captured[0].meta.isLegacy).toBe(true)
+  })
+
+  it('flags legacy inline violation by script-sample alone (even without blocked-uri inline)', async () => {
+    const captured: CapturedViolation[] = []
+    await request(makeApp(captured))
+      .post('/ssh/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send(
+        JSON.stringify({
+          'csp-report': {
+            'violated-directive': 'script-src',
+            'blocked-uri': 'https://cdn.example',
+            'script-sample': 'window.webssh2Config ='
+          }
+        })
+      )
+    expect(captured[0].meta.isLegacy).toBe(true)
+  })
+
+  it('throttles repeated posts from one IP — emits no more than capacity, always 204', async () => {
+    const captured: CapturedViolation[] = []
+    const app = makeApp(captured, { capacity: 3, refillPerSec: 0, maxKeys: 100 })
+    for (let i = 0; i < 8; i++) {
+      const r = await request(app)
+        .post('/ssh/csp-report')
+        .set('Content-Type', 'application/csp-report')
+        .send('{}')
+      // Throttled requests are silently dropped — still 204 (not 429)
+      expect(r.status).toBe(204)
+      // Every response (allowed and throttled) carries Cache-Control: no-store
+      expect(r.headers['cache-control']).toBe('no-store')
+    }
+    // No more than capacity (3) calls should reach onViolation
+    expect(captured.length).toBeLessThanOrEqual(3)
+  })
+
+  it('rejects a body over 8 kb with 204 (not 413)', async () => {
+    const bigBody = JSON.stringify({ 'csp-report': { 'blocked-uri': 'x'.repeat(9000) } })
+    const res = await request(makeApp([]))
+      .post('/ssh/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send(bigBody)
+    expect(res.status).toBe(204)
+    expect(res.headers['cache-control']).toBe('no-store')
+  })
+
+  it('accepts application/reports+json (Reporting API shape)', async () => {
+    const captured: CapturedViolation[] = []
+    await request(makeApp(captured))
+      .post('/ssh/csp-report')
+      .set('Content-Type', 'application/reports+json')
+      .send(
+        JSON.stringify({
+          body: { effectiveDirective: 'img-src', blockedURL: 'https://x' }
+        })
+      )
+    expect(captured[0].report).toMatchObject({ directive: 'img-src', blockedUri: 'https://x' })
+  })
+
+  it('returns 204 + no-store even for an empty body', async () => {
+    const captured: CapturedViolation[] = []
+    const res = await request(makeApp(captured))
+      .post('/ssh/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send('{}')
+    expect(res.status).toBe(204)
+    expect(res.headers['cache-control']).toBe('no-store')
+    expect(captured).toHaveLength(1)
+    expect(captured[0].report).toEqual({})
+  })
+})
+
+describe('createRoutesV2 csp-report registration (mode gating)', () => {
+  it('registers /ssh/csp-report when mode != off and 404s when mode == off', async () => {
+    const secret: string = TEST_SESSION_SECRET_VALID
+    const base = createDefaultConfig(secret)
+
+    // Mode report-only → endpoint should exist
+    const onApp = express()
+    onApp.use('/ssh', createRoutesV2({ ...base, csp: { ...base.csp, mode: 'report-only' } }))
+    const onRes = await request(onApp)
+      .post('/ssh/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send('{}')
+    expect(onRes.status).toBe(204)
+
+    // Mode off → endpoint must not be registered
+    const offApp = express()
+    offApp.use('/ssh', createRoutesV2({ ...base, csp: { ...base.csp, mode: 'off' } }))
+    const offRes = await request(offApp)
+      .post('/ssh/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send('{}')
+    expect(offRes.status).toBe(404)
+  })
+
+  it('registers /ssh/csp-report when mode == enforce', async () => {
+    const secret: string = TEST_SESSION_SECRET_VALID
+    const base = createDefaultConfig(secret)
+
+    const enforceApp = express()
+    enforceApp.use('/ssh', createRoutesV2({ ...base, csp: { ...base.csp, mode: 'enforce' } }))
+    const enforceRes = await request(enforceApp)
+      .post('/ssh/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send('{}')
+    expect(enforceRes.status).toBe(204)
+  })
+})

--- a/tests/integration/csp-report.vitest.ts
+++ b/tests/integration/csp-report.vitest.ts
@@ -18,9 +18,11 @@ interface CapturedViolation {
   meta: { isLegacy: boolean; clientIp?: string; userAgent?: string }
 }
 
+const DEFAULT_RATE_LIMIT = { capacity: 5, refillPerSec: 0, maxKeys: 100 }
+
 const makeApp = (
   captured: CapturedViolation[],
-  rl = { capacity: 5, refillPerSec: 0, maxKeys: 100 }
+  rl = DEFAULT_RATE_LIMIT
 ): express.Application => {
   const app = express()
   const router = express.Router()

--- a/tests/integration/static-cache-headers.vitest.ts
+++ b/tests/integration/static-cache-headers.vitest.ts
@@ -4,8 +4,7 @@
 // Depends on node_modules/webssh2_client/client/public existing, which is
 // guaranteed by `npm install` (webssh2_client is a runtime dependency).
 
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import fs from 'node:fs'
 import { describe, it, expect, beforeAll } from 'vitest'
 import request from 'supertest'
 import type { Application } from 'express'
@@ -15,10 +14,25 @@ import { createDefaultConfig } from '../../app/config/config-processor.js'
 import { TELNET_DEFAULTS } from '../../app/constants/index.js'
 import { TEST_SESSION_SECRET_VALID } from '@tests/test-constants.js'
 import {
+  cacheControlForAsset,
   CACHE_CONTROL_HTML,
-  CACHE_CONTROL_STABLE,
 } from '../../app/utils/static-cache.js'
 import type { Config } from '../../app/types/config.js'
+
+// The bundled client may ship either content-hashed filenames (Vite's
+// `webssh2-<hash>.js`, current in 5.1.0+) or stable names (`webssh2.bundle.js`,
+// older builds). Discover the actual names at runtime so the test stays correct
+// regardless of which the installed client produces, and derive each name's
+// expected Cache-Control from the same policy the server applies.
+const JS_BUNDLE_PATTERN = /^webssh2-.*\.js$/
+const CSS_PATTERN = /^webssh2-.*\.css$/
+
+function findAsset(pattern: RegExp, fallback: string): string {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- app-resolved public dir
+  const files: string[] = fs.readdirSync(getClientPublicPath())
+  const match = files.find((file) => pattern.test(file))
+  return match ?? fallback
+}
 
 function createTestConfig(): Config {
   const secret: string = TEST_SESSION_SECRET_VALID
@@ -41,32 +55,31 @@ function createTestConfig(): Config {
 
 describe('static asset cache headers', () => {
   let app: Application
+  let bundleName: string
+  let cssName: string
+  let bundleCacheControl: string
+  let cssCacheControl: string
 
   beforeAll(() => {
-    const bundlePath = join(getClientPublicPath(), 'webssh2.bundle.js')
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test prerequisite check on app-resolved path
-    if (!existsSync(bundlePath)) {
-      throw new Error(
-        `Client bundle not found at ${bundlePath}. ` +
-          'These tests require the webssh2_client public assets ' +
-          '(run `npm install`, or build the client if using npm link).'
-      )
-    }
+    bundleName = findAsset(JS_BUNDLE_PATTERN, 'webssh2.bundle.js')
+    cssName = findAsset(CSS_PATTERN, 'webssh2.css')
+    bundleCacheControl = cacheControlForAsset(bundleName)
+    cssCacheControl = cacheControlForAsset(cssName)
     const config = createTestConfig()
     app = createAppAsync(config).app
   })
 
-  it('serves the bundle with short public caching and an ETag', async () => {
-    const res = await request(app).get('/ssh/assets/webssh2.bundle.js')
+  it('serves the bundle with the policy cache header and an ETag', async () => {
+    const res = await request(app).get(`/ssh/assets/${bundleName}`)
     expect(res.status).toBe(200)
-    expect(res.headers['cache-control']).toBe(CACHE_CONTROL_STABLE)
+    expect(res.headers['cache-control']).toBe(bundleCacheControl)
     expect(res.headers['etag']).toBeDefined()
   })
 
-  it('serves stylesheets with short public caching', async () => {
-    const res = await request(app).get('/ssh/assets/webssh2.css')
+  it('serves stylesheets with the policy cache header', async () => {
+    const res = await request(app).get(`/ssh/assets/${cssName}`)
     expect(res.status).toBe(200)
-    expect(res.headers['cache-control']).toBe(CACHE_CONTROL_STABLE)
+    expect(res.headers['cache-control']).toBe(cssCacheControl)
   })
 
   it('serves raw client.htm with no-cache', async () => {
@@ -76,9 +89,9 @@ describe('static asset cache headers', () => {
   })
 
   it('applies the same policy on the telnet assets mount', async () => {
-    const res = await request(app).get('/telnet/assets/webssh2.bundle.js')
+    const res = await request(app).get(`/telnet/assets/${bundleName}`)
     expect(res.status).toBe(200)
-    expect(res.headers['cache-control']).toBe(CACHE_CONTROL_STABLE)
+    expect(res.headers['cache-control']).toBe(bundleCacheControl)
     expect(res.headers['etag']).toBeDefined()
   })
 
@@ -89,12 +102,12 @@ describe('static asset cache headers', () => {
   })
 
   it('answers conditional requests with 304 when the ETag matches', async () => {
-    const first = await request(app).get('/ssh/assets/webssh2.bundle.js')
+    const first = await request(app).get(`/ssh/assets/${bundleName}`)
     const etag = first.headers['etag']
     expect(etag).toBeDefined()
 
     const second = await request(app)
-      .get('/ssh/assets/webssh2.bundle.js')
+      .get(`/ssh/assets/${bundleName}`)
       .set('If-None-Match', etag as string)
     expect(second.status).toBe(304)
   })

--- a/tests/integration/static-cache-headers.vitest.ts
+++ b/tests/integration/static-cache-headers.vitest.ts
@@ -108,7 +108,7 @@ describe('static asset cache headers', () => {
 
     const second = await request(app)
       .get(`/ssh/assets/${bundleName}`)
-      .set('If-None-Match', etag as string)
+      .set('If-None-Match', etag)
     expect(second.status).toBe(304)
   })
 })

--- a/tests/playwright/csp-enforce.spec.ts
+++ b/tests/playwright/csp-enforce.spec.ts
@@ -1,0 +1,101 @@
+/* global document */
+/**
+ * CSP enforcement E2E spec — issue #546
+ *
+ * Validates that the WebSSH2 client works correctly under an ENFORCED
+ * Content-Security-Policy.  The suite:
+ *   1. Listens for console messages containing "Content Security Policy" so
+ *      any runtime CSP violations from app code are captured.
+ *   2. Navigates to a live SSH session using the same Basic Auth URL pattern
+ *      as the other E2E SSH specs.
+ *   3. Asserts the xterm terminal renders — proving the client read runtime
+ *      config from the inert JSON block rather than the blocked inline script.
+ *   4. Asserts no app-originated CSP violations occurred (the one expected
+ *      violation — the blocked legacy `window.webssh2Config = null;` inline
+ *      script — is intentionally filtered out).
+ *   5. (Strong) Evaluates in-page that the JSON config block is populated with
+ *      a non-null object, confirming the JSON-block injection path works.
+ *
+ * Run requirements: ENABLE_E2E_SSH=1 plus the Docker/container SSH test server.
+ * Without those, the spec is skipped (same guard as the other E2E SSH specs).
+ *
+ * The webServer in playwright.config.ts sets WEBSSH2_CSP_MODE=enforce by
+ * default (overridable via E2E_CSP_MODE), so the entire E2E suite executes
+ * under the enforced CSP when ENABLE_E2E_SSH=1 is set.
+ */
+import { test, expect } from '@playwright/test'
+import {
+  SSH_HOST,
+  SSH_PORT,
+  USERNAME,
+  PASSWORD,
+  BASE_URL,
+  TIMEOUTS,
+} from './constants.js'
+import {
+  buildBasicAuthUrl,
+  waitForV2Connection,
+  waitForV2Terminal,
+} from './v2-helpers.js'
+
+const E2E_ENABLED = process.env.ENABLE_E2E_SSH === '1'
+
+test.describe('CSP enforcement — terminal boots from JSON config block (#546)', () => {
+  test.skip(!E2E_ENABLED, 'Set ENABLE_E2E_SSH=1 to run this test')
+
+  test(
+    'terminal renders and no app CSP violations fire under enforced CSP',
+    async ({ page }) => {
+      // Collect console messages that mention the CSP BEFORE navigation so
+      // we never miss an early violation.
+      const cspMessages: string[] = []
+      page.on('console', (msg) => {
+        if (/Content Security Policy/i.test(msg.text())) {
+          cspMessages.push(msg.text())
+        }
+      })
+
+      // Navigate using Basic Auth URL — same pattern as the other E2E SSH specs.
+      const url = buildBasicAuthUrl(BASE_URL, USERNAME, PASSWORD, SSH_HOST, SSH_PORT)
+      await page.goto(url)
+
+      // Wait for the WebSocket SSH connection to be established.
+      await waitForV2Connection(page)
+
+      // Wait for the xterm terminal to be visible and interactive.
+      // This assertion implicitly proves that the client correctly read runtime
+      // config from the inert JSON block: if the blocked inline script were the
+      // only config source, the app would fail to initialize and the terminal
+      // would never appear.
+      await waitForV2Terminal(page, TIMEOUTS.CONNECTION)
+
+      // The terminal canvas must be present in the DOM.
+      await expect(page.locator('.xterm-screen')).toBeVisible({ timeout: TIMEOUTS.CONNECTION })
+
+      // Assert no app-breaking CSP violations.
+      // The one benign/expected violation is the blocked legacy
+      // `window.webssh2Config = null;` inline script — filter it out so we
+      // only fail on genuine regressions in app-controlled code.
+      const appViolations = cspMessages.filter((m) => !/webssh2Config/i.test(m))
+      expect(appViolations).toEqual([])
+
+      // Strong assertion: evaluate in-page that the JSON config block exists
+      // and contains a non-null parsed object.  This is the authoritative proof
+      // that the server-side injection into the inert <script type="application/json">
+      // element worked and the client consumed it.
+      const blockOk = await page.evaluate(() => {
+        const el = document.getElementById('webssh2-config')
+        if (el === null) {
+          return false
+        }
+        try {
+          const parsed: unknown = JSON.parse(el.textContent)
+          return typeof parsed === 'object' && parsed !== null
+        } catch {
+          return false
+        }
+      })
+      expect(blockOk).toBe(true)
+    }
+  )
+})

--- a/tests/unit/config/config-schema.vitest.ts
+++ b/tests/unit/config/config-schema.vitest.ts
@@ -47,6 +47,23 @@ describe('csp config schema', () => {
     }
   })
 
+  it('falls back to the canonical path when reportUri is empty/whitespace', () => {
+    const cfg = {
+      ...createDefaultConfig(TEST_SECRET_123),
+      csp: {
+        mode: 'report-only',
+        reportUri: '   ',
+        connectSrc: [],
+        frameAncestors: ['none'],
+      },
+    }
+    const result = validateConfigSchema(cfg)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.csp.reportUri).toBe('/ssh/csp-report')
+    }
+  })
+
   it('default config with csp_violation rate-limit survives validation', () => {
     const cfg = createDefaultConfig(TEST_SECRET_123)
     const result = validateConfigSchema(cfg)

--- a/tests/unit/config/config-schema.vitest.ts
+++ b/tests/unit/config/config-schema.vitest.ts
@@ -1,0 +1,49 @@
+// tests/unit/config/config-schema.vitest.ts
+// Tests for CspSchema in the Zod config schema
+
+import { describe, it, expect } from 'vitest'
+import { validateConfigSchema } from '../../../app/utils/schema-validator.js'
+import { createDefaultConfig } from '../../../app/config/config-processor.js'
+import { TEST_SECRET_123 } from '../../test-constants.js'
+
+describe('csp config schema', () => {
+  it('preserves the csp section through validation (not stripped)', () => {
+    const cfg = createDefaultConfig(TEST_SECRET_123)
+    const result = validateConfigSchema(cfg)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.csp).toEqual({
+        mode: 'report-only',
+        reportUri: '/ssh/csp-report',
+        connectSrc: [],
+        frameAncestors: ['none'],
+      })
+    }
+  })
+
+  it('rejects an invalid csp.mode', () => {
+    const cfg = {
+      ...createDefaultConfig(TEST_SECRET_123),
+      csp: { mode: 'strict', reportUri: '/x', connectSrc: [], frameAncestors: ['none'] },
+    }
+    const result = validateConfigSchema(cfg)
+    expect(result.ok).toBe(false)
+  })
+
+  it('normalizes a trailing slash on reportUri', () => {
+    const cfg = {
+      ...createDefaultConfig(TEST_SECRET_123),
+      csp: {
+        mode: 'report-only',
+        reportUri: '/ssh/csp-report/',
+        connectSrc: [],
+        frameAncestors: ['none'],
+      },
+    }
+    const result = validateConfigSchema(cfg)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.csp.reportUri).toBe('/ssh/csp-report')
+    }
+  })
+})

--- a/tests/unit/config/config-schema.vitest.ts
+++ b/tests/unit/config/config-schema.vitest.ts
@@ -46,4 +46,14 @@ describe('csp config schema', () => {
       expect(result.value.csp.reportUri).toBe('/ssh/csp-report')
     }
   })
+
+  it('default config with csp_violation rate-limit survives validation', () => {
+    const cfg = createDefaultConfig(TEST_SECRET_123)
+    const result = validateConfigSchema(cfg)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const rules = result.value.logging?.controls?.rateLimit?.rules ?? []
+      expect(rules.some((r) => r.target === 'csp_violation' && r.limit === 60)).toBe(true)
+    }
+  })
 })

--- a/tests/unit/config/default-config.vitest.ts
+++ b/tests/unit/config/default-config.vitest.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_CONFIG_BASE } from '../../../app/config/default-config.js'
+
+describe('csp defaults', () => {
+  it('defaults to report-only with the canonical report path', () => {
+    expect(DEFAULT_CONFIG_BASE.csp).toEqual({
+      mode: 'report-only',
+      reportUri: '/ssh/csp-report',
+      connectSrc: [],
+      frameAncestors: ['none']
+    })
+  })
+})

--- a/tests/unit/config/default-config.vitest.ts
+++ b/tests/unit/config/default-config.vitest.ts
@@ -11,3 +11,10 @@ describe('csp defaults', () => {
     })
   })
 })
+
+describe('logging defaults', () => {
+  it('rate-limits csp_violation logs by default', () => {
+    const rules = DEFAULT_CONFIG_BASE.logging?.controls?.rateLimit?.rules ?? []
+    expect(rules).toContainEqual({ target: 'csp_violation', limit: 60, intervalMs: 60000 })
+  })
+})

--- a/tests/unit/config/env-mapper.vitest.ts
+++ b/tests/unit/config/env-mapper.vitest.ts
@@ -408,3 +408,18 @@ describe('mapEnvironmentVariables', () => {
     })
   })
 })
+
+describe('csp env mapping', () => {
+  it('maps WEBSSH2_CSP_* to the csp config path', () => {
+    const result = mapEnvironmentVariables({
+      WEBSSH2_CSP_MODE: 'enforce',
+      WEBSSH2_CSP_REPORT_URI: '/ssh/csp-report',
+      WEBSSH2_CSP_CONNECT_SRC: 'https://a.example:443,wss://a.example:443',
+      WEBSSH2_CSP_FRAME_ANCESTORS: 'self'
+    })
+    expect(result.csp?.mode).toBe('enforce')
+    expect(result.csp?.reportUri).toBe('/ssh/csp-report')
+    expect(result.csp?.connectSrc).toEqual(['https://a.example:443', 'wss://a.example:443'])
+    expect(result.csp?.frameAncestors).toEqual(['self'])
+  })
+})

--- a/tests/unit/config/env-mapper.vitest.ts
+++ b/tests/unit/config/env-mapper.vitest.ts
@@ -303,7 +303,7 @@ describe('mapEnvironmentVariables', () => {
       const env = {
         WEBSSH2_SSO_ENABLED: 'true',
         WEBSSH2_SSO_HEADER_USERNAME: 'X-Remote-User',
-        WEBSSH2_SSO_HEADER_PASSWORD: 'X-Remote-Password'
+        WEBSSH2_SSO_HEADER_PASSWORD: 'X-Remote-Password' // NOSONAR - HTTP header name, not a credential
       }
 
       const result = mapEnvironmentVariables(env)
@@ -313,7 +313,7 @@ describe('mapEnvironmentVariables', () => {
           enabled: true,
           headerMapping: {
             username: 'X-Remote-User',
-            password: 'X-Remote-Password'
+            password: 'X-Remote-Password' // NOSONAR - HTTP header name, not a credential
           }
         }
       })

--- a/tests/unit/logging/controls.vitest.ts
+++ b/tests/unit/logging/controls.vitest.ts
@@ -119,6 +119,21 @@ describe('evaluateLoggingControls', () => {
     expect(afterCooldown.updatedState.metrics.published).toBe(3)
   })
 
+  it('drops csp_violation beyond the configured limit within the interval', () => {
+    const config: LoggingControlsConfig = {
+      rateLimit: { rules: [{ target: 'csp_violation', limit: 2, intervalMs: 60000 }] }
+    }
+    let state = createLoggingControlState()
+    const run = (): boolean => {
+      const d = evaluateLoggingControls({ event: 'csp_violation', nowMs: 1000, config, state })
+      state = d.updatedState
+      return d.allow
+    }
+    expect(run()).toBe(true)
+    expect(run()).toBe(true)
+    expect(run()).toBe(false) // 3rd within interval dropped
+  })
+
   it('treats rate limit rules independently per event when specified', () => {
     const config: LoggingControlsConfig = {
       rateLimit: {

--- a/tests/unit/logging/event-catalog.vitest.ts
+++ b/tests/unit/logging/event-catalog.vitest.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { LOG_EVENT_NAMES, isLogEventName } from '../../../app/logging/event-catalog.js'
+
+describe('LOG_EVENT_NAMES', () => {
+  it('includes csp_violation as a registered log event name', () => {
+    expect((LOG_EVENT_NAMES as readonly string[]).includes('csp_violation')).toBe(true)
+  })
+
+  it('isLogEventName returns true for csp_violation', () => {
+    expect(isLogEventName('csp_violation')).toBe(true)
+  })
+})

--- a/tests/unit/security-headers.vitest.ts
+++ b/tests/unit/security-headers.vitest.ts
@@ -1,0 +1,360 @@
+// tests/unit/security-headers.vitest.ts
+// Unit tests for the tightened, config-driven CSP builder
+
+import { describe, it, expect, vi } from 'vitest'
+import request from 'supertest'
+import express, { type Application } from 'express'
+import { buildCspDirectives, cspHeaderValue, createSecurityHeadersMiddleware } from '../../app/security-headers.js'
+import * as connectSrc from '../../app/security/connect-src.js'
+import type { Config, CspConfig } from '../../app/types/config.js'
+import { HEADERS } from '../../app/constants/index.js'
+
+// ---------------------------------------------------------------------------
+// Config builder helpers
+// ---------------------------------------------------------------------------
+
+function makeCsp(over: Partial<CspConfig> = {}): CspConfig {
+  return {
+    mode: 'enforce',
+    reportUri: '/ssh/csp-report',
+    connectSrc: [],
+    frameAncestors: ['none'],
+    ...over,
+  }
+}
+
+function makeConfig(over: Partial<Config> = {}): Config {
+  return {
+    listen: { ip: '0.0.0.0', port: 2222 },
+    http: { origins: ['*:*'] },
+    user: { name: null, password: null, privateKey: null, passphrase: null },
+    ssh: {
+      host: null,
+      port: 22,
+      term: 'xterm-256color',
+      readyTimeout: 20_000,
+      keepaliveInterval: 120_000,
+      keepaliveCountMax: 10,
+      alwaysSendKeyboardInteractivePrompts: false,
+      disableInteractiveAuth: false,
+      algorithms: { cipher: [], compress: [], hmac: [], kex: [], serverHostKey: [] },
+      allowedAuthMethods: ['password', 'keyboard-interactive', 'publickey'],
+      hostKeyVerification: {
+        enabled: false,
+        mode: 'server',
+        unknownKeyAction: 'reject',
+        serverStore: { enabled: true, dbPath: '' },
+        clientStore: { enabled: false },
+      },
+    },
+    header: { text: null, background: null },
+    options: {
+      challengeButton: false,
+      autoLog: false,
+      allowReauth: false,
+      allowReconnect: false,
+      allowReplay: false,
+    },
+    session: { secret: 'test-secret', name: 'webssh2.sid' },
+    sso: {
+      enabled: false,
+      csrfProtection: false,
+      trustedProxies: [],
+      headerMapping: { username: 'x-user', password: 'x-pass', session: 'x-session' },
+    },
+    csp: makeCsp(),
+    ...over,
+  } as Config
+}
+
+// ---------------------------------------------------------------------------
+// buildCspDirectives
+// ---------------------------------------------------------------------------
+
+describe('buildCspDirectives', () => {
+  it("script-src is 'self' with no unsafe-inline", () => {
+    expect(buildCspDirectives(makeConfig(), true)['script-src']).toEqual(["'self'"])
+  })
+
+  it("style-src keeps 'unsafe-inline' (xterm needs it)", () => {
+    expect(buildCspDirectives(makeConfig(), true)['style-src']).toEqual(["'self'", "'unsafe-inline'"])
+  })
+
+  it("connect-src is 'self' only when CORS is wildcard", () => {
+    expect(buildCspDirectives(makeConfig(), true)['connect-src']).toEqual(["'self'"])
+  })
+
+  it('connect-src folds in concrete origins + csp.connectSrc extras', () => {
+    const cfg = makeConfig({
+      http: { origins: ['gw.example:8443'] },
+      csp: makeCsp({ connectSrc: ['https://x.example'] }),
+    })
+    const d = buildCspDirectives(cfg, true)
+    expect(d['connect-src']).toContain('wss://gw.example:8443')
+    expect(d['connect-src']).toContain('https://x.example')
+  })
+
+  it("base-uri 'none', object-src 'none'", () => {
+    const d = buildCspDirectives(makeConfig(), true)
+    expect(d['base-uri']).toEqual(["'none'"])
+    expect(d['object-src']).toEqual(["'none'"])
+  })
+
+  it("frame-ancestors follows config (none -> 'none', self -> 'self', list verbatim)", () => {
+    expect(
+      buildCspDirectives(makeConfig(), true)['frame-ancestors']
+    ).toEqual(["'none'"])
+
+    expect(
+      buildCspDirectives(makeConfig({ csp: makeCsp({ frameAncestors: ['self'] }) }), true)['frame-ancestors']
+    ).toEqual(["'self'"])
+
+    expect(
+      buildCspDirectives(makeConfig({ csp: makeCsp({ frameAncestors: ['https://embed.example'] }) }), true)[
+        'frame-ancestors'
+      ]
+    ).toEqual(['https://embed.example'])
+  })
+
+  it("empty frame-ancestors fails safe to 'none'", () => {
+    const d = buildCspDirectives(makeConfig({ csp: makeCsp({ frameAncestors: [] }) }), true)
+    expect(d['frame-ancestors']).toEqual(["'none'"])
+  })
+
+  it("empty frame-ancestors serializes to frame-ancestors 'none' (never a bare directive)", () => {
+    const d = buildCspDirectives(makeConfig({ csp: makeCsp({ frameAncestors: [] }) }), true)
+    const csp = cspHeaderValue(d)
+    expect(csp).toContain("frame-ancestors 'none'")
+    expect(csp).not.toMatch(/frame-ancestors\s*(;|$)/)
+  })
+
+  it('includes report-uri and report-to when mode != off, absent when off', () => {
+    const on = buildCspDirectives(makeConfig(), true)
+    expect(on['report-uri']).toEqual(['/ssh/csp-report'])
+    expect(on['report-to']).toEqual(['csp-endpoint'])
+
+    const off = buildCspDirectives(makeConfig({ csp: makeCsp({ mode: 'off' }) }), true)
+    expect(off['report-uri']).toBeUndefined()
+    expect(off['report-to']).toBeUndefined()
+  })
+
+  it('includes report directives in report-only mode', () => {
+    const d = buildCspDirectives(makeConfig({ csp: makeCsp({ mode: 'report-only' }) }), true)
+    expect(d['report-uri']).toEqual(['/ssh/csp-report'])
+    expect(d['report-to']).toEqual(['csp-endpoint'])
+  })
+
+  it('does not include ws:// sources when secure=true', () => {
+    const cfg = makeConfig({
+      http: { origins: ['host.example:8443'] },
+      csp: makeCsp(),
+    })
+    const d = buildCspDirectives(cfg, true)
+    expect(d['connect-src']).not.toContain('ws://host.example:8443')
+    expect(d['connect-src']).not.toContain('http://host.example:8443')
+  })
+
+  it('includes ws:// and http:// sources when secure=false', () => {
+    const cfg = makeConfig({
+      http: { origins: ['host.example:8080'] },
+      csp: makeCsp(),
+    })
+    const d = buildCspDirectives(cfg, false)
+    expect(d['connect-src']).toContain('ws://host.example:8080')
+    expect(d['connect-src']).toContain('http://host.example:8080')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// cspHeaderValue
+// ---------------------------------------------------------------------------
+
+describe('cspHeaderValue', () => {
+  it('serializes directives in order', () => {
+    expect(
+      cspHeaderValue({ 'default-src': ["'self'"], 'object-src': ["'none'"] })
+    ).toBe("default-src 'self'; object-src 'none'")
+  })
+
+  it('handles multiple values per directive', () => {
+    expect(
+      cspHeaderValue({ 'connect-src': ["'self'", 'wss://example.com'] })
+    ).toBe("connect-src 'self' wss://example.com")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Middleware integration (CSP header name + Reporting-Endpoints)
+// ---------------------------------------------------------------------------
+
+function makeApp(cfg: Config): Application {
+  const app = express()
+  app.use(createSecurityHeadersMiddleware(cfg))
+  app.get('/ping', (_req, res) => {
+    res.status(200).json({ ok: true })
+  })
+  return app
+}
+
+describe('createSecurityHeadersMiddleware CSP header selection', () => {
+  it('mode=report-only → Content-Security-Policy-Report-Only present, not enforce header', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ mode: 'report-only' }) }))
+    const res = await request(app).get('/ping')
+    expect(res.headers[HEADERS.CONTENT_SECURITY_POLICY_REPORT_ONLY.toLowerCase()]).toBeDefined()
+    expect(res.headers[HEADERS.CONTENT_SECURITY_POLICY.toLowerCase()]).toBeUndefined()
+  })
+
+  it('mode=report-only → Reporting-Endpoints header contains csp-endpoint', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ mode: 'report-only', reportUri: '/ssh/csp-report' }) }))
+    const res = await request(app).get('/ping')
+    const reportingHeader = res.headers[HEADERS.REPORTING_ENDPOINTS.toLowerCase()]
+    expect(reportingHeader).toBeDefined()
+    expect(reportingHeader).toContain('csp-endpoint=')
+    expect(reportingHeader).toContain('/ssh/csp-report')
+  })
+
+  it('mode=enforce → Content-Security-Policy present, not report-only header', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ mode: 'enforce' }) }))
+    const res = await request(app).get('/ping')
+    expect(res.headers[HEADERS.CONTENT_SECURITY_POLICY.toLowerCase()]).toBeDefined()
+    expect(res.headers[HEADERS.CONTENT_SECURITY_POLICY_REPORT_ONLY.toLowerCase()]).toBeUndefined()
+  })
+
+  it('mode=enforce → Reporting-Endpoints header present with csp-endpoint', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ mode: 'enforce', reportUri: '/ssh/csp-report' }) }))
+    const res = await request(app).get('/ping')
+    expect(res.headers[HEADERS.REPORTING_ENDPOINTS.toLowerCase()]).toBe('csp-endpoint="/ssh/csp-report"')
+  })
+
+  it('mode=off → neither CSP header present', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ mode: 'off' }) }))
+    const res = await request(app).get('/ping')
+    expect(res.headers[HEADERS.CONTENT_SECURITY_POLICY.toLowerCase()]).toBeUndefined()
+    expect(res.headers[HEADERS.CONTENT_SECURITY_POLICY_REPORT_ONLY.toLowerCase()]).toBeUndefined()
+  })
+
+  it('mode=off → Reporting-Endpoints not present', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ mode: 'off' }) }))
+    const res = await request(app).get('/ping')
+    expect(res.headers[HEADERS.REPORTING_ENDPOINTS.toLowerCase()]).toBeUndefined()
+  })
+
+  it('tightened CSP does not contain unsafe-inline in script-src', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ mode: 'enforce' }) }))
+    const res = await request(app).get('/ping')
+    const csp = res.headers[HEADERS.CONTENT_SECURITY_POLICY.toLowerCase()] as string
+    const scriptSrc = csp.split(';').find((d) => d.trim().startsWith('script-src'))
+    expect(scriptSrc).toBeDefined()
+    expect(scriptSrc).not.toContain('unsafe-inline')
+  })
+
+  it('tightened CSP does not contain bare ws: or wss: wildcards in connect-src', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ mode: 'enforce' }) }))
+    const res = await request(app).get('/ping')
+    const csp = res.headers[HEADERS.CONTENT_SECURITY_POLICY.toLowerCase()] as string
+    const connectDirective = csp.split(';').find((d) => d.trim().startsWith('connect-src'))
+    expect(connectDirective).toBeDefined()
+    // Should not have bare scheme wildcards like "ws:" or "wss:" without a host
+    expect(connectDirective).not.toMatch(/\bwss?:\s/)
+    expect(connectDirective).not.toMatch(/\bwss?:$/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// X-Frame-Options consistency with frame-ancestors
+// ---------------------------------------------------------------------------
+
+describe('X-Frame-Options derived from frame-ancestors', () => {
+  it("frame-ancestors=['none'] → X-Frame-Options: DENY", async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ frameAncestors: ['none'] }) }))
+    const res = await request(app).get('/ping')
+    expect(res.headers['x-frame-options']).toBe('DENY')
+  })
+
+  it("frame-ancestors=['self'] → X-Frame-Options: SAMEORIGIN", async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ frameAncestors: ['self'] }) }))
+    const res = await request(app).get('/ping')
+    expect(res.headers['x-frame-options']).toBe('SAMEORIGIN')
+  })
+
+  it('frame-ancestors with explicit origin → X-Frame-Options omitted', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ frameAncestors: ['https://embed.example'] }) }))
+    const res = await request(app).get('/ping')
+    expect(res.headers['x-frame-options']).toBeUndefined()
+  })
+
+  it('empty frame-ancestors fails safe to X-Frame-Options: DENY', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ frameAncestors: [] }) }))
+    const res = await request(app).get('/ping')
+    expect(res.headers['x-frame-options']).toBe('DENY')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SSO form-action adjustment
+// ---------------------------------------------------------------------------
+
+describe('SSO form-action adjustment', () => {
+  it('appends https: to form-action when SSO enabled with trustedProxies', async () => {
+    const cfg = makeConfig({
+      sso: {
+        enabled: true,
+        csrfProtection: false,
+        trustedProxies: ['10.0.0.0/8'],
+        headerMapping: { username: 'x-user', password: 'x-pass', session: 'x-session' },
+      },
+    })
+    const app = makeApp(cfg)
+    const res = await request(app).get('/ping')
+    const csp = res.headers[HEADERS.CONTENT_SECURITY_POLICY.toLowerCase()] as string
+    const formAction = csp.split(';').find((d) => d.trim().startsWith('form-action'))
+    expect(formAction).toContain("'self'")
+    expect(formAction).toContain('https:')
+  })
+
+  it('form-action stays self-only when SSO disabled', async () => {
+    const app = makeApp(makeConfig())
+    const res = await request(app).get('/ping')
+    const csp = res.headers[HEADERS.CONTENT_SECURITY_POLICY.toLowerCase()] as string
+    const formAction = csp.split(';').find((d) => d.trim().startsWith('form-action'))
+    expect(formAction).toContain("'self'")
+    expect(formAction).not.toContain('https:')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Memoization guard: middleware does not rebuild CSP per request
+// ---------------------------------------------------------------------------
+
+describe('CSP memoization', () => {
+  it('returns identical CSP string on successive requests (proves precomputed, not rebuilt)', async () => {
+    const app = makeApp(makeConfig({ csp: makeCsp({ mode: 'enforce' }) }))
+    const [r1, r2] = await Promise.all([request(app).get('/ping'), request(app).get('/ping')])
+    const header = HEADERS.CONTENT_SECURITY_POLICY.toLowerCase()
+    expect(r1.headers[header]).toBe(r2.headers[header])
+  })
+
+  // Spy on the cross-module dependency deriveConnectSrc (imported by
+  // buildCspDirectives from ./security/connect-src.js) so vi.spyOn can
+  // intercept it. Spying on the module's own buildCspDirectives would not work
+  // because its internal call uses the local binding, not the module export.
+  it('precomputes the CSP once at construction, never per-request', () => {
+    const spy = vi.spyOn(connectSrc, 'deriveConnectSrc')
+    try {
+      const mw = createSecurityHeadersMiddleware(makeConfig({ csp: makeCsp({ mode: 'enforce' }) }))
+      // Built once for secure=true and once for secure=false at construction.
+      expect(spy).toHaveBeenCalledTimes(2)
+
+      spy.mockClear()
+      const res = { setHeader: vi.fn() } as unknown as Parameters<typeof mw>[1]
+      const secureReq = { secure: true, method: 'GET', url: '/ping' } as unknown as Parameters<typeof mw>[0]
+      const insecureReq = { secure: false, method: 'GET', url: '/ping' } as unknown as Parameters<typeof mw>[0]
+      mw(secureReq, res, vi.fn())
+      mw(insecureReq, res, vi.fn())
+      // No rebuild per request — handler only reads closed-over strings.
+      expect(spy).toHaveBeenCalledTimes(0)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})

--- a/tests/unit/security-posture.vitest.ts
+++ b/tests/unit/security-posture.vitest.ts
@@ -21,16 +21,19 @@ function createHardenedConfig(): Config {
   if (config.telnet !== undefined) {
     config.telnet.allowedSubnets = [TEST_SUBNETS.PRIVATE_10]
   }
+  config.csp.mode = 'enforce'
+  config.http.origins = ['gw.example:443']
   return config
 }
 
 describe('auditSecurityPosture', () => {
-  it('flags host key verification and ssh subnets on the default config', () => {
+  it('flags host key verification, ssh subnets, and non-enforced CSP on the default config', () => {
     const warnings = auditSecurityPosture(createDefaultConfig())
 
-    expect(warnings).toHaveLength(2)
+    expect(warnings).toHaveLength(3)
     expect(findWarning(warnings, 'host_key_verification_disabled')).toBeDefined()
     expect(findWarning(warnings, 'ssh_allowed_subnets_empty')).toBeDefined()
+    expect(findWarning(warnings, 'csp_not_enforced')).toBeDefined()
   })
 
   it('does not flag telnet subnets when telnet is disabled (default)', () => {
@@ -151,5 +154,77 @@ describe('auditSecurityPosture', () => {
     expect(telnetSubnets?.configKey).toBe('telnet.allowedSubnets')
     expect(telnetSubnets?.message).toContain('telnet.allowedSubnets')
     expect(telnetSubnets?.remediation).toContain('telnet.allowedSubnets')
+  })
+})
+
+describe('csp posture warnings', () => {
+  it('warns when csp.mode is not enforce (report-only default is non-enforcing)', () => {
+    const config = createDefaultConfig()
+    config.ssh.hostKeyVerification.enabled = true
+    config.ssh.allowedSubnets = [TEST_SUBNETS.PRIVATE_10]
+    // leave csp.mode at default 'report-only'
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(warnings.some((w) => w.check === 'csp_not_enforced')).toBe(true)
+  })
+
+  it('warns when enforce is combined with wildcard http.origins', () => {
+    const config = createDefaultConfig()
+    config.ssh.hostKeyVerification.enabled = true
+    config.ssh.allowedSubnets = [TEST_SUBNETS.PRIVATE_10]
+    config.http.origins = ['*:*']
+    config.csp.mode = 'enforce'
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(warnings.some((w) => w.check === 'csp_connect_src_wildcard')).toBe(true)
+  })
+
+  it('no csp warnings when enforce + concrete origins', () => {
+    const config = createDefaultConfig()
+    config.ssh.hostKeyVerification.enabled = true
+    config.ssh.allowedSubnets = [TEST_SUBNETS.PRIVATE_10]
+    config.http.origins = ['gw.example:443']
+    config.csp.mode = 'enforce'
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(warnings.some((w) => w.check.startsWith('csp_'))).toBe(false)
+  })
+
+  it('does not warn csp_not_enforced when mode is enforce', () => {
+    const config = createDefaultConfig()
+    config.ssh.hostKeyVerification.enabled = true
+    config.ssh.allowedSubnets = [TEST_SUBNETS.PRIVATE_10]
+    config.http.origins = ['gw.example:443']
+    config.csp.mode = 'enforce'
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(warnings.some((w) => w.check === 'csp_not_enforced')).toBe(false)
+  })
+
+  it('warns csp_not_enforced when mode is off', () => {
+    const config = createDefaultConfig()
+    config.ssh.hostKeyVerification.enabled = true
+    config.ssh.allowedSubnets = [TEST_SUBNETS.PRIVATE_10]
+    config.csp.mode = 'off'
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(warnings.some((w) => w.check === 'csp_not_enforced')).toBe(true)
+  })
+
+  it('does not warn csp_connect_src_wildcard when mode is report-only (even with wildcard origins)', () => {
+    const config = createDefaultConfig()
+    config.ssh.hostKeyVerification.enabled = true
+    config.ssh.allowedSubnets = [TEST_SUBNETS.PRIVATE_10]
+    config.http.origins = ['*:*']
+    config.csp.mode = 'report-only'
+
+    const warnings = auditSecurityPosture(config)
+
+    expect(warnings.some((w) => w.check === 'csp_connect_src_wildcard')).toBe(false)
   })
 })

--- a/tests/unit/security-posture.vitest.ts
+++ b/tests/unit/security-posture.vitest.ts
@@ -205,7 +205,7 @@ describe('csp posture warnings', () => {
     expect(warnings.some((w) => w.check === 'csp_not_enforced')).toBe(false)
   })
 
-  it('warns csp_not_enforced when mode is off', () => {
+  it('warns csp_disabled (not csp_not_enforced) when mode is off', () => {
     const config = createDefaultConfig()
     config.ssh.hostKeyVerification.enabled = true
     config.ssh.allowedSubnets = [TEST_SUBNETS.PRIVATE_10]
@@ -213,7 +213,8 @@ describe('csp posture warnings', () => {
 
     const warnings = auditSecurityPosture(config)
 
-    expect(warnings.some((w) => w.check === 'csp_not_enforced')).toBe(true)
+    expect(warnings.some((w) => w.check === 'csp_disabled')).toBe(true)
+    expect(warnings.some((w) => w.check === 'csp_not_enforced')).toBe(false)
   })
 
   it('does not warn csp_connect_src_wildcard when mode is report-only (even with wildcard origins)', () => {

--- a/tests/unit/security/connect-src.vitest.ts
+++ b/tests/unit/security/connect-src.vitest.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { deriveConnectSrc } from '../../../app/security/connect-src.js'
+
+describe('deriveConnectSrc', () => {
+  it("always includes 'self' and excludes wildcard CORS origins", () => {
+    const r = deriveConnectSrc(['*:*'], [], true)
+    expect(r.sources).toEqual(["'self'"])
+    expect(r.wildcard).toBe(true)
+  })
+
+  it('translates a concrete host:port origin to wss+https sources', () => {
+    const r = deriveConnectSrc(['gw.example:8443'], [], true)
+    expect(r.sources).toEqual(["'self'", 'https://gw.example:8443', 'wss://gw.example:8443'])
+    expect(r.wildcard).toBe(false)
+  })
+
+  it('adds ws/http variants for non-secure deployments', () => {
+    const r = deriveConnectSrc(['gw.example:8080'], [], false)
+    expect(r.sources).toContain('ws://gw.example:8080')
+    expect(r.sources).toContain('http://gw.example:8080')
+  })
+
+  it('passes through an origin that already has a scheme', () => {
+    const r = deriveConnectSrc(['https://gw.example'], [], true)
+    expect(r.sources).toContain('https://gw.example')
+  })
+
+  it('appends operator extras and de-duplicates', () => {
+    const r = deriveConnectSrc(['gw.example:8443'], ['wss://gw.example:8443', 'https://x.example'], true)
+    expect(r.sources.filter((s) => s === 'wss://gw.example:8443')).toHaveLength(1)
+    expect(r.sources).toContain('https://x.example')
+  })
+
+  it('never emits a raw *:* token', () => {
+    const r = deriveConnectSrc(['*:*', 'gw.example:8443'], [], true)
+    expect(r.sources).not.toContain('*:*')
+    expect(r.wildcard).toBe(true)
+  })
+
+  it('drops every wildcard variant, leaving only self', () => {
+    const r = deriveConnectSrc(['*:*', '*', '*.foo.com'], [], true)
+    expect(r.sources).toEqual(["'self'"])
+    expect(r.wildcard).toBe(true)
+  })
+
+  it('skips empty-string and whitespace-only CORS origins', () => {
+    const empty = deriveConnectSrc([''], [], true)
+    expect(empty.sources).toEqual(["'self'"])
+    expect(empty.wildcard).toBe(false)
+
+    const blank = deriveConnectSrc(['   '], [], true)
+    expect(blank.sources).toEqual(["'self'"])
+    expect(blank.wildcard).toBe(false)
+  })
+
+  it('drops a bare wildcard and flags it', () => {
+    const r = deriveConnectSrc(['*'], [], true)
+    expect(r.sources).toEqual(["'self'"])
+    expect(r.wildcard).toBe(true)
+  })
+
+  it('rejects a non-network scheme origin', () => {
+    const r = deriveConnectSrc(['javascript://evil'], [], true)
+    expect(r.sources).not.toContain('javascript://evil')
+    expect(r.sources).toEqual(["'self'"])
+  })
+
+  it('passes operator extras through verbatim, including intentional wildcards', () => {
+    const r = deriveConnectSrc([], ['*.internal.example'], true)
+    expect(r.sources).toContain('*.internal.example')
+    expect(r.wildcard).toBe(false)
+  })
+
+  it('drops a CORS origin containing CR/LF control chars', () => {
+    const r = deriveConnectSrc(['host.example:8080\r\nX: y'], [], true)
+    expect(r.sources).not.toContain('host.example:8080\r\nX: y')
+    expect(r.sources).toEqual(["'self'"])
+  })
+})

--- a/tests/unit/security/csp-report.vitest.ts
+++ b/tests/unit/security/csp-report.vitest.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { extractCspReport } from '../../../app/security/csp-report.js'
+
+describe('extractCspReport', () => {
+  it('extracts whitelisted fields from a legacy csp-report body', () => {
+    const r = extractCspReport({
+      'csp-report': {
+        'document-uri': 'https://gw/ssh',
+        'violated-directive': 'script-src',
+        'blocked-uri': 'inline',
+        disposition: 'enforce',
+        'script-sample': 'window.webssh2Config = null;'
+      }
+    })
+    expect(r).toMatchObject({
+      directive: 'script-src',
+      blockedUri: 'inline',
+      disposition: 'enforce',
+      documentUri: 'https://gw/ssh'
+    })
+  })
+
+  it('supports the Reporting-API body shape ({ body: {...} })', () => {
+    const r = extractCspReport({ body: { effectiveDirective: 'img-src', blockedURL: 'https://x', documentURL: 'https://gw' } })
+    expect(r.directive).toBe('img-src')
+    expect(r.blockedUri).toBe('https://x')
+    expect(r.documentUri).toBe('https://gw')
+  })
+
+  it('strips CR/LF/control chars to prevent log forging', () => {
+    const r = extractCspReport({ 'csp-report': { 'blocked-uri': 'a\r\nFAKE LOG LINE' } })
+    expect(r.blockedUri).toBe('aFAKE LOG LINE')
+  })
+
+  it('truncates over-long fields', () => {
+    const long = 'x'.repeat(2000)
+    const r = extractCspReport({ 'csp-report': { 'document-uri': long } })
+    expect(r.documentUri!.length).toBe(512)
+  })
+
+  it('truncates script-sample to 80 chars', () => {
+    const r = extractCspReport({ 'csp-report': { 'script-sample': 'y'.repeat(500) } })
+    expect(r.scriptSample!.length).toBe(80)
+  })
+
+  it('ignores non-string fields', () => {
+    const r = extractCspReport({ 'csp-report': { 'blocked-uri': { nested: 'obj' }, 'document-uri': 123 } })
+    expect(r.blockedUri).toBeUndefined()
+    expect(r.documentUri).toBeUndefined()
+  })
+
+  it('returns empty object for non-object / missing report', () => {
+    expect(extractCspReport(null)).toEqual({})
+    expect(extractCspReport(undefined)).toEqual({})
+    expect(extractCspReport('string')).toEqual({})
+    expect(extractCspReport([])).toEqual({})
+    expect(extractCspReport({})).toEqual({})
+  })
+})

--- a/tests/unit/security/rate-limiter.vitest.ts
+++ b/tests/unit/security/rate-limiter.vitest.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { createRateLimiter } from '../../../app/security/rate-limiter.js'
+
+describe('createRateLimiter', () => {
+  it('allows up to capacity then blocks within the window', () => {
+    const limiter = createRateLimiter({ capacity: 3, refillPerSec: 0, maxKeys: 100 })
+    const t = 1000
+    expect(limiter.allow('ip1', t)).toBe(true)
+    expect(limiter.allow('ip1', t)).toBe(true)
+    expect(limiter.allow('ip1', t)).toBe(true)
+    expect(limiter.allow('ip1', t)).toBe(false)
+  })
+
+  it('refills over time', () => {
+    const limiter = createRateLimiter({ capacity: 1, refillPerSec: 1, maxKeys: 100 })
+    expect(limiter.allow('ip1', 0)).toBe(true)
+    expect(limiter.allow('ip1', 0)).toBe(false)
+    expect(limiter.allow('ip1', 1000)).toBe(true)
+  })
+
+  it('does not exceed capacity when refilling', () => {
+    const limiter = createRateLimiter({ capacity: 2, refillPerSec: 100, maxKeys: 100 })
+    // long idle would overfill a naive impl; cap at capacity
+    expect(limiter.allow('ip1', 0)).toBe(true)
+    expect(limiter.allow('ip1', 100000)).toBe(true)
+    expect(limiter.allow('ip1', 100000)).toBe(true)
+    expect(limiter.allow('ip1', 100000)).toBe(false) // only `capacity` tokens, not thousands
+  })
+
+  it('isolates keys', () => {
+    const limiter = createRateLimiter({ capacity: 1, refillPerSec: 0, maxKeys: 100 })
+    expect(limiter.allow('a', 0)).toBe(true)
+    expect(limiter.allow('b', 0)).toBe(true)
+  })
+
+  it('evicts the oldest key when maxKeys is exceeded (bounds memory)', () => {
+    const limiter = createRateLimiter({ capacity: 1, refillPerSec: 0, maxKeys: 2 })
+    limiter.allow('a', 0)
+    limiter.allow('b', 1)
+    limiter.allow('c', 2) // evicts oldest ('a')
+    expect(limiter.size()).toBeLessThanOrEqual(2)
+  })
+})

--- a/tests/unit/socket/service-socket-adapter.vitest.ts
+++ b/tests/unit/socket/service-socket-adapter.vitest.ts
@@ -172,6 +172,12 @@ const createConfig = (): Config => ({
       password: SSO_PASSWORD_HEADER,
       session: 'x-session'
     }
+  },
+  csp: {
+    mode: 'report-only',
+    reportUri: '/ssh/csp-report',
+    connectSrc: [],
+    frameAncestors: ['none']
   }
 })
 

--- a/tests/unit/utils/html-transformer.vitest.ts
+++ b/tests/unit/utils/html-transformer.vitest.ts
@@ -159,3 +159,58 @@ describe('injectConfigWithThemingString', () => {
     expect(html).toBe('<script>console.log("noop")</script>')
   })
 })
+
+describe('JSON config block injection', () => {
+  const NEW_CLIENT_HTML =
+    '<script type="application/json" id="webssh2-config">null</script>\n' +
+    '<script>window.webssh2Config = null;</script>'
+
+  it('injects config into the JSON block as a parseable object', () => {
+    const result = injectConfig(NEW_CLIENT_HTML, { a: 1, nested: { b: 'x' } })
+    const match =
+      /<script type="application\/json" id="webssh2-config">(.*?)<\/script>/s.exec(result)
+    expect(match).not.toBeNull()
+    expect(JSON.parse(match![1])).toEqual({ a: 1, nested: { b: 'x' } })
+  })
+
+  it('also replaces the legacy window placeholder on a new-client template', () => {
+    const result = injectConfig(NEW_CLIENT_HTML, { a: 1 })
+    expect(result).toContain('window.webssh2Config = {"a":1};')
+    expect(result).not.toContain('window.webssh2Config = null;')
+  })
+
+  it('is a no-op for the JSON block on an old-client template (legacy still replaced)', () => {
+    const oldClient = '<script>window.webssh2Config = null;</script>'
+    const result = injectConfig(oldClient, { a: 1 })
+    expect(result).toBe('<script>window.webssh2Config = {"a":1};</script>')
+  })
+
+  it('hard XSS gate: attacker header.text cannot break out of the JSON block', () => {
+    const evil = { header: { text: '</script><img src=x onerror=alert(1)>' } }
+    const result = injectConfig(NEW_CLIENT_HTML, evil)
+    expect(result.toLowerCase()).not.toContain('</script><img')
+    const match =
+      /<script type="application\/json" id="webssh2-config">(.*?)<\/script>/s.exec(result)
+    expect(JSON.parse(match![1])).toEqual(evil)
+  })
+
+  it('escapes U+2028 / U+2029 inside the JSON block', () => {
+    const result = injectConfig(NEW_CLIENT_HTML, { s: '\u2028\u2029' })
+    const match =
+      /<script type="application\/json" id="webssh2-config">(.*?)<\/script>/s.exec(result)
+    expect(match![1]).toContain('\\u2028')
+    expect(match![1]).toContain('\\u2029')
+    expect(JSON.parse(match![1])).toEqual({ s: '\u2028\u2029' })
+  })
+
+  it('merges theming into the JSON block too', () => {
+    const result = injectConfigWithThemingString(
+      NEW_CLIENT_HTML,
+      { a: 1 },
+      '{"enabled":false}'
+    )
+    const match =
+      /<script type="application\/json" id="webssh2-config">(.*?)<\/script>/s.exec(result)
+    expect(JSON.parse(match![1])).toEqual({ a: 1, theming: { enabled: false } })
+  })
+})


### PR DESCRIPTION
## Summary

Implements issue #546: adopt the client's CSP-compatible JSON config-block injection, then ship a tightened, config-toggled Content-Security-Policy with a hardened violation-report endpoint. Phase 3 (removing the legacy inline script) is intentionally deferred to a future major.

**Phase 1 — JSON config-block injection**

- Inject runtime config into the inert `<script type="application/json" id="webssh2-config">` block the client reads at startup (survives a strict `script-src 'self'`), keeping the legacy `<script>window.webssh2Config = ...</script>` as a transition fallback.
- Single `serializeConfig` escape helper is the one XSS trust boundary (`<` → `<`, U+2028/U+2029); `theming-injection` delegates to it.
- Bump bundled `webssh2_client` to `^5.1.0`; document the JSON block contract and deprecate the inline-script method.

**Phase 2 — tightened, config-toggled CSP**

- New `csp` config section (`mode` `off` | `report-only` | `enforce`, default `report-only`; `reportUri`; `connectSrc`; `frameAncestors`) with `WEBSSH2_CSP_*` env vars and Zod validation.
- Tightened policy: `script-src 'self'` (drops `'unsafe-inline'`), `style-src 'self' 'unsafe-inline'` (xterm), `object-src 'none'`, `base-uri 'none'`; `connect-src` derived from `'self'` + non-wildcard `http.origins` + `csp.connectSrc` (the default `*:*` CORS wildcard is never emitted into CSP); `frame-ancestors` from config with consistent `X-Frame-Options`.
- Memoized per-mode middleware (`Content-Security-Policy` / `-Report-Only` / none); `report-uri` + `report-to` + `Reporting-Endpoints`.
- Boot `security_posture` warnings when CSP is not enforced and when `enforce` is combined with wildcard CORS.
- Hardened unauthenticated `POST /ssh/csp-report`: per-IP token-bucket throttle **before** parsing, dedicated 8 KB multi-type body parser, always returns empty `204` + `no-store` (oversized → 204, not 413), sanitized whitelist-only `csp_violation` structured event (`subsystem: security`), default 60/min log rate-limit, expected legacy-inline violation demoted to debug.

## Red-team

All 13 findings from the 2026-06-16 adversarial review are addressed and confirmed by a final holistic review: S1–S6, DoW1–2, A1–3, P1–2.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 1652 tests pass
- [x] `npm run build` — clean
- [x] Runtime: `curl -sD - http://127.0.0.1:2288/ssh/config` shows `Content-Security-Policy-Report-Only: ... script-src 'self' ...` (no `unsafe-inline`) and `Reporting-Endpoints`, and the `csp_not_enforced` boot warning is logged
- [x] E2E (CI/Docker): `npx playwright test tests/playwright/csp-enforce.spec.ts` — terminal boots under enforced CSP from the JSON config block

Closes #546.
