### PR TITLE
chore: add markdownlint config and declare code-fence languages

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,23 @@
+{
+  // Repo markdownlint config. Scoped to the rules worth enforcing on the
+  // existing docs so the VS Code extension, the CLI, and the global
+  // pre-commit hook (markdownlint-cli2 --fix) all agree.
+  //
+  // "default": false keeps the existing docs from being flagged en masse for
+  // rules they were never authored against. Notable rules left OFF:
+  //   - MD013 (line length): prose/tables are not hard-wrapped here.
+  //   - MD060 (table column style): the docs use aligned/padded tables and
+  //     MD060 has no auto-fixer in this version, so enforcing it would mean
+  //     hand-reformatting every table. Re-enable + reformat as a separate
+  //     pass if compact tables are wanted.
+  "config": {
+    "default": false,
+    // Allow repeated headings as long as they live under different parents
+    // (e.g. per-CVE "Exposure assessment" / "References" sections).
+    "MD024": { "siblings_only": true },
+    // Fenced code blocks must declare a language.
+    "MD040": true
+  },
+  "globs": ["**/*.md"],
+  "ignores": ["node_modules", "dist", "coverage", "CHANGELOG.md", ".private-docs"]
+}

--- a/DOCS/CONTAINER.md
+++ b/DOCS/CONTAINER.md
@@ -7,7 +7,7 @@ Examples include the nginx-webssh2 project or custom container images.
 
 After downloading and extracting `webssh2-<version>.tar.gz`, the release root contains:
 
-```
+```text
 ./dist/
 ./manifest.json
 ./package.json

--- a/DOCS/archive/WebSSH2-BasicAuth-Flow-Analysis.md
+++ b/DOCS/archive/WebSSH2-BasicAuth-Flow-Analysis.md
@@ -91,12 +91,12 @@ sequenceDiagram
 ## Basic Auth URL Patterns
 
 ### Standard Basic Auth URL
-```
+```text
 http://username:password@host:port/ssh/host/target?port=sshport
 ```
 
 ### With Additional Parameters
-```
+```text
 http://username:password@host:port/ssh/host/target?port=sshport&sshterm=xterm-256color&rows=50&cols=120
 ```
 

--- a/DOCS/client/KEYBOARD_CAPTURE.md
+++ b/DOCS/client/KEYBOARD_CAPTURE.md
@@ -54,7 +54,7 @@ The Keyboard Capture feature provides three levels of control:
 **Use Case**: Essential for tmux users and anyone using vim, emacs, or other editors that rely on Escape.
 
 **Example**:
-```
+```text
 When enabled:
 - Pressing ESC in vim → exits insert mode (✓)
 - Pressing ESC in search → goes to terminal (not search close)
@@ -72,7 +72,7 @@ When enabled:
 **Use Case**: Critical for tmux users (default prefix key) and tmux workflows.
 
 **Example**:
-```
+```text
 When enabled:
 - Ctrl+B → sent to tmux as prefix key (✓)
 - Browser bookmarks can be accessed via browser menu or Alt+D → Ctrl+B
@@ -85,7 +85,7 @@ When enabled:
 **Format**: Comma-separated list of key combinations.
 
 **Examples**:
-```
+```text
 F11                    → Full-screen toggle
 Ctrl+T                 → Browser new tab
 Alt+D                  → Browser address bar
@@ -116,7 +116,7 @@ The keyboard capture system operates at the event handler level:
 
 Implementation files in `webssh2_client`:
 
-```
+```text
 client/src/
 ├── types/config.d.ts                          # KeyboardCaptureSettings interface
 ├── utils/keyboard-capture.ts                  # Core capture logic
@@ -226,7 +226,7 @@ Settings are **browser-specific** and stored in localStorage. If you use WebSSH2
 **Scenario**: Developer using multiple conflicting shortcuts.
 
 **Configuration**:
-```
+```text
 Capture Escape: Enabled
 Capture Ctrl+B: Enabled
 Custom Keys: F11, Ctrl+T, Ctrl+Shift+N, Alt+D
@@ -337,7 +337,7 @@ localStorage.debug = 'webssh2-client:keyboard-capture'
 
 ### Debug Output Examples
 
-```
+```text
 webssh2-client:keyboard-capture Capturing Escape key for terminal +0ms
 webssh2-client:keyboard-capture Capturing Ctrl+B for terminal +150ms
 webssh2-client:keyboard-capture Capturing custom key "F11" for terminal +300ms

--- a/DOCS/client/KEYBOARD_CAPTURE_SUMMARY.md
+++ b/DOCS/client/KEYBOARD_CAPTURE_SUMMARY.md
@@ -18,21 +18,21 @@ Control which keyboard events are sent to the terminal vs. handled by the web UI
 ### Common Configurations
 
 **General terminal Users**:
-```
+```text
 ☑ Capture Escape: Enabled
 ☐ Capture Ctrl+B: Disabled
 Custom Keys: (leave empty)
 ```
 
 **For tmux Users**:
-```
+```text
 ☐ Capture Escape: Disabled
 ☑ Capture Ctrl+B: Enabled
 Custom Keys: (leave empty)
 ```
 
 **For Power Users**:
-```
+```text
 ☑ Capture Escape: Enabled
 ☑ Capture Ctrl+B: Enabled
 Custom Keys: F11, Ctrl+T, Alt+D
@@ -54,7 +54,7 @@ Custom Keys: F11, Ctrl+T, Alt+D
 
 ## Examples
 
-```
+```text
 F11                    → Capture F11 key
 Ctrl+T                 → Capture Ctrl+T (new tab)
 Alt+D                  → Capture Alt+D (address bar)

--- a/DOCS/client/README.md
+++ b/DOCS/client/README.md
@@ -54,7 +54,7 @@ The WebSSH2 client is built with:
 
 ### Key Components
 
-```
+```text
 webssh2_client/client/src/
 ├── app.tsx                          # Main application
 ├── components/                      # UI components

--- a/DOCS/configuration/OVERVIEW.md
+++ b/DOCS/configuration/OVERVIEW.md
@@ -56,7 +56,7 @@ npm start
 
 ### Using URL Parameters
 
-```
+```text
 http://localhost:2222/ssh?port=22&header=Development
 ```
 
@@ -64,7 +64,7 @@ http://localhost:2222/ssh?port=22&header=Development
 
 All WebSSH2 environment variables follow a consistent naming pattern:
 
-```
+```text
 WEBSSH2_<SECTION>_<SUBSECTION>_<SETTING>
 ```
 

--- a/DOCS/configuration/URL-PARAMETERS.md
+++ b/DOCS/configuration/URL-PARAMETERS.md
@@ -20,25 +20,25 @@ WebSSH2 supports configuration through URL query parameters, allowing you to cus
 
 ### Basic Connection
 
-```
+```text
 http://localhost:2222/ssh/host/example.com
 ```
 
 ### Custom Port
 
-```
+```text
 http://localhost:2222/ssh/host/example.com?port=2244
 ```
 
 ### Multiple Parameters
 
-```
+```text
 http://localhost:2222/ssh/host/example.com?port=2244&sshterm=xterm-256color
 ```
 
 ### With Interactive Login
 
-```
+```text
 http://localhost:2222/ssh?port=22&header=Production%20Server
 ```
 
@@ -48,7 +48,7 @@ http://localhost:2222/ssh?port=22&header=Production%20Server
 
 Specifies the SSH port on the target server.
 
-```
+```text
 ?port=2222
 ?port=8022
 ```
@@ -69,7 +69,7 @@ Common values:
 - `screen`
 - `screen-256color`
 
-```
+```text
 ?sshterm=xterm-256color
 ```
 
@@ -128,7 +128,7 @@ that already relied on what was rendered.
 
 Pass environment variables to the SSH session:
 
-```
+```text
 ?env=DEBUG:true
 ?env=NODE_ENV:production,DEBUG:true
 ?env=FOO:bar,BAR:baz,QUX:123
@@ -147,7 +147,7 @@ Format: `KEY:value,KEY2:value2`
 
 ### Development Environment
 
-```
+```text
 http://localhost:2222/ssh/host/dev-server?port=22&sshterm=xterm-256color&header=DEV&headerBackground=orange&env=NODE_ENV:development,DEBUG:*
 ```
 
@@ -159,7 +159,7 @@ http://localhost:2222/ssh/host/prod-server?header=PRODUCTION&headerBackground=%2
 
 ### Testing Environment with Debugging
 
-```
+```text
 http://localhost:2222/ssh?port=2244&env=DEBUG:webssh2:*,LOG_LEVEL:debug&header=TEST%20SERVER&headerBackground=%23FFA500
 ```
 

