### PR TITLE
feat(security): verify webssh2_client bundle integrity + provenance (#547)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.trust.outputs.run == 'true'
-        run: npm ci
+        # Bundle verification only needs tsx + the (pre-built) webssh2_client
+        # package, so skip lifecycle scripts — no native builds required here.
+        run: npm ci --ignore-scripts
 
       - name: Assert gh CLI supports pinned attestation verification
         if: steps.trust.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [ main, master, develop, feat/**, release-please--branches--** ]
   pull_request:
     branches: [ '**' ]
+  workflow_dispatch:
+    inputs:
+      bundle_verify_outage_override:
+        description: >-
+          Bypass client-bundle verification ONLY for a confirmed GitHub
+          release / Attestations / Rekor outage. Tamper failures still block.
+          The bypass is recorded in this run's logs and actor.
+        type: boolean
+        default: false
 
 jobs:
   build-lint-test:
@@ -56,6 +65,94 @@ jobs:
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: 'trivy-results.sarif'
+
+  verify-client-bundle:
+    # Verify the webssh2_client bundle's integrity + provenance (issue #547).
+    # Network- and token-dependent, so it is skipped on fork/dependabot PRs
+    # (read-only token / withheld secrets); the same-repo and main-branch runs
+    # are the gate of record.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Determine trust gate
+        id: trust
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = 'pull_request' ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo 'run=false' >> "$GITHUB_OUTPUT"
+            echo 'Fork PR; bundle verification skipped (advisory; same-repo/main run is the gate).'
+          elif [ "$ACTOR" = 'dependabot[bot]' ]; then
+            echo 'run=false' >> "$GITHUB_OUTPUT"
+            echo 'Dependabot PR; bundle verification skipped (secrets withheld; main run is the gate).'
+          else
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.trust.outputs.run == 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        if: steps.trust.outputs.run == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.trust.outputs.run == 'true'
+        run: npm ci
+
+      - name: Assert gh CLI supports pinned attestation verification
+        if: steps.trust.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          gh --version
+          ver=$(gh --version | sed -n 's/^gh version \([0-9.]*\).*/\1/p')
+          # gh attestation verify with --cert-identity is GA since 2.49.0.
+          required=2.49.0
+          lowest=$(printf '%s\n%s\n' "$ver" "$required" | sort -V | head -n1)
+          if [ "$lowest" != "$required" ]; then
+            echo "::error::gh $ver is older than required $required for attestation verify"
+            exit 1
+          fi
+
+      - name: Negative control — wrong signer identity must be rejected
+        if: steps.trust.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ver=$(node -p "require('./package-lock.json').packages['node_modules/webssh2_client'].version")
+          curl -fsSL --proto '=https' --tlsv1.2 --max-filesize 1048576 -o /tmp/cs-negative.txt \
+            "https://github.com/billchurch/webssh2_client/releases/download/v${ver}/checksums.txt"
+          if gh attestation verify /tmp/cs-negative.txt \
+               --repo billchurch/webssh2_client \
+               --cert-identity 'https://github.com/billchurch/webssh2_client/.github/workflows/evil.yml@refs/heads/main' \
+               >/dev/null 2>&1; then
+            echo '::error::Negative control PASSED verification — gh identity pinning is not effective'
+            exit 1
+          fi
+          echo 'Negative control OK: a wrong signer identity is rejected.'
+
+      - name: Verify client bundle integrity + provenance
+        if: steps.trust.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WEBSSH2_BUNDLE_VERIFY_OUTAGE_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.bundle_verify_outage_override && 'true' || 'false' }}
+        run: npm run security:verify-bundle
+
+      - name: Verify registry signatures + provenance attestations
+        if: steps.trust.outputs.run == 'true'
+        run: npm audit signatures
 
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -265,7 +265,9 @@ jobs:
 
       - name: Install dependencies for bundle verification
         if: matrix.arch == 'amd64'
-        run: npm ci
+        # Only tsx + the pre-built webssh2_client package are needed; skip
+        # lifecycle scripts (no native builds required for verification).
+        run: npm ci --ignore-scripts
 
       - name: Extract client bundle from built image
         if: matrix.arch == 'amd64'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,13 @@ on:
         default: ''
         required: false
         type: string
+      bundle_verify_outage_override:
+        description: >-
+          Bypass client-bundle verification ONLY for a confirmed GitHub
+          release / Attestations / Rekor outage. Tamper failures still block.
+        default: false
+        required: false
+        type: boolean
   release:
     types:
       - published
@@ -245,6 +252,36 @@ jobs:
           docker logs "$CID"
           docker stop "$CID" || true
           exit 1
