### PR TITLE
fix(docker): upgrade bundled npm to 11.18.0 to clear npm-CLI CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,10 +1,14 @@
 # Trivy ignore rules — every entry MUST link to a SECURITY.md assessment.
 # Format: one CVE per line; trailing comment optional but encouraged.
 
-# CVE-2026-33671 — picomatch 4.0.3 ReDoS bundled inside the global npm shipped
-# in node:22-alpine. Not exploitable in our runtime image: the container
-# entrypoint is `node dist/index.js`; the bundled npm is never invoked.
-# See SECURITY.md → "CVE-2026-33671 (picomatch ReDoS in bundled npm)".
-# Re-evaluate when upstream node:22-alpine ships an npm release that pulls
-# picomatch >= 4.0.4; remove this entry then.
-CVE-2026-33671
+# CVE-2026-14257 — brace-expansion 5.0.7 DoS (unbounded expansion length)
+# vendored inside the global npm@11.18.0 installed by the Dockerfile runtime
+# stage. Fixed only in brace-expansion 5.0.8 (published 2026-07-23), which no
+# npm release vendors yet. Not exploitable in our runtime image: the bundled
+# npm is only invoked by operators running `npm run hostkeys:prod` against
+# first-party package.json scripts — no attacker-controlled glob patterns
+# reach it. See SECURITY.md → "CVE-2026-14257 (brace-expansion DoS in bundled
+# npm)". Re-evaluate on each npm release: bump the pinned npm version in the
+# Dockerfile once a release vendors brace-expansion >= 5.0.8, then remove
+# this entry.
+CVE-2026-14257

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,16 +56,16 @@ RUN npm run build
 FROM ${BASE_IMAGE} AS runtime
 WORKDIR /srv/webssh2
 
-# Install tini for proper signal handling and zombie process reaping
-RUN apk add --no-cache tini
-
-# Upgrade the bundled npm CLI. node:22-alpine ships npm 10.x whose vendored
+# Install tini for proper signal handling and zombie process reaping, and
+# upgrade the bundled npm CLI. node:22-alpine ships npm 10.x whose vendored
 # tar/sigstore/brace-expansion carry CVEs (incl. CVE-2026-59873, CRITICAL)
 # that are only fixed in npm >= 11.18.0 and will never be backported to 10.x,
 # so waiting on base-image digest bumps cannot clear them. npm must remain in
 # the runtime image for the operator host-key CLI (npm run hostkeys:prod).
 # Pinned exact per supply-chain policy; bump deliberately.
-RUN npm install -g npm@11.18.0 && npm cache clean --force
+RUN apk add --no-cache tini \
+  && npm install -g --ignore-scripts npm@11.18.0 \
+  && npm cache clean --force
 
 ENV NODE_ENV=production \
     PORT=2222 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,14 @@ WORKDIR /srv/webssh2
 # Install tini for proper signal handling and zombie process reaping
 RUN apk add --no-cache tini
 
+# Upgrade the bundled npm CLI. node:22-alpine ships npm 10.x whose vendored
+# tar/sigstore/brace-expansion carry CVEs (incl. CVE-2026-59873, CRITICAL)
+# that are only fixed in npm >= 11.18.0 and will never be backported to 10.x,
+# so waiting on base-image digest bumps cannot clear them. npm must remain in
+# the runtime image for the operator host-key CLI (npm run hostkeys:prod).
+# Pinned exact per supply-chain policy; bump deliberately.
+RUN npm install -g npm@11.18.0 && npm cache clean --force
+
 ENV NODE_ENV=production \
     PORT=2222 \
     WEBSSH2_LISTEN_IP=0.0.0.0 \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -286,11 +286,67 @@ This vulnerability affects the `fromJSON` and `fromCrossJSON` functions in clien
 
 **Mitigation status:**
 
