### PR TITLE
feat(config): shiftEnterNewline option + client config injection

### DIFF
--- a/DOCS/client/KEYBOARD_CAPTURE.md
+++ b/DOCS/client/KEYBOARD_CAPTURE.md
@@ -415,3 +415,14 @@ Main function that determines if a key should be captured by the terminal.
   - Added capture Ctrl+B setting
   - Added custom capture keys
   - Updated Terminal Settings UI with collapsible sections
+
+## Shift+Enter Newline
+
+By default Shift+Enter is indistinguishable from Enter (both send `CR`,
+a VT100 limitation). With `options.terminal.shiftEnterNewline` enabled
+(or the "Shift+Enter Newline" toggle in Terminal Settings), the client
+sends `ESC`+`CR` instead, which Claude Code and most readline-style
+TUIs treat as "insert newline". See
+[#497](https://github.com/billchurch/webssh2/issues/497). This is an
+interim shim until a stable xterm.js release supports the Kitty
+keyboard protocol.

--- a/DOCS/configuration/CONFIG-JSON.md
+++ b/DOCS/configuration/CONFIG-JSON.md
@@ -334,6 +334,15 @@ You can choose whether credential replay sends a carriage return (CR) or carriag
 
 This option can also be controlled via the environment variable `WEBSSH2_OPTIONS_REPLAY_CRLF`.
 
+- `options.terminal.shiftEnterNewline` (boolean, default `false`): When
+  `true`, the client remaps Shift+Enter to send `ESC`+`CR` (`\x1b\r`)
+  instead of `CR`, letting TUIs like Claude Code distinguish "insert
+  newline" from "submit"
+  ([#497](https://github.com/billchurch/webssh2/issues/497)). Users can
+  override this per browser in the client's Terminal Settings. Interim
+  shim until xterm.js ships Kitty keyboard protocol support in a stable
+  release.
+
 ### SSH Environment Variable Allowlist
 
 Control which environment variable names are forwarded to the SSH session. If unset or empty, WebSSH2 applies format/value filtering but does not restrict by name beyond that.

--- a/DOCS/configuration/CONFIG-JSON.md
+++ b/DOCS/configuration/CONFIG-JSON.md
@@ -334,6 +334,8 @@ You can choose whether credential replay sends a carriage return (CR) or carriag
 
 This option can also be controlled via the environment variable `WEBSSH2_OPTIONS_REPLAY_CRLF`.
 
+### Terminal Options
+
 - `options.terminal.shiftEnterNewline` (boolean, default `false`): When
   `true`, the client remaps Shift+Enter to send `ESC`+`CR` (`\x1b\r`)
   instead of `CR`, letting TUIs like Claude Code distinguish "insert

--- a/DOCS/configuration/ENVIRONMENT-VARIABLES.md
+++ b/DOCS/configuration/ENVIRONMENT-VARIABLES.md
@@ -599,6 +599,7 @@ docker run --name webssh2 --rm -it \
 | `WEBSSH2_OPTIONS_ALLOW_RECONNECT` | boolean | `true` | Allow reconnection |
 | `WEBSSH2_OPTIONS_ALLOW_REPLAY` | boolean | `true` | Allow session replay |
 | `WEBSSH2_OPTIONS_REPLAY_CRLF` | boolean | `false` | Send CRLF for credential replay (default is CR) |
+| `WEBSSH2_TERMINAL_SHIFT_ENTER_NEWLINE` | boolean | `false` | Remap Shift+Enter to ESC+CR (newline in Claude Code-style TUIs) |
 
 ### Terminal Theming (`options.theming`)
 

--- a/app/config/default-config.ts
+++ b/app/config/default-config.ts
@@ -137,6 +137,7 @@ export const DEFAULT_CONFIG_BASE: Omit<Config, 'session'> & { session: Omit<Conf
     allowReconnect: true,
     allowReplay: true,
     replayCRLF: false,
+    terminal: { shiftEnterNewline: false },
     theming: DEFAULT_THEMING_CONFIG,
   },
   session: {

--- a/app/config/env-mapper.ts
+++ b/app/config/env-mapper.ts
@@ -76,6 +76,8 @@ export const ENV_VAR_MAPPING: Record<string, EnvVarMap> = {
   WEBSSH2_OPTIONS_ALLOW_RECONNECT: { path: 'options.allowReconnect', type: 'boolean' },
   WEBSSH2_OPTIONS_ALLOW_REPLAY: { path: 'options.allowReplay', type: 'boolean' },
   WEBSSH2_OPTIONS_REPLAY_CRLF: { path: 'options.replayCRLF', type: 'boolean' },
+  // Shift+Enter → ESC+CR remap (billchurch/webssh2#497)
+  WEBSSH2_TERMINAL_SHIFT_ENTER_NEWLINE: { path: 'options.terminal.shiftEnterNewline', type: 'boolean' },
   WEBSSH2_SESSION_SECRET: { path: 'session.secret', type: 'string' },
   WEBSSH2_SESSION_NAME: { path: 'session.name', type: 'string' },
   WEBSSH2_SSO_ENABLED: { path: 'sso.enabled', type: 'boolean' },

--- a/app/connectionHandler.ts
+++ b/app/connectionHandler.ts
@@ -151,6 +151,15 @@ function buildHeaderConfig(
   return { header }
 }
 
+function buildTerminalConfig(cfg: Config): Record<string, unknown> {
+  // Only injected when enabled — keeps the config payload byte-identical
+  // for deployments that have not opted in (billchurch/webssh2#497).
+  if (cfg.options.terminal?.shiftEnterNewline !== true) {
+    return {}
+  }
+  return { terminal: { shiftEnterNewline: true } }
+}
+
 async function sendClient(
   config: Record<string, unknown>,
   res: Response,
@@ -238,6 +247,7 @@ export function buildTempConfig(
   Object.assign(tempConfig, buildConnectionMode(opts))
   Object.assign(tempConfig, buildSshCredentials(req.session, req))
   Object.assign(tempConfig, buildHeaderConfig(cfg, req.session))
+  Object.assign(tempConfig, buildTerminalConfig(cfg))
   return tempConfig
 }
 

--- a/app/schemas/config-schema.ts
+++ b/app/schemas/config-schema.ts
@@ -188,6 +188,15 @@ const ThemingSchema = z.object({
 }).optional()
 
 /**
+ * Terminal configuration schema
+ */
+const OptionsTerminalSchema = z
+  .object({
+    shiftEnterNewline: z.boolean()
+  })
+  .optional()
+
+/**
  * Options configuration schema
  */
 const OptionsSchema = z.object({
@@ -197,6 +206,7 @@ const OptionsSchema = z.object({
   allowReconnect: z.boolean(),
   allowReplay: z.boolean(),
   replayCRLF: z.boolean().optional(),
+  terminal: OptionsTerminalSchema,
   theming: ThemingSchema
 })
 

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -161,6 +161,11 @@ export interface ThemingConfig {
   readonly headerBackground: ThemingHeaderBackground
 }
 
+/** Opt-in client terminal behavior toggles delivered via config injection */
+export interface OptionsTerminalConfig {
+  readonly shiftEnterNewline: boolean
+}
+
 /**
  * Options configuration
  */
@@ -171,6 +176,7 @@ export interface OptionsConfig {
   allowReconnect: boolean
   allowReplay: boolean
   replayCRLF?: boolean
+  terminal?: OptionsTerminalConfig
   theming?: ThemingConfig
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "socket.io": "^4.8.1",
         "ssh2": "1.17",
         "validator": "^13.15.35",
-        "webssh2_client": "5.1.0",
+        "webssh2_client": "5.2.0",
         "zod": "^4.1.12"
       },
       "bin": {
@@ -6067,9 +6067,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/webssh2_client": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-5.1.0.tgz",
-      "integrity": "sha512-XeXGjmjSY1XyzZmR6Axo7gV+2Ct/vF1+xXht3xMM3JVM4USVF2FIDm+InSAXQPzqEO8LjoLdOx+PwnQqxjGWnQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-5.2.0.tgz",
+      "integrity": "sha512-dFh6bvHtnH4zYyxNhYq+M+pguRtpSOiZXvEx2sufjh8a8O/afx6D2QhhT+8e2swKIIQKdzcwmVVt/EFxtZOYow==",
       "license": "MIT",
       "engines": {
         "node": ">= 22"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "socket.io": "^4.8.1",
     "ssh2": "1.17",
     "validator": "^13.15.35",
-    "webssh2_client": "5.1.0",
+    "webssh2_client": "5.2.0",
     "zod": "^4.1.12"
   },
   "scripts": {

--- a/tests/unit/config/env-mapper-shift-enter.vitest.ts
+++ b/tests/unit/config/env-mapper-shift-enter.vitest.ts
@@ -1,0 +1,30 @@
+// tests/unit/config/env-mapper-shift-enter.vitest.ts
+
+import { describe, it, expect } from 'vitest'
+import { mapEnvironmentVariables } from '../../../app/config/env-mapper.js'
+
+type OptionsOut = { terminal?: { shiftEnterNewline?: boolean } } | undefined
+
+describe('env-mapper WEBSSH2_TERMINAL_SHIFT_ENTER_NEWLINE', () => {
+  it('maps "true" to options.terminal.shiftEnterNewline', () => {
+    const out = mapEnvironmentVariables({
+      WEBSSH2_TERMINAL_SHIFT_ENTER_NEWLINE: 'true'
+    })
+    const options = out['options'] as OptionsOut
+    expect(options?.terminal?.shiftEnterNewline).toBe(true)
+  })
+
+  it('maps "false" explicitly', () => {
+    const out = mapEnvironmentVariables({
+      WEBSSH2_TERMINAL_SHIFT_ENTER_NEWLINE: 'false'
+    })
+    const options = out['options'] as OptionsOut
+    expect(options?.terminal?.shiftEnterNewline).toBe(false)
+  })
+
+  it('is absent when the env var is not set', () => {
+    const out = mapEnvironmentVariables({})
+    const options = out['options'] as OptionsOut
+    expect(options?.terminal).toBeUndefined()
+  })
+})

--- a/tests/unit/config/options-terminal-shift-enter.vitest.ts
+++ b/tests/unit/config/options-terminal-shift-enter.vitest.ts
@@ -31,7 +31,7 @@ describe('options.terminal.shiftEnterNewline', () => {
       ...cfg,
       options: { ...cfg.options, terminal: { shiftEnterNewline: 'yes' } }
     }
-    const result = validateConfigSchema(bad as never)
+    const result = validateConfigSchema(bad)
     expect(result.ok).toBe(false)
   })
 

--- a/tests/unit/config/options-terminal-shift-enter.vitest.ts
+++ b/tests/unit/config/options-terminal-shift-enter.vitest.ts
@@ -37,6 +37,7 @@ describe('options.terminal.shiftEnterNewline', () => {
 
   it('stays valid when the terminal block is absent (older config.json)', () => {
     const cfg = createDefaultConfig(TEST_SECRET_123)
+    // eslint-disable-next-line @typescript-eslint/naming-convention, sonarjs/no-unused-vars -- intentional discard destructure
     const { terminal: _terminal, ...optionsWithout } = cfg.options
     const result = validateConfigSchema({ ...cfg, options: optionsWithout })
     expect(result.ok).toBe(true)

--- a/tests/unit/config/options-terminal-shift-enter.vitest.ts
+++ b/tests/unit/config/options-terminal-shift-enter.vitest.ts
@@ -1,0 +1,44 @@
+// tests/unit/config/options-terminal-shift-enter.vitest.ts
+// options.terminal.shiftEnterNewline (billchurch/webssh2#497)
+
+import { describe, it, expect } from 'vitest'
+import { validateConfigSchema } from '../../../app/utils/schema-validator.js'
+import { createDefaultConfig } from '../../../app/config/config-processor.js'
+import { TEST_SECRET_123 } from '../../test-constants.js'
+
+describe('options.terminal.shiftEnterNewline', () => {
+  it('defaults to false', () => {
+    const cfg = createDefaultConfig(TEST_SECRET_123)
+    expect(cfg.options.terminal?.shiftEnterNewline).toBe(false)
+  })
+
+  it('passes schema validation when enabled', () => {
+    const cfg = createDefaultConfig(TEST_SECRET_123)
+    const enabled = {
+      ...cfg,
+      options: { ...cfg.options, terminal: { shiftEnterNewline: true } }
+    }
+    const result = validateConfigSchema(enabled)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.options.terminal?.shiftEnterNewline).toBe(true)
+    }
+  })
+
+  it('rejects a non-boolean value', () => {
+    const cfg = createDefaultConfig(TEST_SECRET_123)
+    const bad = {
+      ...cfg,
+      options: { ...cfg.options, terminal: { shiftEnterNewline: 'yes' } }
+    }
+    const result = validateConfigSchema(bad as never)
+    expect(result.ok).toBe(false)
+  })
+
+  it('stays valid when the terminal block is absent (older config.json)', () => {
+    const cfg = createDefaultConfig(TEST_SECRET_123)
+    const { terminal: _terminal, ...optionsWithout } = cfg.options
+    const result = validateConfigSchema({ ...cfg, options: optionsWithout })
+    expect(result.ok).toBe(true)
+  })
+})

--- a/tests/unit/connection-handler/terminal-injection.vitest.ts
+++ b/tests/unit/connection-handler/terminal-injection.vitest.ts
@@ -1,0 +1,63 @@
+// tests/unit/connection-handler/terminal-injection.vitest.ts
+// buildTempConfig terminal slice (billchurch/webssh2#497)
+
+import { describe, it, expect } from 'vitest'
+import type { Request } from 'express'
+import { buildTempConfig } from '../../../app/connectionHandler.js'
+import { createDefaultConfig } from '../../../app/config/config-processor.js'
+import type { AuthSession } from '../../../app/auth/auth-utils.js'
+import type { Config } from '../../../app/types/config.js'
+import { TEST_SSH } from '../../test-constants.js'
+
+type TestReq = Request & { session?: AuthSession; sessionID?: string }
+
+function makeReq(): TestReq {
+  return {
+    path: '/host/',
+    protocol: 'https',
+    get: ((key: string) =>
+      key === 'host' ? TEST_SSH.HOST : undefined) as unknown as Request['get'],
+    session: {
+      sshCredentials: {
+        host: TEST_SSH.HOST,
+        port: TEST_SSH.PORT,
+        term: 'xterm'
+      },
+      usedBasicAuth: false,
+      authMethod: 'password',
+      headerOverride: undefined
+    },
+    sessionID: 'test-session-id'
+  } as TestReq
+}
+
+const defaultConfig = createDefaultConfig()
+
+function cfgWithShiftEnter(enabled: boolean): Config {
+  return {
+    ...defaultConfig,
+    options: {
+      ...defaultConfig.options,
+      terminal: { shiftEnterNewline: enabled }
+    }
+  }
+}
+
+describe('buildTempConfig - terminal slice', () => {
+  it('injects terminal.shiftEnterNewline when enabled', () => {
+    const tempConfig = buildTempConfig(makeReq(), cfgWithShiftEnter(true))
+    expect(tempConfig['terminal']).toEqual({ shiftEnterNewline: true })
+  })
+
+  it('omits the terminal key entirely when disabled', () => {
+    const tempConfig = buildTempConfig(makeReq(), cfgWithShiftEnter(false))
+    expect('terminal' in tempConfig).toBe(false)
+  })
+
+  it('omits the terminal key when options.terminal is absent', () => {
+    const { terminal: _terminal, ...optionsWithout } = defaultConfig.options
+    const cfg = { ...defaultConfig, options: optionsWithout } as Config
+    const tempConfig = buildTempConfig(makeReq(), cfg)
+    expect('terminal' in tempConfig).toBe(false)
+  })
+})

--- a/tests/unit/connection-handler/terminal-injection.vitest.ts
+++ b/tests/unit/connection-handler/terminal-injection.vitest.ts
@@ -57,7 +57,7 @@ describe('buildTempConfig - terminal slice', () => {
   it('omits the terminal key when options.terminal is absent', () => {
     // eslint-disable-next-line @typescript-eslint/naming-convention, sonarjs/no-unused-vars -- intentional discard destructure
     const { terminal: _terminal, ...optionsWithout } = defaultConfig.options
-    const cfg = { ...defaultConfig, options: optionsWithout } as Config
+    const cfg = { ...defaultConfig, options: optionsWithout }
     const tempConfig = buildTempConfig(makeReq(), cfg)
     expect('terminal' in tempConfig).toBe(false)
   })

--- a/tests/unit/connection-handler/terminal-injection.vitest.ts
+++ b/tests/unit/connection-handler/terminal-injection.vitest.ts
@@ -55,6 +55,7 @@ describe('buildTempConfig - terminal slice', () => {
   })
 
   it('omits the terminal key when options.terminal is absent', () => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention, sonarjs/no-unused-vars -- intentional discard destructure
     const { terminal: _terminal, ...optionsWithout } = defaultConfig.options
     const cfg = { ...defaultConfig, options: optionsWithout } as Config
     const tempConfig = buildTempConfig(makeReq(), cfg)


### PR DESCRIPTION
Server side of the interim Shift+Enter fix for #497.

- New `options.terminal.shiftEnterNewline` (default **off**) +
  `WEBSSH2_TERMINAL_SHIFT_ENTER_NEWLINE` env var
- `buildTempConfig` injects `terminal: { shiftEnterNewline: true }`
  into the client config block only when enabled; payload is
  byte-identical when off
- Safe with the currently pinned client (5.1.0): older bundles simply
  ignore the extra key. The client-side remap ships in
  billchurch/webssh2_client and lands here later via an exact pin bump.
- Docs: CONFIG-JSON, ENVIRONMENT-VARIABLES, KEYBOARD_CAPTURE

Refs #497

https://claude.ai/code/session_012jwDZSEKBhuQmhQuGujHC1