+
+      # Verify the bundle baked into the image we are about to push matches the
+      # attested webssh2_client release (issue #547). The bundle is identical
+      # across arches, so this runs once on amd64. Pre-push and fail-closed.
+      - name: Setup Node.js for bundle verification
+        if: matrix.arch == 'amd64'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies for bundle verification
+        if: matrix.arch == 'amd64'
+        run: npm ci
+
+      - name: Extract client bundle from built image
+        if: matrix.arch == 'amd64'
+        run: |
+          set -euo pipefail
+          docker create --name webssh2-bundle-verify local/webssh2:scan
+          docker cp webssh2-bundle-verify:/srv/webssh2/node_modules/webssh2_client/client ./image-client-bundle
+          docker rm webssh2-bundle-verify
+
+      - name: Verify image bundle integrity + provenance
+        if: matrix.arch == 'amd64'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WEBSSH2_CLIENT_DIR: ${{ github.workspace }}/image-client-bundle
+          WEBSSH2_BUNDLE_VERIFY_OUTAGE_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.bundle_verify_outage_override && 'true' || 'false' }}
+        run: npm run security:verify-bundle
 
       # PHASE 2: scan/smoke passed -> push this arch by digest to BOTH registries
       # (gha cache makes this a near-instant re-export, no recompile).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -165,6 +165,63 @@ Additional notes:
 - Prefer the narrowest CIDR ranges possible and pair them with
   network-level egress controls
 
+## Client bundle integrity verification
+
+This gateway serves a pre-built browser bundle from the `webssh2_client` npm
+package (`node_modules/webssh2_client/client/public`). To ensure the bytes we
+ship match the bytes the client project built and published, CI verifies the
+bundle's integrity **and provenance** before it can reach operators.
+
+The verification (`npm run security:verify-bundle`, implemented in
+`scripts/verify-client-bundle.ts`) does the following:
+
+1. Resolves the pinned `webssh2_client` version from `package-lock.json`
+   (exact-pinned, lockfile-anchored) and rejects anything below `5.1.0` — the
+   first release carrying both `checksums.txt` and a sigstore attestation.
+2. Downloads `checksums.txt` from the matching `v<version>` GitHub release over
+   HTTPS, fail-closed and size-capped.
+3. Verifies the file's sigstore attestation with `gh attestation verify`,
+   pinned via `--cert-identity` to the client's release workflow on its signing
+   ref:
+   `https://github.com/billchurch/webssh2_client/.github/workflows/release.yml@refs/heads/main`.
+   Pinning the certificate identity (not just `--repo`) is what proves the file
+   was produced by the expected workflow — a bare `--repo` check would pass for
+   any attestation from the repository, including one minted by a malicious
+   workflow.
+4. Verifies the installed `public/` files against the attested checksums with
+   `sha256sum -c`.
+5. Runs `npm audit signatures` for registry-side signature verification across
+   the dependency tree (fails on invalid signatures, not on absent provenance).
+
+### Where it runs
+
+- **CI (`ci.yml`)**: a dedicated `verify-client-bundle` job runs the full check.
+  It is skipped on fork and dependabot pull requests (read-only token / withheld
+  secrets); the same-repo and main-branch runs are the gate of record. A
+  negative-control step asserts that a deliberately wrong signer identity is
+  rejected, so a `gh` behavior change cannot silently weaken the pin.
+- **Image publish (`docker-publish.yml`)**: the bundle is extracted from the
+  built image and verified pre-push, so the exact bytes shipped in the Docker
+  image — not just the CI runner's `node_modules` — are gated. This runs once
+  (the bundle is architecture-independent).
+
+### Failure policy and overrides
+
+Tamper-class failures (attestation mismatch, checksum mismatch, missing asset on
+a `>= 5.1.0` release, invalid registry signature) always fail closed.
+
+Network downloads are retried with bounded exponential backoff. If the GitHub
+release CDN, the Attestations API, or the Rekor transparency log is genuinely
+unreachable after retries, the failure is classified as an **outage** rather
+than tamper. An outage — and only an outage — may be bypassed by a maintainer
+re-running the workflow with the `bundle_verify_outage_override` input set,
+which exposes `WEBSSH2_BUNDLE_VERIFY_OUTAGE_OVERRIDE=true` to the script. The
+bypass is recorded in the run's logs and actor; tamper failures are never
+bypassable.
+
+The script also honors `WEBSSH2_CLIENT_DIR` to point verification at a bundle
+extracted from elsewhere (used for the Docker image check).
+
 ## Security Disclosure Policy
 
 - **Private Disclosure**: We request that you give us reasonable time to address the issue before public disclosure

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "socket.io": "^4.8.1",
         "ssh2": "1.17",
         "validator": "^13.15.35",
-        "webssh2_client": "^5.1.0",
+        "webssh2_client": "5.1.0",
         "zod": "^4.1.12"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "socket.io": "^4.8.1",
     "ssh2": "1.17",
     "validator": "^13.15.35",
-    "webssh2_client": "^5.1.0",
+    "webssh2_client": "5.1.0",
     "zod": "^4.1.12"
   },
   "scripts": {
@@ -75,6 +75,7 @@
     "build": "tsc -p tsconfig.build.json",
     "ci": "npm run test",
     "security:audit": "npm audit",
+    "security:verify-bundle": "tsx scripts/verify-client-bundle.ts",
     "hostkeys": "tsx scripts/host-key-seed.ts",
     "hostkeys:prod": "node dist/scripts/host-key-seed.js"
   },