-- The `.trivyignore` file at the repo root suppresses this single CVE for the
-  Trivy image scan gate so unrelated image regressions still fail the build.
-- Tracking upstream: re-evaluate when `node:22-alpine` ships a bundled
-  `npm` whose `picomatch` is `>= 4.0.4`. At that point Renovate's auto-merged
-  digest bump will land the fix and the `.trivyignore` entry should be removed.
+- **Resolved 2026-07-28**: the Dockerfile runtime stage now upgrades the
+  bundled npm to a pinned `npm@11.18.0`, which vendors picomatch 4.0.4
+  (patched). The `.trivyignore` entry has been removed.
+
+### CVE-2026-14257 (brace-expansion DoS in bundled npm)
+
+| Aspect             | Status                                                                         |
+| ------------------ | ------------------------------------------------------------------------------ |
+| Vulnerability type | Denial of Service via unbounded expansion length (out-of-memory crash)         |
+| Affected versions  | brace-expansion <= 5.0.7 (fixed in 5.0.8, published 2026-07-23)                |
+| Our exposure       | brace-expansion 5.0.7 vendored inside the pinned global `npm@11.18.0`          |
+| Path on disk       | `/usr/local/lib/node_modules/npm/node_modules/brace-expansion` (runtime image) |
+| Status             | **Not exploitable** — bundled `npm` never processes attacker-controlled globs  |
+
+**Why we are not affected:**
+
+- The container's `ENTRYPOINT` is `tini` and `CMD` is `node dist/index.js`;
+  the application never invokes `npm` or loads code from the global npm
+  install.
+- The only supported use of `npm` inside the container is the operator-run
+  `npm run hostkeys:prod` host-key CLI, which executes first-party
+  package.json scripts. No attacker-controlled glob patterns reach npm's
+  brace-expansion.
+- As of 2026-07-28 no published npm release vendors brace-expansion 5.0.8
+  (the fix postdates every npm release), so no upgrade path exists yet.
+
+**Mitigation status:**
+
+- The Dockerfile runtime stage pins `npm@11.18.0`, which already remediates
+  the more severe bundled-npm findings (tar CVE-2026-59873 CRITICAL /
+  CVE-2026-59874 HIGH, sigstore CVE-2026-48815 HIGH).
+- The `.trivyignore` file suppresses this single CVE for the Trivy image
+  scan gate so unrelated image regressions still fail the build.
+- Re-evaluate on each npm release: bump the pinned npm version in the
+  Dockerfile once a release vendors brace-expansion >= 5.0.8, then remove
+  the `.trivyignore` entry.
+
+### GHSA-mh99-v99m-4gvg (brace-expansion 1.x in dev toolchain, npm audit)
+
+| Aspect             | Status                                                                        |
+| ------------------ | ----------------------------------------------------------------------------- |
+| Vulnerability type | Denial of Service via unbounded expansion length (same root as CVE-2026-14257)|
+| Affected versions  | advisory range <= 5.0.7; only 5.0.8 listed as patched as of 2026-07-28        |
+| Our exposure       | brace-expansion 1.1.16 via `minimatch@3` inside the eslint dev toolchain      |
+| Status             | **Not exploitable** — devDependencies only; never shipped or run in production|
+
+**Why we are not affected:**
+
+- The vulnerable copy exists only under `@eslint/config-array`,
+  `@eslint/eslintrc`, and `eslint-plugin-node` — all devDependencies. It is
+  absent from the production install (`npm ci --omit=dev`) and the Docker
+  image.
+- Lint glob patterns are first-party (eslint config), not attacker input.
+- No patched 1.x release of brace-expansion exists, and overriding the 1.x
+  copy with 2.x/5.x breaks minimatch@3 at runtime (the CommonJS default
+  export was replaced by a named `expand` export). Upstream backports for the
+  2.x/3.x lines landed 2026-07-27/28; a 1.x backport and updated advisory
+  ranges are expected shortly.
+- Re-evaluate when brace-expansion publishes a patched 1.x release (then
+  `npm audit fix` clears it) or when the GitHub advisory adds per-line
+  patched ranges.
 
 ---
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -54,7 +54,7 @@ sonar.issue.ignore.multicriteria.e9.resourceKey=tests/test-constants.ts
 sonar.issue.ignore.multicriteria.e10.ruleKey=typescript:S1313
 sonar.issue.ignore.multicriteria.e10.resourceKey=tests/test-constants.ts
 sonar.issue.ignore.multicriteria.e11.ruleKey=docker:S8431
-sonar.issue.ignore.multicriteria.e11.resourceKey=Dockerfile
+sonar.issue.ignore.multicriteria.e11.resourceKey=**/Dockerfile
 sonar.issue.ignore.multicriteria.e12.ruleKey=githubactions:S7631
 sonar.issue.ignore.multicriteria.e12.resourceKey=.github/workflows/rebuild-release-tags.yml
 


### PR DESCRIPTION
## Summary

The `docker-image-scan` gate started failing on all branches after Trivy's DB picked up new advisories for packages vendored inside the npm CLI bundled in `node:22-alpine` (npm 10.x):

| Package | CVE | Severity | Fixed in |
| --- | --- | --- | --- |
| tar 7.5.11 | CVE-2026-59873 | CRITICAL | 7.5.19 |
| tar 7.5.11 | CVE-2026-59874 | HIGH | 7.5.18 |
| sigstore 3.1.0 | CVE-2026-48815 | HIGH | 4.1.1 |
| brace-expansion 2.0.2 | CVE-2026-13149 / CVE-2026-14257 | HIGH | 2.1.2 / 5.0.8 |

None of these fixes will ever be backported to npm 10.x, so waiting on base-image digest bumps cannot clear them. npm must stay in the runtime image for the operator host-key CLI (`npm run hostkeys:prod`).

## Changes

- **Dockerfile**: runtime stage installs a pinned `npm@11.18.0` (published 2026-06-29, clears the 14-day quarantine), which vendors patched tar 7.5.19, sigstore 4.1.1, and picomatch 4.0.4
- **.trivyignore**: retires CVE-2026-33671 (picomatch — now patched via the npm upgrade); adds CVE-2026-14257 (brace-expansion 5.0.7 inside npm — the 5.0.8 fix postdates every npm release, so no upgrade path exists yet; entry has a documented re-evaluation trigger)
- **SECURITY.md**: closes out the picomatch assessment, adds assessments for CVE-2026-14257 (bundled npm) and GHSA-mh99-v99m-4gvg (brace-expansion 1.x in the eslint dev toolchain, currently unfixable upstream — blocks the npm-audit gate on #554)

## Verification

- Image built locally and scanned with Trivy using CI's exact settings (`--severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore --exit-code 1`): **exit code 0**
- Confirmed vendored versions inside the image: tar 7.5.19, sigstore 4.1.1, picomatch 4.0.4, npm 11.18.0
- `markdownlint-cli2`: 0 issues