--- a/DOCS/development/SETUP.md
+++ b/DOCS/development/SETUP.md
@@ -94,7 +94,7 @@ webssh2Config: {
 ### Accessing the Development Environment
 
 1. Open your web browser and navigate to:
-```
+```text
 http://localhost:3000
 ```
 

--- a/DOCS/features/ENVIRONMENT-FORWARDING.md
+++ b/DOCS/features/ENVIRONMENT-FORWARDING.md
@@ -11,12 +11,12 @@ WebSSH2 supports passing environment variables through URL parameters, allowing 
 Both routes are supported:
 
 ### Without Auto-connect (Login Form)
-```
+```text
 /ssh?env=FOO:bar,BAR:baz
 ```
 
 ### With Auto-connect (Host in URL)
-```
+```text
 /ssh/host/localhost?port=2244&env=FOO:bar,BAR:baz
 ```
 
@@ -55,17 +55,17 @@ sudo service sshd restart
 Pass environment variables using the `env` query parameter:
 
 ### Single Environment Variable
-```
+```text
 http://localhost:2222/ssh/host/example.com?env=VIM_FILE:config.txt
 ```
 
 ### Multiple Environment Variables
-```
+```text
 http://localhost:2222/ssh/host/example.com?env=VIM_FILE:config.txt,CUSTOM_ENV:test
 ```
 
 ### With Login Form
-```
+```text
 http://localhost:2222/ssh?env=VIM_FILE:config.txt,CUSTOM_ENV:test
 ```
 
@@ -141,7 +141,7 @@ sudo systemctl restart sshd
 
 ### Step 2: Create URL with Environment Variables
 
-```
+```text
 http://localhost:2222/ssh/host/example.com?env=VIM_FILE:settings.conf,CUSTOM_ENV:production
 ```
 
@@ -212,22 +212,22 @@ Test with a simple variable first:
 ## Use Cases
 
 ### 1. Development Environment Setup
-```
+```text
 /ssh/host/dev-server?env=NODE_ENV:development,DEBUG:true
 ```
 
 ### 2. Automatic File Editing
-```
+```text
 /ssh/host/server?env=VIM_FILE:config.yaml,VIM_LINE:42
 ```
 
 ### 3. Project Context
-```
+```text
 /ssh/host/build-server?env=PROJECT:website,BRANCH:feature-123
 ```
 
 ### 4. Locale Settings
-```
+```text
 /ssh/host/server?env=LANG:en_US.UTF-8,LC_ALL:en_US.UTF-8
 ```
 

--- a/DOCS/features/EXEC-CHANNEL.md
+++ b/DOCS/features/EXEC-CHANNEL.md
@@ -152,7 +152,7 @@ You can pass environment variables to exec commands in two ways:
    ```
 
 2. **Via URL query parameters:**
-   ```
+   ```text
    http://localhost:2222/ssh?env=MY_VAR:value,OTHER_VAR:value2
    ```
 

--- a/DOCS/features/SSO.md
+++ b/DOCS/features/SSO.md
@@ -137,7 +137,7 @@ In BIG-IP APM, create a WebSSO configuration:
 
 Configure APM to map session variables to form fields:
 
-```
+```text
 session.logon.last.username → username
 session.logon.last.password → password
 ```

--- a/DOCS/getting-started/QUICK-START.md
+++ b/DOCS/getting-started/QUICK-START.md
@@ -33,7 +33,7 @@ WebSSH2 will start on port 2222 by default.
 
 Open your browser and navigate to:
 
-```
+```text
 http://localhost:2222/ssh
 ```
 
@@ -86,7 +86,7 @@ npm start
 
 Skip the login form by using the host endpoint:
 
-```
+```text
 http://localhost:2222/ssh/host/my-server.com
 ```
 
@@ -119,7 +119,7 @@ npm start
 
 ### 4. With Custom Header
 
-```
+```text
 http://localhost:2222/ssh?header=Development%20Server
 ```
 

--- a/DOCS/reference/ALGORITHMS.md
+++ b/DOCS/reference/ALGORITHMS.md
@@ -185,7 +185,7 @@ WebSSH2 provides built-in presets for common use cases:
 
 Balanced security and compatibility for contemporary systems.
 
-```
+```text
 Ciphers: aes256-gcm@openssh.com, aes128-gcm@openssh.com, aes256-ctr, aes128-ctr
 KEX: ecdh-sha2-nistp256, ecdh-sha2-nistp384, ecdh-sha2-nistp521
 HMAC: hmac-sha2-256, hmac-sha2-512
@@ -196,7 +196,7 @@ Host Keys: ecdsa-sha2-nistp256, ecdsa-sha2-nistp384, ecdsa-sha2-nistp521, ssh-rs
 
 For connecting to older SSH servers.
 
-```
+```text
 Ciphers: aes256-cbc, aes192-cbc, aes128-cbc, 3des-cbc
 KEX: diffie-hellman-group14-sha1, diffie-hellman-group1-sha1
 HMAC: hmac-sha1, hmac-md5
@@ -207,7 +207,7 @@ Host Keys: ssh-rsa, ssh-dss
 
 Maximum security, minimal compatibility.
 
-```
+```text
 Ciphers: aes256-gcm@openssh.com
 KEX: ecdh-sha2-nistp256
 HMAC: hmac-sha2-256


### PR DESCRIPTION
## What

Retro markdown linting, split out from the `#546` CSP work as a standalone chore.

- Adds a scoped `.markdownlint-cli2.jsonc` so the VS Code extension, the CLI, and the global pre-commit hook agree on rules:
  - `MD024` → `siblings_only` (allows repeated per-CVE headings under different parents)
  - `MD040` → on (fenced code blocks must declare a language)
  - `MD013` (line length) and `MD060` (table column style) left **off** — the docs use aligned/padded tables and `MD060` has no auto-fixer in this version, so enforcing it would mean reformatting every table.
- Declares a language on previously-bare fenced code blocks (`MD040`): `text` for URLs, directory trees, key mappings, and sample output; `bash` for command blocks.

## Why

VS Code was surfacing a large number of markdown lint warnings. This makes the repo `markdownlint-cli2` clean (0 errors / 100 files) without any prose or table reflow.

## Notes

- No prose or table content changed — only fence language tags and the new config.
- Code-quality (SonarLint) fixes from the same cleanup session landed separately on `feat/546-csp-json-config`.