--- a/scripts/lib/client-bundle-integrity.ts
+++ b/scripts/lib/client-bundle-integrity.ts
@@ -1,0 +1,213 @@
+// scripts/lib/client-bundle-integrity.ts
+// Pure logic for verifying the integrity + provenance of the webssh2_client
+// browser bundle this gateway ships. I/O (network, subprocess) lives in the
+// script entry point; everything here is pure and unit-testable.
+
+import { err, ok } from '../../app/utils/result.js'
+import type { Result } from '../../app/types/result.js'
+
+/**
+ * First webssh2_client release carrying both `checksums.txt` and the sigstore
+ * attestation of it. Releases below this floor ship only `client-public.zip`
+ * and cannot be verified, so they are rejected.
+ */
+export const MINIMUM_CLIENT_VERSION = '5.1.0'
+
+const STRICT_SEMVER = /^(\d+)\.(\d+)\.(\d+)$/
+
+const CLIENT_PACKAGE_PATH = 'node_modules/webssh2_client'
+
+/** Source repository that builds and attests the client bundle. */
+export const CLIENT_REPO = 'billchurch/webssh2_client'
+
+/**
+ * The exact workflow that runs `actions/attest-build-provenance` in the client
+ * repo. Pinning this is what makes verification prove provenance — `--repo`
+ * alone would pass for any workflow in the repo, including a malicious one.
+ */
+export const CLIENT_SIGNER_WORKFLOW =
+  'billchurch/webssh2_client/.github/workflows/release.yml'
+
+/**
+ * Full sigstore certificate identity (SAN), pinning both the signer workflow
+ * and its ref. `release.yml` triggers on push to `main` (release-please), so
+ * the signing ref is `refs/heads/main`, not a tag. Passed via `--cert-identity`
+ * — which is strictly stronger than `--signer-workflow` (it also pins the ref)
+ * and is mutually exclusive with it in the `gh` CLI.
+ */
+export const CLIENT_CERT_IDENTITY = `https://github.com/${CLIENT_SIGNER_WORKFLOW}@refs/heads/main`
+
+/** Build the `v<version>`-tagged GitHub release asset URL for `checksums.txt`. */
+export function buildChecksumsUrl(version: string): string {
+  return `https://github.com/${CLIENT_REPO}/releases/download/v${version}/checksums.txt`
+}
+
+/**
+ * Argv for `gh attestation verify <file>`, pinned to the client's release
+ * workflow and certificate identity so the check proves the file was produced
+ * by the expected workflow — not merely that some attestation exists.
+ */
+export function buildAttestationVerifyArgs(file: string): readonly string[] {
+  return [
+    'attestation',
+    'verify',
+    file,
+    '--repo',
+    CLIENT_REPO,
+    '--cert-identity',
+    CLIENT_CERT_IDENTITY
+  ]
+}
+
+/**
+ * Keep only the `public/` bundle lines from a `checksums.txt`, which are what
+ * `sha256sum -c` verifies against the installed `client/public/` directory.
+ */
+export function extractPublicChecksumLines(checksumsText: string): string[] {
+  return checksumsText
+    .split('\n')
+    .filter((line) => /^[0-9a-f]+ {2}public\//.test(line))
+}
+
+/**
+ * Why a verification step failed. Tamper reasons mean the artifact is suspect;
+ * outage reasons mean the verification infrastructure was unreachable.
+ */
+export type FailureReason =
+  | 'attestation-verification-failed'
+  | 'checksum-mismatch'
+  | 'asset-missing'
+  | 'signature-invalid'
+  | 'network-unreachable'
+  | 'rate-limited'
+  | 'server-error'
+
+/** Whether a failure should fail the build closed (tamper) or be treated as a recoverable infrastructure outage. */
+export type FailureClass = 'tamper' | 'outage'
+
+const OUTAGE_REASONS: ReadonlySet<FailureReason> = new Set([
+  'network-unreachable',
+  'rate-limited',
+  'server-error'
+])
+
+/**
+ * Classify a failure so the caller can fail closed on tamper (always) while
+ * routing genuine infrastructure outages to the deliberate, audited override
+ * path instead of silently skipping verification. A missing asset on a
+ * `>= 5.1.0` release is tamper — those releases must ship `checksums.txt`.
+ */
+export function classifyFailure(reason: FailureReason): FailureClass {
+  return OUTAGE_REASONS.has(reason) ? 'outage' : 'tamper'
+}
+
+export interface RetryOptions {
+  /** Total attempts including the first. */
+  readonly attempts: number
+  /** Base backoff; attempt N waits `baseDelayMs * 2^(N-1)`. */
+  readonly baseDelayMs: number
+  /** Injected sleep so callers (and tests) control timing. */
+  readonly sleep: (ms: number) => Promise<void>
+  /** Return false to stop retrying a given error (e.g. tamper, not outage). */
+  readonly shouldRetry?: (error: unknown) => boolean
+}
+
+/**
+ * Run an async operation with bounded exponential-backoff retry. Used to ride
+ * out transient outages of the GitHub release CDN / Attestations API / Rekor
+ * without failing the build closed on a blip (A1). Tamper-class failures should
+ * pass a `shouldRetry` that returns false so they fail fast.
+ */
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions
+): Promise<T> {
+  const { attempts, baseDelayMs, sleep, shouldRetry } = options
+  let lastError: unknown
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation()
+    } catch (error: unknown) {
+      lastError = error
+      const retryable = shouldRetry === undefined || shouldRetry(error)
+      if (!retryable || attempt === attempts) {
+        throw error
+      }
+      await sleep(baseDelayMs * 2 ** (attempt - 1))
+    }
+  }
+  throw lastError
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/**
+ * Resolve the webssh2_client version from a parsed `package-lock.json` rather
+ * than the installed package's self-reported `package.json` — the lockfile is
+ * the version the maintainer pinned, so it is the trust anchor. Requires
+ * lockfile v3+ per the supply-chain policy. Returns the raw version; callers
+ * must pass it through {@link validateClientVersion} before use.
+ */
+export function resolveClientVersionFromLockfile(
+  lockfile: unknown
+): Result<string, string> {
+  if (!isRecord(lockfile)) {
+    return err('package-lock.json did not parse to an object')
+  }
+  if (lockfile['lockfileVersion'] !== 3) {
+    return err('package-lock.json must be lockfileVersion 3 for deterministic resolution')
+  }
+  const packages = lockfile['packages']
+  if (!isRecord(packages) || !Object.hasOwn(packages, CLIENT_PACKAGE_PATH)) {
+    return err(`package-lock.json has no "${CLIENT_PACKAGE_PATH}" entry`)
+  }
+  const entry = packages['node_modules/webssh2_client']
+  if (!isRecord(entry) || typeof entry['version'] !== 'string') {
+    return err(`"${CLIENT_PACKAGE_PATH}" lockfile entry has no string version`)
+  }
+  return ok(entry['version'])
+}
+
+type SemverTuple = readonly [number, number, number]
+
+function compareSemver(a: SemverTuple, b: SemverTuple): number {
+  const [aMajor, aMinor, aPatch] = a
+  const [bMajor, bMinor, bPatch] = b
+  if (aMajor !== bMajor) {
+    return aMajor < bMajor ? -1 : 1
+  }
+  if (aMinor !== bMinor) {
+    return aMinor < bMinor ? -1 : 1
+  }
+  if (aPatch !== bPatch) {
+    return aPatch < bPatch ? -1 : 1
+  }
+  return 0
+}
+
+const [FLOOR_MAJOR, FLOOR_MINOR, FLOOR_PATCH] = MINIMUM_CLIENT_VERSION.split('.').map(Number)
+const FLOOR: SemverTuple = [FLOOR_MAJOR ?? 0, FLOOR_MINOR ?? 0, FLOOR_PATCH ?? 0]
+
+/**
+ * Validate a client version string before it is interpolated into any URL or
+ * shell command. Accepts strict `major.minor.patch` semver only (no prerelease,
+ * build metadata, ranges, or other characters) and enforces the minimum floor.
+ */
+export function validateClientVersion(raw: string): Result<string, string> {
+  const match = STRICT_SEMVER.exec(raw)
+  if (match === null) {
+    return err(
+      `client version "${raw}" is not strict semver (expected MAJOR.MINOR.PATCH)`
+    )
+  }
+  const parsed: SemverTuple = [Number(match[1]), Number(match[2]), Number(match[3])]
+  if (compareSemver(parsed, FLOOR) < 0) {
+    return err(
+      `client version ${raw} is below the minimum ${MINIMUM_CLIENT_VERSION} ` +
+        '(no checksums.txt/attestation in older releases)'
+    )
+  }
+  return ok(raw)
+}

--- a/scripts/verify-client-bundle.ts
+++ b/scripts/verify-client-bundle.ts
@@ -1,0 +1,229 @@
+// scripts/verify-client-bundle.ts
+// Verify the integrity + provenance of the installed webssh2_client browser
+// bundle before it ships. Anchored to the client's release workflow via
+// sigstore attestation; see issue #547. Pure logic lives in
+// ./lib/client-bundle-integrity.ts — this file is the I/O adapter.
+
+import { spawn } from 'node:child_process'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { isErr } from '../app/utils/result.js'
+import {
+  buildAttestationVerifyArgs,
+  buildChecksumsUrl,
+  classifyFailure,
+  extractPublicChecksumLines,
+  resolveClientVersionFromLockfile,
+  validateClientVersion,
+  withRetry,
+  type FailureReason
+} from './lib/client-bundle-integrity.js'
+
+const CHECKSUMS_MAX_BYTES = 1_048_576
+const DOWNLOAD_ATTEMPTS = 4
+const DOWNLOAD_BASE_DELAY_MS = 1_000
+
+/** Error carrying the classification used to decide fail-closed vs outage. */
+class VerifyError extends Error {
+  constructor(
+    message: string,
+    readonly reason: FailureReason,
+    options?: ErrorOptions
+  ) {
+    super(message, options)
+    this.name = 'VerifyError'
+  }
+}
+
+interface RunResult {
+  readonly code: number
+  readonly stdout: string
+  readonly stderr: string
+}
+
+function run(
+  command: string,
+  args: readonly string[],
+  options: { readonly cwd?: string; readonly stdin?: string } = {}
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [...args], {
+      cwd: options.cwd,
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8')
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8')
+    })
+    child.on('error', (error: Error) => {
+      reject(error)
+    })
+    child.on('close', (code: number | null) => {
+      resolve({ code: code ?? 1, stdout, stderr })
+    })
+    if (options.stdin !== undefined) {
+      child.stdin.write(options.stdin)
+    }
+    child.stdin.end()
+  })
+}
+
+async function downloadChecksums(version: string): Promise<string> {
+  const url = buildChecksumsUrl(version)
+  return withRetry(
+    async () => {
+      let response: Response
+      try {
+        response = await globalThis.fetch(url, { redirect: 'follow' })
+      } catch (cause: unknown) {
+        throw new VerifyError(`network error fetching ${url}`, 'network-unreachable', { cause })
+      }
+      if (response.status === 404) {
+        throw new VerifyError(`checksums.txt missing for release v${version}`, 'asset-missing')
+      }
+      if (response.status === 429) {
+        throw new VerifyError(`rate limited fetching ${url}`, 'rate-limited')
+      }
+      if (response.status >= 500) {
+        throw new VerifyError(`server error ${response.status} fetching ${url}`, 'server-error')
+      }
+      if (!response.ok) {
+        throw new VerifyError(`unexpected status ${response.status} fetching ${url}`, 'asset-missing')
+      }
+      const declared = Number(response.headers.get('content-length') ?? '0')
+      if (declared > CHECKSUMS_MAX_BYTES) {
+        throw new VerifyError('checksums.txt exceeds size cap', 'asset-missing')
+      }
+      const body = await response.text()
+      if (body.length > CHECKSUMS_MAX_BYTES) {
+        throw new VerifyError('checksums.txt exceeds size cap', 'asset-missing')
+      }
+      return body
+    },
+    {
+      attempts: DOWNLOAD_ATTEMPTS,
+      baseDelayMs: DOWNLOAD_BASE_DELAY_MS,
+      sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+      shouldRetry: (error) =>
+        error instanceof VerifyError && classifyFailure(error.reason) === 'outage'
+    }
+  )
+}
+
+async function verifyAttestation(checksumsPath: string): Promise<void> {
+  let result: RunResult
+  try {
+    result = await run('gh', buildAttestationVerifyArgs(checksumsPath))
+  } catch (cause: unknown) {
+    // A missing/unusable gh CLI is an environment fault, not a bypassable
+    // outage — surface it as a hard error so it can never skip verification.
+    throw new Error('gh CLI is required for attestation verification but could not be launched', {
+      cause
+    })
+  }
+  if (result.code !== 0) {
+    throw new VerifyError(
+      `attestation verification failed:\n${result.stderr.trim()}`,
+      'attestation-verification-failed'
+    )
+  }
+}
+
+async function verifyChecksums(checksumsText: string, clientDir: string): Promise<void> {
+  const lines = extractPublicChecksumLines(checksumsText)
+  if (lines.length === 0) {
+    throw new VerifyError('checksums.txt listed no public/ bundle files', 'asset-missing')
+  }
+  const result = await run('sha256sum', ['-c', '-'], {
+    cwd: clientDir,
+    stdin: `${lines.join('\n')}\n`
+  })
+  if (result.code !== 0) {
+    throw new VerifyError(
+      `bundle checksum mismatch:\n${result.stdout.trim()}\n${result.stderr.trim()}`,
+      'checksum-mismatch'
+    )
+  }
+}
+
+interface Paths {
+  readonly lockfilePath: string
+  readonly clientDir: string
+}
+
+function resolvePaths(): Paths {
+  const workspace = process.cwd()
+  return {
+    lockfilePath: join(workspace, 'package-lock.json'),
+    // Allows pointing at a bundle extracted from the built Docker image.
+    clientDir:
+      process.env['WEBSSH2_CLIENT_DIR'] ??
+      join(workspace, 'node_modules', 'webssh2_client', 'client')
+  }
+}
+
+async function resolveVersion(lockfilePath: string): Promise<string> {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- lockfilePath is workspace-relative, not user input
+  const raw = await readFile(lockfilePath, 'utf8')
+  const parsed: unknown = JSON.parse(raw)
+  const resolved = resolveClientVersionFromLockfile(parsed)
+  if (isErr(resolved)) {
+    throw new VerifyError(resolved.error, 'asset-missing')
+  }
+  const validated = validateClientVersion(resolved.value)
+  if (isErr(validated)) {
+    throw new VerifyError(validated.error, 'asset-missing')
+  }
+  return validated.value
+}
+
+async function verifyBundle(paths: Paths): Promise<string> {
+  const version = await resolveVersion(paths.lockfilePath)
+  const checksumsText = await downloadChecksums(version)
+  const dir = await mkdtemp(join(tmpdir(), 'webssh2-bundle-'))
+  const checksumsPath = join(dir, 'checksums.txt')
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- checksumsPath is under a freshly created mkdtemp directory
+  await writeFile(checksumsPath, checksumsText, 'utf8')
+  await verifyAttestation(checksumsPath)
+  await verifyChecksums(checksumsText, paths.clientDir)
+  return version
+}
+
+function isBypassAllowed(): boolean {
+  return process.env['WEBSSH2_BUNDLE_VERIFY_OUTAGE_OVERRIDE'] === 'true'
+}
+
+async function main(): Promise<number> {
+  const paths = resolvePaths()
+  try {
+    const version = await verifyBundle(paths)
+    process.stdout.write(`✓ webssh2_client@${version} bundle verified (provenance + checksums)\n`)
+    return 0
+  } catch (error: unknown) {
+    if (error instanceof VerifyError) {
+      const failureClass = classifyFailure(error.reason)
+      if (failureClass === 'outage' && isBypassAllowed()) {
+        process.stderr.write(
+          `⚠ bundle verification skipped — infrastructure outage (${error.reason}) and ` +
+            `WEBSSH2_BUNDLE_VERIFY_OUTAGE_OVERRIDE set.\n${error.message}\n`
+        )
+        return 0
+      }
+      const label = failureClass === 'tamper' ? 'TAMPER' : 'OUTAGE'
+      process.stderr.write(`✗ bundle verification failed [${label}/${error.reason}]\n${error.message}\n`)
+      return 1
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`✗ bundle verification error: ${message}\n`)
+    return 1
+  }
+}
+
+const exitCode = await main()
+process.exitCode = exitCode

--- a/tests/unit/scripts/client-bundle-integrity.vitest.ts
+++ b/tests/unit/scripts/client-bundle-integrity.vitest.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildAttestationVerifyArgs,
+  buildChecksumsUrl,
+  CLIENT_CERT_IDENTITY,
+  CLIENT_REPO,
+  classifyFailure,
+  extractPublicChecksumLines,
+  MINIMUM_CLIENT_VERSION,
+  resolveClientVersionFromLockfile,
+  validateClientVersion,
+  withRetry
+} from '../../../scripts/lib/client-bundle-integrity.js'
+
+const aLockfile = (overrides?: Record<string, unknown>): Record<string, unknown> => ({
+  lockfileVersion: 3,
+  packages: {
+    'node_modules/webssh2_client': {
+      version: '5.1.0',
+      resolved: 'https://registry.npmjs.org/webssh2_client/-/webssh2_client-5.1.0.tgz',
+      integrity: 'sha512-deadbeef'
+    }
+  },
+  ...overrides
+})
+
+describe('validateClientVersion', () => {
+  it('accepts a strict semver at or above the minimum floor', () => {
+    const result = validateClientVersion('5.1.0')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('5.1.0')
+    }
+  })
+
+  it('accepts a version above the floor', () => {
+    const result = validateClientVersion('5.2.3')
+    expect(result.ok).toBe(true)
+  })
+
+  it('exposes 5.1.0 as the minimum client version', () => {
+    expect(MINIMUM_CLIENT_VERSION).toBe('5.1.0')
+  })
+
+  it('rejects a version below the floor (no checksums/attestation)', () => {
+    const result = validateClientVersion('5.0.0')
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a prerelease/build-metadata version as non-strict', () => {
+    const result = validateClientVersion('5.1.0-beta.1')
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a version carrying shell metacharacters', () => {
+    const result = validateClientVersion('5.1.0; rm -rf /')
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a version attempting path traversal', () => {
+    const result = validateClientVersion('5.1.0/../../other-repo')
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects an empty string', () => {
+    const result = validateClientVersion('')
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('resolveClientVersionFromLockfile', () => {
+  it('extracts the webssh2_client version from a lockfile v3 packages entry', () => {
+    const result = resolveClientVersionFromLockfile(aLockfile())
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('5.1.0')
+    }
+  })
+
+  it('rejects a lockfile older than version 3', () => {
+    const result = resolveClientVersionFromLockfile(aLockfile({ lockfileVersion: 2 }))
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a lockfile missing the webssh2_client package entry', () => {
+    const result = resolveClientVersionFromLockfile(aLockfile({ packages: {} }))
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a non-object input', () => {
+    const result = resolveClientVersionFromLockfile('not-a-lockfile')
+    expect(result.ok).toBe(false)
+  })
+
+  it('does not read inherited prototype properties as the package entry', () => {
+    const result = resolveClientVersionFromLockfile(aLockfile({ packages: Object.create({ 'node_modules/webssh2_client': { version: '9.9.9' } }) }))
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('buildChecksumsUrl', () => {
+  it('builds the v<version>-tagged release asset URL', () => {
+    expect(buildChecksumsUrl('5.1.0')).toBe(
+      'https://github.com/billchurch/webssh2_client/releases/download/v5.1.0/checksums.txt'
+    )
+  })
+})
+
+describe('buildAttestationVerifyArgs', () => {
+  const args = buildAttestationVerifyArgs('checksums.txt')
+
+  it('verifies the provided file', () => {
+    expect(args.slice(0, 3)).toEqual(['attestation', 'verify', 'checksums.txt'])
+  })
+
+  it('pins the source repository', () => {
+    const i = args.indexOf('--repo')
+    expect(i).toBeGreaterThan(-1)
+    expect(args[i + 1]).toBe(CLIENT_REPO)
+  })
+
+  it('pins the certificate identity to the release workflow on refs/heads/main (provenance, not just "an attestation exists")', () => {
+    const i = args.indexOf('--cert-identity')
+    expect(i).toBeGreaterThan(-1)
+    expect(args[i + 1]).toBe(CLIENT_CERT_IDENTITY)
+    expect(CLIENT_CERT_IDENTITY).toBe(
+      'https://github.com/billchurch/webssh2_client/.github/workflows/release.yml@refs/heads/main'
+    )
+  })
+
+  it('does not combine mutually exclusive signer flags (gh rejects --cert-identity with --signer-workflow)', () => {
+    expect(args).not.toContain('--signer-workflow')
+    expect(args).not.toContain('--signer-repo')
+    expect(args).not.toContain('--cert-identity-regex')
+  })
+})
+
+describe('extractPublicChecksumLines', () => {
+  const checksums = [
+    '# webssh2_client v5.1.0 SHA-256 checksums',
+    'aaaa1111  client-public.zip',
+    'bbbb2222  public/index.html',
+    'cccc3333  public/assets/app.js',
+    '',
+    'dddd4444  some/other/path'
+  ].join('\n')
+
+  it('keeps only the public/ bundle lines', () => {
+    const lines = extractPublicChecksumLines(checksums)
+    expect(lines).toEqual([
+      'bbbb2222  public/index.html',
+      'cccc3333  public/assets/app.js'
+    ])
+  })
+
+  it('returns no lines when the file lists nothing under public/', () => {
+    expect(extractPublicChecksumLines('aaaa1111  client-public.zip')).toEqual([])
+  })
+})
+
+describe('classifyFailure', () => {
+  it('treats a failed attestation verification as tamper (fail closed)', () => {
+    expect(classifyFailure('attestation-verification-failed')).toBe('tamper')
+  })
+
+  it('treats a checksum mismatch as tamper', () => {
+    expect(classifyFailure('checksum-mismatch')).toBe('tamper')
+  })
+
+  it('treats a missing asset on a >=5.1.0 release as tamper', () => {
+    expect(classifyFailure('asset-missing')).toBe('tamper')
+  })
+
+  it('treats an invalid registry signature as tamper', () => {
+    expect(classifyFailure('signature-invalid')).toBe('tamper')
+  })
+
+  it('treats an unreachable network as an outage (override path)', () => {
+    expect(classifyFailure('network-unreachable')).toBe('outage')
+  })
+
+  it('treats rate limiting as an outage', () => {
+    expect(classifyFailure('rate-limited')).toBe('outage')
+  })
+
+  it('treats an upstream 5xx as an outage', () => {
+    expect(classifyFailure('server-error')).toBe('outage')
+  })
+})
+
+describe('withRetry', () => {
+  const noSleep = (): Promise<void> => Promise.resolve()
+
+  it('returns the value on first success without sleeping', async () => {
+    const sleeps: number[] = []
+    const value = await withRetry(() => Promise.resolve('ok'), {
+      attempts: 3,
+      baseDelayMs: 100,
+      sleep: (ms) => {
+        sleeps.push(ms)
+        return Promise.resolve()
+      }
+    })
+    expect(value).toBe('ok')
+    expect(sleeps).toEqual([])
+  })
+
+  it('retries a throwing operation and succeeds on a later attempt', async () => {
+    let attempts = 0
+    const value = await withRetry(
+      () => {
+        attempts += 1
+        if (attempts < 3) {
+          return Promise.reject(new Error('transient'))
+        }
+        return Promise.resolve('recovered')
+      },
+      { attempts: 3, baseDelayMs: 100, sleep: noSleep }
+    )
+    expect(value).toBe('recovered')
+    expect(attempts).toBe(3)
+  })
+
+  it('uses exponential backoff between attempts', async () => {
+    const sleeps: number[] = []
+    await expect(
+      withRetry(() => Promise.reject(new Error('down')), {
+        attempts: 3,
+        baseDelayMs: 100,
+        sleep: (ms) => {
+          sleeps.push(ms)
+          return Promise.resolve()
+        }
+      })
+    ).rejects.toThrow('down')
+    expect(sleeps).toEqual([100, 200])
+  })
+
+  it('rethrows the last error after exhausting attempts', async () => {
+    let attempts = 0
+    await expect(
+      withRetry(
+        () => {
+          attempts += 1
+          return Promise.reject(new Error(`fail-${attempts}`))
+        },
+        { attempts: 2, baseDelayMs: 1, sleep: noSleep }
+      )
+    ).rejects.toThrow('fail-2')
+    expect(attempts).toBe(2)
+  })
+
+  it('does not retry when shouldRetry returns false', async () => {
+    let attempts = 0
+    await expect(
+      withRetry(
+        () => {
+          attempts += 1
+          return Promise.reject(new Error('tamper'))
+        },
+        {
+          attempts: 5,
+          baseDelayMs: 1,
+          sleep: noSleep,
+          shouldRetry: () => false
+        }
+      )
+    ).rejects.toThrow('tamper')
+    expect(attempts).toBe(1)
+  })
+})

--- a/tests/unit/scripts/client-bundle-integrity.vitest.ts
+++ b/tests/unit/scripts/client-bundle-integrity.vitest.ts
@@ -43,29 +43,14 @@ describe('validateClientVersion', () => {
     expect(MINIMUM_CLIENT_VERSION).toBe('5.1.0')
   })
 
-  it('rejects a version below the floor (no checksums/attestation)', () => {
-    const result = validateClientVersion('5.0.0')
-    expect(result.ok).toBe(false)
-  })
-
-  it('rejects a prerelease/build-metadata version as non-strict', () => {
-    const result = validateClientVersion('5.1.0-beta.1')
-    expect(result.ok).toBe(false)
-  })
-
-  it('rejects a version carrying shell metacharacters', () => {
-    const result = validateClientVersion('5.1.0; rm -rf /')
-    expect(result.ok).toBe(false)
-  })
-
-  it('rejects a version attempting path traversal', () => {
-    const result = validateClientVersion('5.1.0/../../other-repo')
-    expect(result.ok).toBe(false)
-  })
-
-  it('rejects an empty string', () => {
-    const result = validateClientVersion('')
-    expect(result.ok).toBe(false)
+  it.each([
+    ['below the floor (no checksums/attestation)', '5.0.0'],
+    ['a prerelease/build-metadata version as non-strict', '5.1.0-beta.1'],
+    ['a version carrying shell metacharacters', '5.1.0; rm -rf /'],
+    ['a version attempting path traversal', '5.1.0/../../other-repo'],
+    ['an empty string', '']
+  ])('rejects %s', (_label, input) => {
+    expect(validateClientVersion(input).ok).toBe(false)
   })
 })
 
@@ -160,38 +145,23 @@ describe('extractPublicChecksumLines', () => {
 })
 
 describe('classifyFailure', () => {
-  it('treats a failed attestation verification as tamper (fail closed)', () => {
-    expect(classifyFailure('attestation-verification-failed')).toBe('tamper')
-  })
-
-  it('treats a checksum mismatch as tamper', () => {
-    expect(classifyFailure('checksum-mismatch')).toBe('tamper')
-  })
-
-  it('treats a missing asset on a >=5.1.0 release as tamper', () => {
-    expect(classifyFailure('asset-missing')).toBe('tamper')
-  })
-
-  it('treats an invalid registry signature as tamper', () => {
-    expect(classifyFailure('signature-invalid')).toBe('tamper')
-  })
-
-  it('treats an unreachable network as an outage (override path)', () => {
-    expect(classifyFailure('network-unreachable')).toBe('outage')
-  })
-
-  it('treats rate limiting as an outage', () => {
-    expect(classifyFailure('rate-limited')).toBe('outage')
-  })
-
-  it('treats an upstream 5xx as an outage', () => {
-    expect(classifyFailure('server-error')).toBe('outage')
+  // Tamper reasons must fail closed; outage reasons route to the override path.
+  it.each([
+    ['attestation-verification-failed', 'tamper'],
+    ['checksum-mismatch', 'tamper'],
+    ['asset-missing', 'tamper'],
+    ['signature-invalid', 'tamper'],
+    ['network-unreachable', 'outage'],
+    ['rate-limited', 'outage'],
+    ['server-error', 'outage']
+  ] as const)('classifies %s as %s', (reason, expected) => {
+    expect(classifyFailure(reason)).toBe(expected)
   })
 })
 
-describe('withRetry', () => {
-  const noSleep = (): Promise<void> => Promise.resolve()
+const noSleep = (): Promise<void> => Promise.resolve()
 
+describe('withRetry', () => {
   it('returns the value on first success without sleeping', async () => {
     const sleeps: number[] = []
     const value = await withRetry(() => Promise.resolve('ok'), {


### PR DESCRIPTION
Closes #547.

Verifies the `webssh2_client` browser bundle this gateway serves against the client project's attested GitHub release, so a tampered npm artifact or a release/registry mismatch fails the build/publish instead of reaching operators.

## What it does

`npm run security:verify-bundle` (`scripts/verify-client-bundle.ts`):

1. Resolves the **exact-pinned** client version from `package-lock.json` and rejects anything below `5.1.0` (first release with `checksums.txt` + sigstore attestation).
2. Downloads `checksums.txt` from the `v<version>` release over HTTPS, fail-closed and size-capped.
3. Verifies the file's sigstore attestation with `gh attestation verify`, **pinned via `--cert-identity`** to the client release workflow on `refs/heads/main`.
4. Verifies the installed `public/` files with `sha256sum -c`.
5. Runs `npm audit signatures` for registry-side provenance.

The provenance pin is the crux: a bare `--repo` check passes for *any* attestation from the repo (including one minted by a malicious workflow). Pinning the certificate identity proves the file was produced by the expected workflow. `gh` forbids combining `--cert-identity` with `--signer-workflow`, so we use `--cert-identity` alone — which also pins the signing ref, making it strictly stronger. Verified live: correct identity passes; wrong ref and wrong workflow both rejected.

## Where it runs

- **`ci.yml`** — dedicated `verify-client-bundle` job. Skipped on fork/dependabot PRs (read-only token / withheld secrets); same-repo and main runs are the gate of record. Includes a `gh` version floor assertion and a negative-control step asserting a wrong signer identity is rejected (so a `gh` behavior change can't silently weaken the pin).
- **`docker-publish.yml`** — extracts the bundle from the **built image** and verifies it pre-push (once, amd64), so the bytes operators actually run are gated, not just the CI runner's `node_modules`.

## Failure policy

Tamper (attestation/checksum mismatch, missing asset, invalid signature) always fails closed. Network calls retry with bounded backoff; a genuine GitHub/Attestations/Rekor **outage** — and only an outage — is bypassable via a maintainer-only, audited `bundle_verify_outage_override` workflow input. A missing `gh` CLI is a hard error, never a bypass.

## Testing

- 32 unit tests for the pure core (`scripts/lib/client-bundle-integrity.ts`), written test-first.
- **Real end-to-end run** against `webssh2_client@5.1.0`: `✓ ... bundle verified (provenance + checksums)`.
- **Tamper test**: modified bundle → `[TAMPER/checksum-mismatch]`, exit 1.
- Full suite: 1685/1685 pass · lint 0 errors · typecheck clean · build clean · markdownlint clean.

Also pins `webssh2_client` to exact `5.1.0` and documents the scheme in `SECURITY.md`.
