### PR TITLE
fix: resolve remaining 37 SonarCloud findings (phases 2-4)

### DIFF
--- a/.devcontainer/scripts/tools.sh
+++ b/.devcontainer/scripts/tools.sh
@@ -40,7 +40,14 @@ chmod 644 ~/.ssh/allowed_signers
 
 echo "allowed_signers file created successfully."
 
-npm install
+# Skip dependency lifecycle scripts (supply-chain hardening), then run the
+# ones this workspace needs explicitly: the better-sqlite3 native binding used
+# by the host-key store, and this repo's own postinstall.
+npm install --ignore-scripts
+
+npm rebuild better-sqlite3
+
+npm run prepare:runtime
 
 npm cache clean --force
 sudo apt-get clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,18 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        # Skip lifecycle scripts so a compromised dependency cannot execute
+        # arbitrary code in CI; the scripts this pipeline actually needs are
+        # re-run explicitly in the next step.
+        run: npm ci --ignore-scripts
+
+      - name: Restore native/runtime dependencies
+        # better-sqlite3 is the only runtime-critical native module (host-key
+        # store); its prebuilt binding is fetched by its install script.
+        # prepare:runtime is this repo's own postinstall, run explicitly.
+        run: |
+          npm rebuild better-sqlite3
+          npm run prepare:runtime
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/e2e-ssh.yml
+++ b/.github/workflows/e2e-ssh.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run E2E tests with containerized sshd
         env:
           ENABLE_E2E_SSH: '1'
-        run: npx playwright test -c playwright.config.ts tests/playwright/e2e-ssh-acceptenv.spec.ts
+        run: npx --no-install playwright test -c playwright.config.ts tests/playwright/e2e-ssh-acceptenv.spec.ts
 
       - name: Upload Playwright report (if present)
         if: always()

--- a/.github/workflows/e2e-ssh.yml
+++ b/.github/workflows/e2e-ssh.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run E2E tests with containerized sshd
         env:
           ENABLE_E2E_SSH: '1'
-        run: npx --no-install playwright test -c playwright.config.ts tests/playwright/e2e-ssh-acceptenv.spec.ts
+        run: npx --no-install playwright test -c playwright.config.ts tests/playwright/e2e-ssh-acceptenv-v2.spec.ts
 
       - name: Upload Playwright report (if present)
         if: always()

--- a/.github/workflows/rebuild-release-tags.yml
+++ b/.github/workflows/rebuild-release-tags.yml
@@ -325,7 +325,7 @@ jobs:
       - name: Snapshot existing sha-tag digest (for post-push assertion)
         run: |
           short="${RELEASE_SHA:0:7}"
-          before=$(curl -fsSL "https://hub.docker.com/v2/repositories/billchurch/webssh2/tags/sha-${short}" \
+          before=$(curl -fsSL --proto '=https' --proto-redir '=https' "https://hub.docker.com/v2/repositories/billchurch/webssh2/tags/sha-${short}" \
             | jq -r '.digest' 2>/dev/null || echo "")
           echo "SHA_TAG_SHORT=${short}"          >> "$GITHUB_ENV"
           echo "SHA_TAG_DIGEST_BEFORE=${before}" >> "$GITHUB_ENV"
@@ -392,7 +392,7 @@ jobs:
       - name: Assert sha-tag digest unchanged
         if: env.SIMULATE != 'true'
         run: |
-          after=$(curl -fsSL "https://hub.docker.com/v2/repositories/billchurch/webssh2/tags/sha-${SHA_TAG_SHORT}" \
+          after=$(curl -fsSL --proto '=https' --proto-redir '=https' "https://hub.docker.com/v2/repositories/billchurch/webssh2/tags/sha-${SHA_TAG_SHORT}" \
             | jq -r '.digest')
           if [ "$after" != "${SHA_TAG_DIGEST_BEFORE}" ]; then
             echo "::error::sha-${SHA_TAG_SHORT} digest changed from ${SHA_TAG_DIGEST_BEFORE} to ${after}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,16 @@ WORKDIR /srv/webssh2
 COPY package.json package-lock.json ./
 COPY scripts ./scripts
 
+# Lifecycle scripts are skipped so a compromised dependency cannot execute
+# arbitrary code during the build. better-sqlite3 is the only runtime-critical
+# native module (host-key store), so its install script is re-run explicitly
+# via npm rebuild. The repo's own postinstall (prepare:runtime) only fetches a
+# rollup native binary for bundlers; the build here is plain tsc, and anything
+# it installs --no-save is dropped by the runtime stage's npm prune, so it is
+# deliberately not run.
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --omit=optional --audit=false --fund=false
+    npm ci --omit=optional --audit=false --fund=false --ignore-scripts \
+  && npm rebuild better-sqlite3
 
 
 # =============================================================================

--- a/app/config/env-mapper.ts
+++ b/app/config/env-mapper.ts
@@ -212,6 +212,186 @@ const BUILTIN_THEME_NAMES: readonly string[] = [
 /** Valid values for the headerBackground theming option */
 const VALID_HEADER_BACKGROUND = new Set(['independent', 'followTerminal', 'locked'])
 
+const ADDITIONAL_THEMES_ENV = 'WEBSSH2_THEMING_ADDITIONAL_THEMES'
+const ADDITIONAL_THEMES_PATH = 'options.theming.additionalThemes'
+
+/** A resolved assignment: the config path to write and the value to write there */
+type ConfigEntry = readonly [path: string, value: unknown]
+
+/** Theming assignments plus the warnings raised while resolving them */
+interface ThemingResolution {
+  readonly entries: readonly ConfigEntry[]
+  readonly warnings: readonly ThemeValidationWarning[]
+}
+
+/**
+ * Read an environment variable as a string, treating absent and non-string
+ * values alike as unset.
+ * @pure
+ */
+function readEnvString(
+  env: Record<string, string | undefined>,
+  name: string
+): string | undefined {
+  const value = safeGet(env, createSafeKey(name))
+  return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * Resolve the algorithm preset into a base `ssh.algorithms` assignment.
+ * Yields nothing when the preset is unset or unrecognized.
+ * @pure
+ */
+function collectPresetEntries(env: Record<string, string | undefined>): readonly ConfigEntry[] {
+  const presetVar = ALGORITHM_ENV_VARS.PRESET
+  const presetName = readEnvString(env, presetVar)
+  if (presetName === undefined) {
+    return []
+  }
+
+  const preset = getAlgorithmPreset(presetName)
+  if (preset === undefined) {
+    return []
+  }
+
+  const presetMapping = safeGet(ENV_VAR_MAPPING, createSafeKey(presetVar)) as EnvVarMap | undefined
+  if (presetMapping === undefined) {
+    return []
+  }
+
+  // Clone the preset to avoid mutating the global ALGORITHM_PRESETS object
+  const presetClone = {
+    cipher: [...preset.cipher],
+    kex: [...preset.kex],
+    hmac: [...preset.hmac],
+    compress: [...preset.compress],
+    serverHostKey: [...preset.serverHostKey]
+  }
+  return [[presetMapping.path, presetClone]]
+}
+
+/**
+ * Resolve every non-preset variable in ENV_VAR_MAPPING that is set in `env`.
+ * Preset is skipped here because it is applied first, so these individual
+ * assignments overwrite the preset values.
+ * @pure
+ */
+function collectMappedEntries(env: Record<string, string | undefined>): readonly ConfigEntry[] {
+  const entries: ConfigEntry[] = []
+  for (const [envVar, mapping] of Object.entries(ENV_VAR_MAPPING)) {
+    if (mapping.type === 'preset') {
+      continue
+    }
+
+    // Access restricted to known keys from ENV_VAR_MAPPING
+    const envValue = readEnvString(env, envVar)
+    if (envValue !== undefined) {
+      entries.push([mapping.path, parseEnvValue(envValue, mapping.type)])
+    }
+  }
+  return entries
+}
+
+/**
+ * Resolve the themes allowlist, dropping names that fail THEME_NAME_REGEX.
+ * @pure
+ */
+function collectThemeNamesEntries(env: Record<string, string | undefined>): readonly ConfigEntry[] {
+  const raw = readEnvString(env, 'WEBSSH2_THEMING_THEMES')
+  if (raw === undefined) {
+    return []
+  }
+
+  const valid = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => THEME_NAME_REGEX.test(s))
+  return [['options.theming.themes', valid]]
+}
+
+/**
+ * Resolve the default theme, falling back to 'Default' when malformed.
+ * @pure
+ */
+function collectDefaultThemeEntries(env: Record<string, string | undefined>): readonly ConfigEntry[] {
+  const raw = readEnvString(env, 'WEBSSH2_THEMING_DEFAULT_THEME')
+  if (raw === undefined) {
+    return []
+  }
+
+  const trimmed = raw.trim()
+  const resolved = THEME_NAME_REGEX.test(trimmed) ? trimmed : 'Default'
+  return [['options.theming.defaultTheme', resolved]]
+}
+
+/**
+ * Resolve the header background mode, leaving it unset when not recognized.
+ * @pure
+ */
+function collectHeaderBackgroundEntries(
+  env: Record<string, string | undefined>
+): readonly ConfigEntry[] {
+  const raw = readEnvString(env, 'WEBSSH2_THEMING_HEADER_BACKGROUND')
+  if (raw === undefined || !VALID_HEADER_BACKGROUND.has(raw)) {
+    return []
+  }
+
+  return [['options.theming.headerBackground', raw]]
+}
+
+/**
+ * Resolve the base64 JSON additional-themes payload. A payload that fails to
+ * decode yields an empty theme list plus a single warning describing why.
+ * @pure
+ */
+function resolveAdditionalThemes(env: Record<string, string | undefined>): ThemingResolution {
+  const raw = readEnvString(env, ADDITIONAL_THEMES_ENV)
+  if (raw === undefined) {
+    return { entries: [], warnings: [] }
+  }
+
+  const parsed = parseBase64JsonArrayEnv(raw)
+  if (parsed.ok) {
+    const loaded = loadAdditionalThemes(parsed.value, {
+      source: ADDITIONAL_THEMES_ENV,
+      builtinNames: BUILTIN_THEME_NAMES,
+    })
+    return {
+      entries: [[ADDITIONAL_THEMES_PATH, loaded.valid]],
+      warnings: loaded.warnings
+    }
+  }
+
+  return {
+    entries: [[ADDITIONAL_THEMES_PATH, []]],
+    warnings: [
+      {
+        source: ADDITIONAL_THEMES_ENV,
+        path: '',
+        reason: parsed.detail === undefined ? parsed.reason : `${parsed.reason}: ${parsed.detail}`
+      }
+    ]
+  }
+}
+
+/**
+ * Resolve the theming env vars that require bespoke validation beyond the
+ * generic ENV_VAR_MAPPING parsing.
+ * @pure
+ */
+function resolveThemingEnv(env: Record<string, string | undefined>): ThemingResolution {
+  const additional = resolveAdditionalThemes(env)
+  return {
+    entries: [
+      ...collectThemeNamesEntries(env),
+      ...collectDefaultThemeEntries(env),
+      ...collectHeaderBackgroundEntries(env),
+      ...additional.entries
+    ],
+    warnings: additional.warnings
+  }
+}
+
 /**
  * Map environment variables to configuration object
  * Individual algorithm settings take precedence over preset values
@@ -224,94 +404,22 @@ export function mapEnvironmentVariables(
   env: Record<string, string | undefined>,
   hooks?: EnvMapperHooks
 ): Record<string, unknown> {
+  const theming = resolveThemingEnv(env)
+  // Order matters: the preset supplies base algorithm values, and the
+  // individual variables applied after it overwrite the ones they name.
+  const entries = [
+    ...collectPresetEntries(env),
+    ...collectMappedEntries(env),
+    ...theming.entries
+  ]
+
   const config: Record<string, unknown> = {}
-
-  // First pass: process preset if it exists (provides base algorithm values)
-  const presetVar = ALGORITHM_ENV_VARS.PRESET
-  const presetValue = safeGet(env, createSafeKey(presetVar))
-  if (presetValue !== undefined && typeof presetValue === 'string') {
-    const preset = getAlgorithmPreset(presetValue)
-    if (preset != null) {
-      const presetMapping = safeGet(ENV_VAR_MAPPING, createSafeKey(presetVar)) as EnvVarMap | undefined
-      if (presetMapping !== undefined) {
-        // Clone the preset to avoid mutating the global ALGORITHM_PRESETS object
-        const presetClone = {
-          cipher: [...preset.cipher],
-          kex: [...preset.kex],
-          hmac: [...preset.hmac],
-          compress: [...preset.compress],
-          serverHostKey: [...preset.serverHostKey]
-        }
-        setNestedProperty(config, presetMapping.path, presetClone)
-      }
-    }
+  for (const [path, value] of entries) {
+    setNestedProperty(config, path, value)
   }
 
-  // Second pass: process all non-preset variables (individual overrides take precedence)
-  for (const [envVar, mapping] of Object.entries(ENV_VAR_MAPPING)) {
-    // Skip preset since it was already processed
-    if (mapping.type === 'preset') {
-      continue
-    }
-
-    // Access restricted to known keys from ENV_VAR_MAPPING
-    const envValue = safeGet(env, createSafeKey(envVar))
-    if (envValue !== undefined && typeof envValue === 'string') {
-      const parsedValue = parseEnvValue(envValue, mapping.type)
-      setNestedProperty(config, mapping.path, parsedValue)
-    }
-  }
-
-  // Third pass: complex theming env vars that require bespoke validation.
-  // Structured WARN logging for dropped/invalid entries is wired in Task 10.
-
-  const themesRaw = safeGet(env, createSafeKey('WEBSSH2_THEMING_THEMES'))
-  if (themesRaw !== undefined && typeof themesRaw === 'string') {
-    const valid = themesRaw
-      .split(',')
-      .map((s) => s.trim())
-      .filter((s) => THEME_NAME_REGEX.test(s))
-    setNestedProperty(config, 'options.theming.themes', valid)
-  }
-
-  const defaultThemeRaw = safeGet(env, createSafeKey('WEBSSH2_THEMING_DEFAULT_THEME'))
-  if (defaultThemeRaw !== undefined && typeof defaultThemeRaw === 'string') {
-    const trimmed = defaultThemeRaw.trim()
-    const resolved = THEME_NAME_REGEX.test(trimmed) ? trimmed : 'Default'
-    setNestedProperty(config, 'options.theming.defaultTheme', resolved)
-  }
-
-  const headerBgRaw = safeGet(env, createSafeKey('WEBSSH2_THEMING_HEADER_BACKGROUND'))
-  if (headerBgRaw !== undefined && typeof headerBgRaw === 'string') {
-    if (VALID_HEADER_BACKGROUND.has(headerBgRaw)) {
-      setNestedProperty(config, 'options.theming.headerBackground', headerBgRaw)
-    }
-  }
-
-  const additionalRaw = safeGet(env, createSafeKey('WEBSSH2_THEMING_ADDITIONAL_THEMES'))
-  if (additionalRaw !== undefined && typeof additionalRaw === 'string') {
-    const parsed = parseBase64JsonArrayEnv(additionalRaw)
-    if (parsed.ok) {
-      const loaded = loadAdditionalThemes(parsed.value, {
-        source: 'WEBSSH2_THEMING_ADDITIONAL_THEMES',
-        builtinNames: BUILTIN_THEME_NAMES,
-      })
-      setNestedProperty(config, 'options.theming.additionalThemes', loaded.valid)
-      if (hooks?.onThemingWarning !== undefined) {
-        for (const warning of loaded.warnings) {
-          hooks.onThemingWarning(warning)
-        }
-      }
-    } else {
-      setNestedProperty(config, 'options.theming.additionalThemes', [])
-      if (hooks?.onThemingWarning !== undefined) {
-        hooks.onThemingWarning({
-          source: 'WEBSSH2_THEMING_ADDITIONAL_THEMES',
-          path: '',
-          reason: parsed.detail === undefined ? parsed.reason : `${parsed.reason}: ${parsed.detail}`
-        })
-      }
-    }
+  for (const warning of theming.warnings) {
+    hooks?.onThemingWarning?.(warning)
   }
 
   return config

--- a/app/middleware/auth-processor.ts
+++ b/app/middleware/auth-processor.ts
@@ -4,7 +4,7 @@
 import type { Config } from '../types/config.js'
 import type { Result } from '../types/result.js'
 import { ok, err } from '../utils/index.js'
-import validator from 'validator'
+import escape from 'validator/lib/escape'
 
 /**
  * SSH Credentials structure
@@ -90,7 +90,7 @@ export function processBasicAuthCredentials(
   credentials: BasicAuthCredentials
 ): SshCredentials {
   return {
-    username: validator.escape(credentials.name ?? ''),
+    username: escape(credentials.name ?? ''),
     password: credentials.pass ?? ''
   }
 }

--- a/app/middleware/auth-processor.ts
+++ b/app/middleware/auth-processor.ts
@@ -4,7 +4,7 @@
 import type { Config } from '../types/config.js'
 import type { Result } from '../types/result.js'
 import { ok, err } from '../utils/index.js'
-import escape from 'validator/lib/escape'
+import escape from 'validator/lib/escape.js'
 
 /**
  * SSH Credentials structure

--- a/app/services/sftp/sftp-service.ts
+++ b/app/services/sftp/sftp-service.ts
@@ -748,6 +748,37 @@ export class SftpService implements FileService {
       const downloadState = { cancelled: false }
       this.downloadStreams.set(transferId, { stream: null, cancelled: false })
 
+      // Emit progress to callbacks.onProgress at most once per progressInterval
+      const emitProgressIfDue = (now: number): void => {
+        if (now - lastProgressTime < progressInterval) {
+          return
+        }
+        lastProgressTime = now
+        const progressResult = this.getProgress(transferId)
+        if (progressResult.ok) {
+          callbacks.onProgress(progressResult.value)
+        }
+      }
+
+      // Log the transfer rate every 100 chunks
+      const logChunkRateIfDue = (chunkIndex: number, now: number): void => {
+        if (chunkIndex === 0 || chunkIndex % 100 !== 0) {
+          return
+        }
+        const currentRate = bytesTransferred / ((now - startTime) / 1000)
+        logger('Download chunk #%d: rate=%s KB/s', chunkIndex, (currentRate / 1024).toFixed(2))
+      }
+
+      // All chunks emitted - complete the transfer
+      const completeDownload = (): void => {
+        cleanup()
+        const completeResult = this.transferManager.completeTransfer(transferId)
+        if (completeResult.ok) {
+          callbacks.onComplete(buildCompleteResponse(transferId, 'download', completeResult.value))
+        }
+        logger('Download completed:', transferId)
+      }
+
       let isEmitting = false
       const emitBufferedChunks = async (): Promise<void> => {
         if (isEmitting) {
@@ -773,32 +804,14 @@ export class SftpService implements FileService {
               isLast
             })
 
-            // Emit progress periodically
             const now = Date.now()
-            if (now - lastProgressTime >= progressInterval) {
-              lastProgressTime = now
-              const progressResult = this.getProgress(transferId)
-              if (progressResult.ok) {
-                callbacks.onProgress(progressResult.value)
-              }
-            }
-
-            // Log timing every 100 chunks
-            if (nextChunkToEmit > 0 && nextChunkToEmit % 100 === 0) {
-              const currentRate = bytesTransferred / ((now - startTime) / 1000)
-              logger('Download chunk #%d: rate=%s KB/s', nextChunkToEmit, (currentRate / 1024).toFixed(2))
-            }
+            emitProgressIfDue(now)
+            logChunkRateIfDue(nextChunkToEmit, now)
 
             nextChunkToEmit++
 
             if (isLast) {
-              // All chunks emitted - complete the transfer
-              cleanup()
-              const completeResult = this.transferManager.completeTransfer(transferId)
-              if (completeResult.ok) {
-                callbacks.onComplete(buildCompleteResponse(transferId, 'download', completeResult.value))
-              }
-              logger('Download completed:', transferId)
+              completeDownload()
               resolve()
               return
             }

--- a/app/services/theming/theme-validator.ts
+++ b/app/services/theming/theme-validator.ts
@@ -24,6 +24,7 @@ export const HEX_COLOR_REGEX = /^#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i
 
 const LICENSE_REGEX = /^[\w .,\-()@/+:]{0,256}$/u
 const MAX_THEME_BYTES = 4 * 1024
+const MAX_SOURCE_LENGTH = 256
 const FORBIDDEN_PROTOTYPE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 const SCRIPT_BAIT = /<\/?(?:script)|<!--/i
 
@@ -42,20 +43,38 @@ export interface ValidateThemeOptions {
   readonly builtinNames: readonly string[]
 }
 
+/** A single field's sanitized value plus the errors it accumulated. */
+interface FieldResult<T> {
+  readonly value: T
+  readonly errors: readonly ThemeValidationError[]
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function rebuildColors(
-  input: unknown,
-  errors: ThemeValidationError[],
-  pathPrefix: string
-): ThemeColors {
-  const out: Partial<Record<keyof ThemeColors, string>> = {}
-  if (!isPlainObject(input)) {
-    errors.push({ path: pathPrefix, reason: 'colors must be an object' })
-    return out
+/** Rejects __proto__ / constructor / prototype declared directly on the entry. */
+function collectForbiddenEntryKeyErrors(
+  input: Record<string, unknown>
+): ThemeValidationError[] {
+  const errors: ThemeValidationError[] = []
+  for (const key of FORBIDDEN_PROTOTYPE_KEYS) {
+    if (Object.hasOwn(input, key)) {
+      errors.push({
+        path: key,
+        reason: 'forbidden prototype-pollution key on entry'
+      })
+    }
   }
+  return errors
+}
+
+/** Flags every input color key that is polluting or outside the allowlist. */
+function collectColorKeyErrors(
+  input: Record<string, unknown>,
+  pathPrefix: string
+): ThemeValidationError[] {
+  const errors: ThemeValidationError[] = []
   for (const key of Object.keys(input)) {
     if (FORBIDDEN_PROTOTYPE_KEYS.has(key)) {
       errors.push({
@@ -69,6 +88,18 @@ function rebuildColors(
       })
     }
   }
+  return errors
+}
+
+function rebuildColors(input: unknown, pathPrefix: string): FieldResult<ThemeColors> {
+  if (!isPlainObject(input)) {
+    return {
+      value: {},
+      errors: [{ path: pathPrefix, reason: 'colors must be an object' }]
+    }
+  }
+  const errors = collectColorKeyErrors(input, pathPrefix)
+  const out: Partial<Record<keyof ThemeColors, string>> = {}
   for (const key of THEME_COLOR_KEYS) {
     if (!Object.hasOwn(input, key)) {
       continue
@@ -85,7 +116,130 @@ function rebuildColors(
     // eslint-disable-next-line security/detect-object-injection -- key is from THEME_COLOR_KEYS allowlist, not user input
     out[key] = value
   }
-  return out
+  return { value: out, errors }
+}
+
+function collidesWithBuiltin(
+  canonical: string,
+  builtinNames: readonly string[]
+): boolean {
+  const lower = canonicalizeThemeName(canonical)
+  return builtinNames.some((builtin) => canonicalizeThemeName(builtin) === lower)
+}
+
+/** Extra name rules that only apply to admin-supplied additional themes. */
+function collectAdditionalNameErrors(
+  canonical: string,
+  builtinNames: readonly string[]
+): ThemeValidationError[] {
+  if (isReservedThemeName(canonical)) {
+    return [{ path: 'name', reason: 'name is reserved' }]
+  }
+  if (collidesWithBuiltin(canonical, builtinNames)) {
+    return [
+      {
+        path: 'name',
+        reason: 'name collides with built-in (case-insensitive)'
+      }
+    ]
+  }
+  return []
+}
+
+function validateName(
+  rawName: unknown,
+  context: ThemeValidationContext,
+  options: ValidateThemeOptions
+): FieldResult<string> {
+  if (typeof rawName !== 'string') {
+    return { value: '', errors: [{ path: 'name', reason: 'name must be a string' }] }
+  }
+  const canonical = rawName.normalize('NFKC').trim().replace(/\s+/g, ' ')
+  if (!THEME_NAME_REGEX.test(canonical)) {
+    return {
+      value: canonical,
+      errors: [{ path: 'name', reason: 'name fails name regex' }]
+    }
+  }
+  if (context !== 'additional') {
+    return { value: canonical, errors: [] }
+  }
+  return {
+    value: canonical,
+    errors: collectAdditionalNameErrors(canonical, options.builtinNames)
+  }
+}
+
+function validateLicense(input: Record<string, unknown>): FieldResult<string | undefined> {
+  if (!Object.hasOwn(input, 'license')) {
+    return { value: undefined, errors: [] }
+  }
+  const license = input['license']
+  if (typeof license !== 'string') {
+    return {
+      value: undefined,
+      errors: [{ path: 'license', reason: 'license must be a string' }]
+    }
+  }
+  if (!LICENSE_REGEX.test(license)) {
+    return {
+      value: undefined,
+      errors: [{ path: 'license', reason: 'license contains disallowed characters' }]
+    }
+  }
+  if (SCRIPT_BAIT.test(license)) {
+    return {
+      value: undefined,
+      errors: [{ path: 'license', reason: 'license contains script bait' }]
+    }
+  }
+  return { value: license, errors: [] }
+}
+
+/** Parses the source URL and keeps only https origins, storing the normalized href. */
+function validateSourceUrl(source: string): FieldResult<string | undefined> {
+  let url: URL
+  try {
+    url = new URL(source)
+  } catch {
+    return {
+      value: undefined,
+      errors: [{ path: 'source', reason: 'source must be a valid URL' }]
+    }
+  }
+  if (url.protocol === 'https:') {
+    return { value: url.href, errors: [] }
+  }
+  return {
+    value: undefined,
+    errors: [{ path: 'source', reason: 'source must be https' }]
+  }
+}
+
+function validateSource(input: Record<string, unknown>): FieldResult<string | undefined> {
+  if (!Object.hasOwn(input, 'source')) {
+    return { value: undefined, errors: [] }
+  }
+  const source = input['source']
+  if (typeof source !== 'string') {
+    return {
+      value: undefined,
+      errors: [{ path: 'source', reason: 'source must be a string' }]
+    }
+  }
+  if (source.length > MAX_SOURCE_LENGTH) {
+    return {
+      value: undefined,
+      errors: [{ path: 'source', reason: 'source exceeds 256 chars' }]
+    }
+  }
+  if (SCRIPT_BAIT.test(source)) {
+    return {
+      value: undefined,
+      errors: [{ path: 'source', reason: 'source contains script bait' }]
+    }
+  }
+  return validateSourceUrl(source)
 }
 
 export function validateTheme(
@@ -93,99 +247,32 @@ export function validateTheme(
   context: ThemeValidationContext,
   options: ValidateThemeOptions
 ): ThemeValidationResult {
-  const errors: ThemeValidationError[] = []
-
   if (!isPlainObject(input)) {
     return { ok: false, errors: [{ path: '', reason: 'must be an object' }] }
   }
 
-  for (const key of FORBIDDEN_PROTOTYPE_KEYS) {
-    if (Object.hasOwn(input, key)) {
-      errors.push({
-        path: key,
-        reason: 'forbidden prototype-pollution key on entry'
-      })
-    }
-  }
+  const name = validateName(input['name'], context, options)
+  const colors = rebuildColors(input['colors'], 'colors')
+  const license = validateLicense(input)
+  const source = validateSource(input)
 
-  const rawName = input['name']
-  let canonicalName = ''
-  if (typeof rawName === 'string') {
-    const canonical = rawName.normalize('NFKC').trim().replace(/\s+/g, ' ')
-    if (!THEME_NAME_REGEX.test(canonical)) {
-      errors.push({ path: 'name', reason: 'name fails name regex' })
-    } else if (context === 'additional') {
-      if (isReservedThemeName(canonical)) {
-        errors.push({ path: 'name', reason: 'name is reserved' })
-      } else {
-        const lower = canonicalizeThemeName(canonical)
-        for (const builtin of options.builtinNames) {
-          if (canonicalizeThemeName(builtin) === lower) {
-            errors.push({
-              path: 'name',
-              reason: 'name collides with built-in (case-insensitive)'
-            })
-            break
-          }
-        }
-      }
-    }
-    canonicalName = canonical
-  } else {
-    errors.push({ path: 'name', reason: 'name must be a string' })
-  }
-
-  const colors = rebuildColors(input['colors'], errors, 'colors')
-
-  let licenseOut: string | undefined
-  if (Object.hasOwn(input, 'license')) {
-    const license = input['license']
-    if (typeof license !== 'string') {
-      errors.push({ path: 'license', reason: 'license must be a string' })
-    } else if (!LICENSE_REGEX.test(license)) {
-      errors.push({
-        path: 'license',
-        reason: 'license contains disallowed characters'
-      })
-    } else if (SCRIPT_BAIT.test(license)) {
-      errors.push({ path: 'license', reason: 'license contains script bait' })
-    } else {
-      licenseOut = license
-    }
-  }
-
-  let sourceOut: string | undefined
-  if (Object.hasOwn(input, 'source')) {
-    const source = input['source']
-    if (typeof source !== 'string') {
-      errors.push({ path: 'source', reason: 'source must be a string' })
-    } else if (source.length > 256) {
-      errors.push({ path: 'source', reason: 'source exceeds 256 chars' })
-    } else if (SCRIPT_BAIT.test(source)) {
-      errors.push({ path: 'source', reason: 'source contains script bait' })
-    } else {
-      try {
-        const url = new URL(source)
-        if (url.protocol === 'https:') {
-          sourceOut = url.href
-        } else {
-          errors.push({ path: 'source', reason: 'source must be https' })
-        }
-      } catch {
-        errors.push({ path: 'source', reason: 'source must be a valid URL' })
-      }
-    }
-  }
+  const errors: ThemeValidationError[] = [
+    ...collectForbiddenEntryKeyErrors(input),
+    ...name.errors,
+    ...colors.errors,
+    ...license.errors,
+    ...source.errors
+  ]
 
   if (errors.length > 0) {
     return { ok: false, errors }
   }
 
   const safe: AdditionalTheme = {
-    name: canonicalName,
-    colors,
-    ...(licenseOut === undefined ? {} : { license: licenseOut }),
-    ...(sourceOut === undefined ? {} : { source: sourceOut })
+    name: name.value,
+    colors: colors.value,
+    ...(license.value === undefined ? {} : { license: license.value }),
+    ...(source.value === undefined ? {} : { source: source.value })
   }
 
   const serialized = JSON.stringify(safe)

--- a/app/utils/data-masker.ts
+++ b/app/utils/data-masker.ts
@@ -47,6 +47,5 @@ export function createMaskingOptions(options?: MaskingOptions): MaskingOptions {
  */
 export function maskSensitive(data: unknown, options?: MaskingOptions): unknown {
   const maskingOptions = createMaskingOptions(options)
-  const masker = maskObject as unknown as (o: unknown, opts: unknown) => unknown
-  return masker(data, maskingOptions)
+  return maskObject(data, maskingOptions)
 }

--- a/app/validation/socket/helpers.ts
+++ b/app/validation/socket/helpers.ts
@@ -1,5 +1,6 @@
 import type { Result } from '../../types/result.js'
-import validator from 'validator'
+import isInt from 'validator/lib/isInt'
+import isPort from 'validator/lib/isPort'
 import { ENV_LIMITS, VALIDATION_LIMITS } from '../../constants/index.js'
 import { safeGet, isRecord } from '../../utils/safe-property-access.js'
 import {
@@ -40,7 +41,7 @@ export const parseIntInRange = (
   fieldName: string
 ): Result<number> => {
   const str = toValidationString(value)
-  if (!validator.isInt(str, { min, max })) {
+  if (!isInt(str, { min, max })) {
     return {
       ok: false,
       error: new Error(`${fieldName} must be an integer between ${min} and ${max}`)
@@ -55,7 +56,7 @@ export const parseIntInRange = (
 
 export const validatePort = (value: unknown): Result<number> => {
   const str = toValidationString(value)
-  if (!validator.isPort(str)) {
+  if (!isPort(str)) {
     return {
       ok: false,
       error: new Error(`Invalid port: ${str}`)

--- a/app/validation/socket/helpers.ts
+++ b/app/validation/socket/helpers.ts
@@ -1,6 +1,6 @@
 import type { Result } from '../../types/result.js'
-import isInt from 'validator/lib/isInt'
-import isPort from 'validator/lib/isPort'
+import isInt from 'validator/lib/isInt.js'
+import isPort from 'validator/lib/isPort.js'
 import { ENV_LIMITS, VALIDATION_LIMITS } from '../../constants/index.js'
 import { safeGet, isRecord } from '../../utils/safe-property-access.js'
 import {

--- a/app/validation/ssh.ts
+++ b/app/validation/ssh.ts
@@ -1,10 +1,10 @@
 // app/validation/ssh.ts
 // Pure validation functions for SSH-related inputs
 
-import isIP from 'validator/lib/isIP'
-import escape from 'validator/lib/escape'
-import isLength from 'validator/lib/isLength'
-import matches from 'validator/lib/matches'
+import isIP from 'validator/lib/isIP.js'
+import escape from 'validator/lib/escape.js'
+import isLength from 'validator/lib/isLength.js'
+import matches from 'validator/lib/matches.js'
 import { DEFAULTS } from '../constants/index.js'
 
 /**

--- a/app/validation/ssh.ts
+++ b/app/validation/ssh.ts
@@ -1,7 +1,10 @@
 // app/validation/ssh.ts
 // Pure validation functions for SSH-related inputs
 
-import validator from 'validator'
+import isIP from 'validator/lib/isIP'
+import escape from 'validator/lib/escape'
+import isLength from 'validator/lib/isLength'
+import matches from 'validator/lib/matches'
 import { DEFAULTS } from '../constants/index.js'
 
 /**
@@ -11,10 +14,10 @@ import { DEFAULTS } from '../constants/index.js'
  * @pure
  */
 export function validateHost(host: string): string {
-  if (validator.isIP(host)) {
+  if (isIP(host)) {
     return host
   }
-  return validator.escape(host)
+  return escape(host)
 }
 
 /**
@@ -40,8 +43,7 @@ export function validateTerm(term?: string): string | null {
   if (term == null || term === '') {
     return null
   }
-  const isValid =
-    validator.isLength(term, { min: 1, max: 30 }) && validator.matches(term, /^[a-zA-Z0-9.-]+$/)
+  const isValid = isLength(term, { min: 1, max: 30 }) && matches(term, /^[a-zA-Z0-9.-]+$/)
   return isValid ? term : null
 }
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -217,14 +217,16 @@ export default [
         },
       ],
       '@typescript-eslint/prefer-optional-chain': 'error',
-      'no-restricted-imports': [
+      'no-restricted-imports': 'off',
+      '@typescript-eslint/no-restricted-imports': [
         'error',
         {
           paths: [
             {
               name: 'validator',
               message:
-                "Import only the functions you need via subpath, e.g. import isEmail from 'validator/lib/isEmail' — importing the whole 'validator' package pulls in every validator.",
+                "Import only the functions you need via subpath, e.g. import isEmail from 'validator/lib/isEmail.js' — importing the whole 'validator' package pulls in every validator.",
+              allowTypeImports: true,
             },
           ],
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -217,6 +217,18 @@ export default [
         },
       ],
       '@typescript-eslint/prefer-optional-chain': 'error',
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'validator',
+              message:
+                "Import only the functions you need via subpath, e.g. import isEmail from 'validator/lib/isEmail' — importing the whole 'validator' package pulls in every validator.",
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ import tsParser from '@typescript-eslint/parser'
 import tsPlugin from '@typescript-eslint/eslint-plugin'
 import unicornPlugin from 'eslint-plugin-unicorn'
 import sonarjsPlugin from 'eslint-plugin-sonarjs'
+import playwrightPlugin from 'eslint-plugin-playwright'
 
 export default [
   eslint.configs.recommended,
@@ -274,6 +275,16 @@ export default [
     rules: {
       '@typescript-eslint/no-var-requires': 'off',
       '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
+  {
+    files: ['tests/playwright/**'],
+    plugins: { playwright: playwrightPlugin },
+    rules: {
+      // S2925 parity: fixed waits are flaky; prefer condition-based waits.
+      'playwright/no-wait-for-timeout': 'error',
+      // S1607 parity: conditional skips with reason strings remain allowed.
+      'playwright/no-skipped-test': ['error', { allowConditional: true }],
     },
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,10 +99,9 @@ export default [
       // S7776 parity: use a Set for repeated membership checks
       'unicorn/prefer-set-has': 'error',
       'unicorn/consistent-function-scoping': 'warn',
-      // sonarjs downgrades: existing functions exceed the threshold; refactors
-      // are tracked separately (see SonarCloud project for canonical findings).
-      // Keeping these visible as warnings so new violations are surfaced.
-      'sonarjs/cognitive-complexity': 'warn',
+      // All known cognitive-complexity offenders were refactored below the
+      // threshold; enforce the rule so new violations fail the build.
+      'sonarjs/cognitive-complexity': 'error',
       // The codebase uses `Result<T, E>` and discriminated-union returns by
       // design — this rule misreads those as inconsistent return types.
       'sonarjs/function-return-type': 'warn',

--- a/eslint.config.sonar.mjs
+++ b/eslint.config.sonar.mjs
@@ -58,7 +58,9 @@ export default [
       },
     },
     rules: {
-      'sonarjs/cognitive-complexity': 'warn',
+      // All known cognitive-complexity offenders were refactored below the
+      // threshold; enforce the rule so new violations fail the build.
+      'sonarjs/cognitive-complexity': 'error',
       'sonarjs/function-return-type': 'warn',
     },
   },

--- a/eslint.config.sonar.mjs
+++ b/eslint.config.sonar.mjs
@@ -14,12 +14,14 @@ import nPlugin from 'eslint-plugin-n'
 import securityPlugin from 'eslint-plugin-security'
 import unicornPlugin from 'eslint-plugin-unicorn'
 import sonarjsPlugin from 'eslint-plugin-sonarjs'
+import playwrightPlugin from 'eslint-plugin-playwright'
 
 const sharedPlugins = {
   '@typescript-eslint': tsPlugin,
   n: nPlugin,
   security: securityPlugin,
   unicorn: unicornPlugin,
+  playwright: playwrightPlugin,
 }
 
 export default [

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -16,7 +16,11 @@ COPY package*.json index.js ./
 
 # Install production dependencies using npm ci for reproducible builds
 # Note: Using npm ci requires package-lock.json to be present
-RUN npm ci --audit=false --fund=false --omit=dev
+# --ignore-scripts blocks dependency lifecycle scripts (supply-chain hardening);
+# better-sqlite3 is the only native runtime dependency, so its install script is
+# re-run explicitly.
+RUN npm ci --audit=false --fund=false --omit=dev --ignore-scripts \
+  && npm rebuild better-sqlite3
 
 COPY app/ ./app/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "eslint": "10.7.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-n": "^18.2.2",
+        "eslint-plugin-playwright": "^2.10.5",
         "eslint-plugin-security": "^4.0.0",
         "eslint-plugin-sonarjs": "^4.0.3",
         "eslint-plugin-unicorn": "^71.1.0",
@@ -2959,6 +2960,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/eslint-plugin-playwright": {
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.5.tgz",
+      "integrity": "sha512-4k+ml4cEd55kePUIW1WsCiOLDwZkAdPZPKMFulR83XpplCaVOTKHF6yvXLYixLtdVbkMjmKV5F3BaGuI3aH8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^17.3.0"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/eslint-plugin-playwright/node_modules/globals": {
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-security": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "eslint": "10.7.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-n": "^18.2.2",
+    "eslint-plugin-playwright": "^2.10.5",
     "eslint-plugin-security": "^4.0.0",
     "eslint-plugin-sonarjs": "^4.0.3",
     "eslint-plugin-unicorn": "^71.1.0",

--- a/scripts/host-key-seed.ts
+++ b/scripts/host-key-seed.ts
@@ -559,74 +559,76 @@ function nextArg(args: readonly string[], index: number): string | undefined {
   return next < args.length ? args.at(next) : undefined
 }
 
+function parseOptionalInt(value: string | undefined): number | undefined {
+  return value === undefined ? undefined : Number.parseInt(value, 10)
+}
+
+interface ParsedFlag {
+  patch: Partial<CliArgs>
+  // Number of extra argv entries this flag consumed beyond itself.
+  consumed: number
+}
+
+// Interprets a single CLI flag, returning the CliArgs fields it sets and how
+// many additional argv entries (e.g. a flag's value) it consumed.
+function parseFlag(arg: string, args: readonly string[], index: number): ParsedFlag {
+  switch (arg) {
+    case '--help':
+    case '-h':
+      return { patch: { command: 'help' }, consumed: 0 }
+    case '--host':
+      return { patch: { command: 'host', host: nextArg(args, index) }, consumed: 1 }
+    case '--port':
+      return { patch: { port: parseOptionalInt(nextArg(args, index)) }, consumed: 1 }
+    case '--hosts':
+      return { patch: { command: 'hosts', file: nextArg(args, index) }, consumed: 1 }
+    case '--known-hosts':
+      return { patch: { command: 'known-hosts', file: nextArg(args, index) }, consumed: 1 }
+    case '--list':
+      return { patch: { command: 'list' }, consumed: 0 }
+    case '--remove':
+      return { patch: { command: 'remove', removeTarget: nextArg(args, index) }, consumed: 1 }
+    case '--db':
+      return { patch: { dbPath: nextArg(args, index) }, consumed: 1 }
+    case '--commit':
+      // Consumed by handleKnownHosts in Task 4 to gate dry-run vs. write.
+      return { patch: { commit: true }, consumed: 0 }
+    case '--max-hosts': {
+      const maxHosts = parseOptionalInt(nextArg(args, index))
+      const patch: Partial<CliArgs> =
+        maxHosts === undefined ? {} : { maxHosts, maxHostsExplicit: true }
+      return { patch, consumed: 1 }
+    }
+    default:
+      return { patch: {}, consumed: 0 }
+  }
+}
+
 export function parseArgs(argv: readonly string[]): CliArgs {
   const args = argv.slice(2) // skip node and script path
-  let command: CliArgs['command'] = 'help'
-  let host: string | undefined
-  let port: number | undefined
-  let file: string | undefined
-  let removeTarget: string | undefined
-  let dbPath: string | undefined
-  let commit = false
-  let maxHosts: number | undefined
-  let maxHostsExplicit = false
+  let result: CliArgs = {
+    command: 'help',
+    host: undefined,
+    port: undefined,
+    file: undefined,
+    removeTarget: undefined,
+    dbPath: undefined,
+    commit: false,
+    maxHosts: undefined,
+    maxHostsExplicit: false
+  }
 
   for (let i = 0; i < args.length; i++) {
     const arg = args.at(i)
-
-    if (arg === '--help' || arg === '-h') {
-      command = 'help'
-    } else if (arg === '--host') {
-      command = 'host'
-      host = nextArg(args, i)
-      i++
-    } else if (arg === '--port') {
-      const portStr = nextArg(args, i)
-      i++
-      if (portStr !== undefined) {
-        port = Number.parseInt(portStr, 10)
-      }
-    } else if (arg === '--hosts') {
-      command = 'hosts'
-      file = nextArg(args, i)
-      i++
-    } else if (arg === '--known-hosts') {
-      command = 'known-hosts'
-      file = nextArg(args, i)
-      i++
-    } else if (arg === '--list') {
-      command = 'list'
-    } else if (arg === '--remove') {
-      command = 'remove'
-      removeTarget = nextArg(args, i)
-      i++
-    } else if (arg === '--db') {
-      dbPath = nextArg(args, i)
-      i++
-    } else if (arg === '--commit') {
-      // Consumed by handleKnownHosts in Task 4 to gate dry-run vs. write.
-      commit = true
-    } else if (arg === '--max-hosts') {
-      const maxStr = nextArg(args, i)
-      i++
-      if (maxStr !== undefined) {
-        maxHosts = Number.parseInt(maxStr, 10)
-        maxHostsExplicit = true
-      }
+    if (arg === undefined) {
+      continue
     }
+    const { patch, consumed } = parseFlag(arg, args, i)
+    result = { ...result, ...patch }
+    i += consumed
   }
 
-  return {
-    command,
-    host,
-    port,
-    file,
-    removeTarget,
-    dbPath,
-    commit,
-    maxHosts,
-    maxHostsExplicit
-  }
+  return result
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/host-key-seed.ts
+++ b/scripts/host-key-seed.ts
@@ -578,8 +578,11 @@ function parseFlag(arg: string, args: readonly string[], index: number): ParsedF
       return { patch: { command: 'help' }, consumed: 0 }
     case '--host':
       return { patch: { command: 'host', host: nextArg(args, index) }, consumed: 1 }
-    case '--port':
-      return { patch: { port: parseOptionalInt(nextArg(args, index)) }, consumed: 1 }
+    case '--port': {
+      const port = parseOptionalInt(nextArg(args, index))
+      const patch: Partial<CliArgs> = port === undefined ? {} : { port }
+      return { patch, consumed: 1 }
+    }
     case '--hosts':
       return { patch: { command: 'hosts', file: nextArg(args, index) }, consumed: 1 }
     case '--known-hosts':

--- a/tests/playwright/basic-auth-config-port.spec.ts
+++ b/tests/playwright/basic-auth-config-port.spec.ts
@@ -5,6 +5,7 @@ import { connectWithBasicAuth, waitForV2Prompt, executeAndVerifyCommand } from '
 const E2E_ENABLED = process.env.ENABLE_E2E_SSH === '1'
 
 test.describe('Config SSH port fallback', () => {
+  // Reason: requires a live Docker SSH test server; opt-in only via ENABLE_E2E_SSH=1.
   test.skip(!E2E_ENABLED, 'Set ENABLE_E2E_SSH=1 to run this test')
 
   test('uses configured ssh.port when Basic Auth URL omits port parameter', async ({ page }) => {

--- a/tests/playwright/constants.ts
+++ b/tests/playwright/constants.ts
@@ -100,6 +100,16 @@ export async function executeCommand(page: Page, command: string): Promise<void>
   await page.locator('.xterm-helper-textarea').click()
   await page.keyboard.type(command)
   await page.keyboard.press('Enter')
+  // This is a generic "run an arbitrary command" helper shared by several
+  // specs (see task-6 report), so there's no single output pattern to wait
+  // on here; callers layer their own condition-based wait afterward for the
+  // outcome they actually care about. Task 4's own port of this same idea to
+  // a per-spec local helper needed two rounds of live Docker verification to
+  // get an echo-based condition right without racing or over-fitting to a
+  // shell-prompt return, so porting it here blind (this helper is used by
+  // other spec files this task didn't touch/verify against a live SSH
+  // server) is left as follow-up work rather than done speculatively.
+  // eslint-disable-next-line playwright/no-wait-for-timeout
   await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
 }
 

--- a/tests/playwright/csp-enforce.spec.ts
+++ b/tests/playwright/csp-enforce.spec.ts
@@ -41,6 +41,7 @@ import {
 const E2E_ENABLED = process.env.ENABLE_E2E_SSH === '1'
 
 test.describe('CSP enforcement — terminal boots from JSON config block (#546)', () => {
+  // Reason: requires a live Docker SSH test server; opt-in only via ENABLE_E2E_SSH=1.
   test.skip(!E2E_ENABLED, 'Set ENABLE_E2E_SSH=1 to run this test')
 
   test(

--- a/tests/playwright/e2e-sftp.spec.ts
+++ b/tests/playwright/e2e-sftp.spec.ts
@@ -80,6 +80,7 @@ async function navigateToPath(page: Page, targetPath: string): Promise<void> {
   // Click on the path bar to make it editable (it has title="Click to edit path")
   // This is a div that switches to an input when clicked
   const pathElement = page.locator('[title="Click to edit path"]')
+  const previousPathText = (await pathElement.textContent()) ?? ''
   await pathElement.click()
 
   // Wait for the input to appear (the div is replaced by an input with border-blue-500)
@@ -90,8 +91,17 @@ async function navigateToPath(page: Page, targetPath: string): Promise<void> {
   await pathInput.fill(targetPath)
   await page.keyboard.press('Enter')
 
-  // Wait for navigation to complete
-  await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
+  // Wait for navigation to settle: the path bar reflects a new path, or an
+  // error banner appears (e.g. path forbidden/restricted)
+  await page.waitForFunction(
+    (previous) => {
+      const currentText = document.querySelector('[title="Click to edit path"]')?.textContent ?? ''
+      const hasError = document.querySelector('[role="alert"]') !== null
+      return currentText !== previous || hasError
+    },
+    previousPathText,
+    { timeout: TIMEOUTS.CONNECTION },
+  )
 }
 
 /**
@@ -204,9 +214,6 @@ async function getErrorMessage(page: Page): Promise<string | null> {
  * Waits for SFTP to be available (sftp-status event received with enabled=true)
  */
 async function waitForSftpAvailable(page: Page): Promise<void> {
-  // Wait a moment for sftp-status event to be processed
-  await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
-
   // Hover over the Menu button to open dropdown (menu opens on mouseEnter)
   const menuButton = page.getByRole('button', { name: 'Menu' })
   await expect(menuButton).toBeVisible({ timeout: TIMEOUTS.CONNECTION })
@@ -261,9 +268,6 @@ test.describe('SFTP E2E Tests', () => {
   test('should show File Browser menu when SFTP is enabled', async () => {
     // @ts-expect-error - accessing attached page
     const page = test.info().page as Page
-
-    // Wait for sftp-status event to be processed
-    await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
 
     // Hover over the Menu button to open dropdown (menu opens on mouseEnter)
     const menuButton = page.getByRole('button', { name: 'Menu' })
@@ -434,10 +438,9 @@ test.describe('SFTP E2E Tests', () => {
 
     // Try to navigate to a system path that might be restricted
     // This tests the path validation in the SFTP service
+    // navigateToPath() already waits for navigation to settle (path change
+    // or error banner), so no additional wait is needed here.
     await navigateToPath(page, '/etc')
-
-    // Wait for response
-    await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
 
     // Take screenshot
     const shotPath = test.info().outputPath('sftp-path-navigation.png')
@@ -481,9 +484,10 @@ test.describe('SFTP E2E Tests', () => {
       buffer: Buffer.from(largeContent),
     })
 
-    // Try to catch transfer progress UI
-    // The TransferProgress component shows during active transfers
-    await page.waitForTimeout(TIMEOUTS.SHORT_WAIT / 2)
+    // Wait for the transfer entry (with its progress bar) to mount. The
+    // entry persists in the transfer list even after completion, so this
+    // reliably captures the transfer UI regardless of upload speed.
+    await expect(page.getByRole('progressbar').first()).toBeVisible({ timeout: TIMEOUTS.ACTION })
 
     // Take screenshot during upload (might catch progress bar)
     const shotPath = test.info().outputPath('sftp-upload-progress.png')

--- a/tests/playwright/e2e-sftp.spec.ts
+++ b/tests/playwright/e2e-sftp.spec.ts
@@ -235,6 +235,7 @@ async function waitForSftpAvailable(page: Page): Promise<void> {
 // =============================================================================
 
 test.describe('SFTP E2E Tests', () => {
+  // Reason: requires a live Docker SSH test server; opt-in only via ENABLE_E2E_SSH=1.
   test.skip(!E2E_ENABLED, 'Set ENABLE_E2E_SSH=1 to run these tests')
 
   test.beforeEach(async ({ browser, baseURL }) => {

--- a/tests/playwright/e2e-ssh-acceptenv-v2.spec.ts
+++ b/tests/playwright/e2e-ssh-acceptenv-v2.spec.ts
@@ -5,6 +5,7 @@ import { waitForV2Terminal, waitForV2Connection, waitForV2Prompt, executeV2Comma
 const E2E_ENABLED = process.env.ENABLE_E2E_SSH === '1'
 
 test.describe('V2 E2E: AcceptEnv via containerized SSHD', () => {
+  // Reason: requires a live Docker SSH test server; opt-in only via ENABLE_E2E_SSH=1.
   test.skip(!E2E_ENABLED, 'Set ENABLE_E2E_SSH=1 to run this test')
 
   test('forwards FOO=bar to SSH session (V2)', async ({ browser, baseURL }) => {

--- a/tests/playwright/e2e-term-size-replay-v2.spec.ts
+++ b/tests/playwright/e2e-term-size-replay-v2.spec.ts
@@ -51,19 +51,31 @@ async function waitForV2Prompt(page: Page, timeout = TIMEOUTS.PROMPT_WAIT): Prom
 async function executeV2Command(page: Page, command: string): Promise<void> {
   await page.locator('.xterm-helper-textarea').click()
   await page.keyboard.type(command)
-  // Snapshot right after typing (and before Enter) so the wait below reacts
-  // to the round trip triggered by Enter, not to the per-keystroke echo of
-  // typing the command itself.
+  // page.keyboard.type() resolves once key events are dispatched, not once
+  // the remote echo round-trips back. Wait for the typed command's echo to
+  // fully land before snapshotting below, so the change-detection reacts
+  // to Enter's round trip specifically, not to the tail of the command's
+  // own echo arriving late.
+  await page.waitForFunction(
+    (typedCommand) => {
+      const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
+      const content = rows.map((row) => row.textContent ?? '').join('\n')
+      return content.includes(typedCommand)
+    },
+    command,
+    { timeout: TIMEOUTS.CONNECTION },
+  )
   const beforeEnter = await page.evaluate(() => {
     const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
     return rows.map((row) => row.textContent ?? '').join('\n')
   })
   await page.keyboard.press('Enter')
   // Wait for the terminal to reflect the round trip for Enter (echoed
-  // newline / command output). This intentionally does not wait for a
-  // return to the shell prompt, since some commands (e.g. interactive
-  // `read` prompts used by the credential-replay test) leave the terminal
-  // in a different state on purpose.
+  // newline / command output), now that the command's own echo has
+  // already fully landed. This intentionally does not wait for a return
+  // to the shell prompt, since some commands (e.g. interactive `read`
+  // prompts used by the credential-replay test) leave the terminal in a
+  // different state on purpose.
   await page.waitForFunction(
     (previousContent) => {
       const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))

--- a/tests/playwright/e2e-term-size-replay-v2.spec.ts
+++ b/tests/playwright/e2e-term-size-replay-v2.spec.ts
@@ -51,8 +51,28 @@ async function waitForV2Prompt(page: Page, timeout = TIMEOUTS.PROMPT_WAIT): Prom
 async function executeV2Command(page: Page, command: string): Promise<void> {
   await page.locator('.xterm-helper-textarea').click()
   await page.keyboard.type(command)
+  // Snapshot right after typing (and before Enter) so the wait below reacts
+  // to the round trip triggered by Enter, not to the per-keystroke echo of
+  // typing the command itself.
+  const beforeEnter = await page.evaluate(() => {
+    const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
+    return rows.map((row) => row.textContent ?? '').join('\n')
+  })
   await page.keyboard.press('Enter')
-  await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
+  // Wait for the terminal to reflect the round trip for Enter (echoed
+  // newline / command output). This intentionally does not wait for a
+  // return to the shell prompt, since some commands (e.g. interactive
+  // `read` prompts used by the credential-replay test) leave the terminal
+  // in a different state on purpose.
+  await page.waitForFunction(
+    (previousContent) => {
+      const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
+      const content = rows.map((row) => row.textContent ?? '').join('\n')
+      return content !== previousContent
+    },
+    beforeEnter,
+    { timeout: TIMEOUTS.CONNECTION },
+  )
 }
 
 async function openV2WithBasicAuth(browser: Browser, baseURL: string | undefined, params: string): Promise<{ page: Page; context: BrowserContext }> {
@@ -100,8 +120,15 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
 
     await executeV2Command(page, 'stty size')
 
-    // Wait for command output to appear
-    await page.waitForTimeout(2000)
+    // Wait for the stty output (a "<rows> <cols>" digit pair) to appear
+    await page.waitForFunction(
+      () => {
+        const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
+        const text = rows.map((row) => row.textContent ?? '').join('\n')
+        return /\d+\s+\d+/.test(text)
+      },
+      { timeout: TIMEOUTS.CONNECTION },
+    )
 
     const out = await page.evaluate(() => {
       // Get all text from terminal rows, not CSS
@@ -158,8 +185,15 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
     // Get initial size
     await executeV2Command(page, 'stty size')
 
-    // Wait for output and check initial size
-    await page.waitForTimeout(1000)
+    // Wait for the stty output (a "<rows> <cols>" digit pair) to appear
+    await page.waitForFunction(
+      () => {
+        const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
+        const text = rows.map((row) => row.textContent ?? '').join('\n')
+        return /\d+\s+\d+/.test(text)
+      },
+      { timeout: TIMEOUTS.CONNECTION },
+    )
 
     // Try to get text content from the terminal rows instead
     const getTerminalText = async (): Promise<string> => {
@@ -194,14 +228,44 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
     const initialSize: string = initialSizeMatch[0]
 
     // Resize browser window (this should trigger terminal resize in V2)
+    const screenWidthBeforeResize = await page.evaluate(
+      () => document.querySelector('.xterm-screen')?.clientWidth ?? 0,
+    )
     await page.setViewportSize({ width: 1200, height: 800 })
-    await page.waitForTimeout(TIMEOUTS.MEDIUM_WAIT)
+    // Wait for xterm to actually re-fit to the new viewport dimensions
+    await page.waitForFunction(
+      (previousWidth) => {
+        const width = document.querySelector('.xterm-screen')?.clientWidth ?? 0
+        return width !== previousWidth
+      },
+      screenWidthBeforeResize,
+      { timeout: TIMEOUTS.MEDIUM_WAIT },
+    )
+    // The client debounces the resize socket emission (RESIZE_DEBOUNCE_DELAY,
+    // 150ms in webssh2_client) before notifying the server, and there is no
+    // client-visible DOM signal for "server applied the new PTY size". This
+    // settle time genuinely has no observable condition to synchronize on
+    // (see task-4 report), so a short fixed wait is kept intentionally.
+    // NOTE: once eslint-plugin-playwright is enabled (task 6), add
+    // `// eslint-disable-next-line playwright/no-wait-for-timeout` above
+    // this line with the same justification.
+    await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
 
     // Check size again (don't clear to preserve history)
     await executeV2Command(page, 'stty size')
 
-    // Wait for command output
-    await page.waitForTimeout(1500)
+    // Wait for the post-resize stty output to differ from the initial size
+    await page.waitForFunction(
+      (previousSize) => {
+        const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
+        const text = rows.map((row) => row.textContent ?? '').join('\n')
+        const matches = [...text.matchAll(/\b(\d+)\s+(\d+)\b/g)]
+        const last = matches.at(-1)
+        return last !== undefined && last[0] !== previousSize
+      },
+      initialSize,
+      { timeout: TIMEOUTS.CONNECTION },
+    )
 
     // Get the new content after resize
     const newOut: string = await getTerminalText()
@@ -285,9 +349,7 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
     for (let i = 0; i < 3; i++) {
       await executeV2Command(page, 'printenv TERM')
 
-      // Wait for command output
-      await page.waitForTimeout(1000)
-
+      // Wait for the TERM value to actually appear in the terminal output
       await page.waitForFunction(
         () => {
           const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
@@ -298,8 +360,17 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
       )
 
       // Execute some other command between checks
-      await executeV2Command(page, `echo "Check ${i + 1}"`)
-      await page.waitForTimeout(500)
+      const checkLabel = `Check ${i + 1}`
+      await executeV2Command(page, `echo "${checkLabel}"`)
+      await page.waitForFunction(
+        (label) => {
+          const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
+          const content = rows.map((row) => row.textContent || '').join('\n')
+          return content.includes(label)
+        },
+        checkLabel,
+        { timeout: TIMEOUTS.CONNECTION },
+      )
     }
 
     const finalContent = await page.evaluate(() => {

--- a/tests/playwright/e2e-term-size-replay-v2.spec.ts
+++ b/tests/playwright/e2e-term-size-replay-v2.spec.ts
@@ -259,9 +259,7 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
     // client-visible DOM signal for "server applied the new PTY size". This
     // settle time genuinely has no observable condition to synchronize on
     // (see task-4 report), so a short fixed wait is kept intentionally.
-    // NOTE: once eslint-plugin-playwright is enabled (task 6), add
-    // `// eslint-disable-next-line playwright/no-wait-for-timeout` above
-    // this line with the same justification.
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
 
     // Check size again (don't clear to preserve history)

--- a/tests/playwright/e2e-term-size-replay-v2.spec.ts
+++ b/tests/playwright/e2e-term-size-replay-v2.spec.ts
@@ -138,6 +138,7 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
       () => {
         const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
         const text = rows.map((row) => row.textContent ?? '').join('\n')
+        // eslint-disable-next-line sonarjs/slow-regex -- digits and whitespace are disjoint character classes, so backtracking stays linear
         return /\d+\s+\d+/.test(text)
       },
       { timeout: TIMEOUTS.CONNECTION },
@@ -151,6 +152,7 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
 
     // Look for any digit pair that looks like terminal dimensions (rows cols)
     // The output might be on a new line after the command
+    // eslint-disable-next-line sonarjs/slow-regex -- digits and whitespace are disjoint character classes, so backtracking stays linear
     const dimensionMatches = out.matchAll(/(\d+)\s+(\d+)/g) //NOSONAR
     const matches = Array.from(dimensionMatches)
 
@@ -203,6 +205,7 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
       () => {
         const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
         const text = rows.map((row) => row.textContent ?? '').join('\n')
+        // eslint-disable-next-line sonarjs/slow-regex -- digits and whitespace are disjoint character classes, so backtracking stays linear
         return /\d+\s+\d+/.test(text)
       },
       { timeout: TIMEOUTS.CONNECTION },

--- a/tests/playwright/e2e-term-size-replay-v2.spec.ts
+++ b/tests/playwright/e2e-term-size-replay-v2.spec.ts
@@ -97,6 +97,7 @@ async function openV2WithBasicAuth(browser: Browser, baseURL: string | undefined
 }
 
 test.describe('V2 E2E: TERM, size, and replay credentials', () => {
+  // Reason: requires a live Docker SSH test server; opt-in only via ENABLE_E2E_SSH=1.
   test.skip(!E2E_ENABLED, 'Set ENABLE_E2E_SSH=1 to run these tests')
 
   test('sets TERM from sshterm (V2)', async ({ browser, baseURL }) => {

--- a/tests/playwright/theming.spec.ts
+++ b/tests/playwright/theming.spec.ts
@@ -29,6 +29,7 @@ const DRACULA_BG = 'rgb(40, 42, 54)'
 const TRANSPARENT_BG = 'rgba(0, 0, 0, 0)'
 
 test.describe('Terminal Theming', () => {
+  // Reason: requires a live Docker SSH test server; opt-in only via ENABLE_E2E_SSH=1.
   test.skip(!E2E_ENABLED, 'Set ENABLE_E2E_SSH=1 to run this test')
 
   test('smoke: select Dracula theme → persists across reload', async ({

--- a/tests/playwright/v2-helpers.ts
+++ b/tests/playwright/v2-helpers.ts
@@ -119,6 +119,18 @@ export async function executeV2Command(page: Page, command: string): Promise<voi
   await page.locator('.xterm-helper-textarea').click()
   await page.keyboard.type(command)
   await page.keyboard.press('Enter')
+  // Generic "run an arbitrary command" helper shared across multiple specs
+  // (see task-6 report) — there's no single output pattern to condition on
+  // here, so callers layer their own waitForFunction for the outcome they
+  // care about. e2e-term-size-replay-v2.spec.ts has a local, differently-
+  // named copy of this same helper that Task 4 converted to an echo-based
+  // waitForFunction, but that took two rounds of live Docker verification to
+  // get right (an initial version resolved instantly, and a second attempt
+  // over-fit to "returns to a shell prompt," which broke the credential-
+  // replay test's `read -s -p` prompt). Porting that fix to this shared
+  // helper without equivalent live verification against every current
+  // caller is left as follow-up work rather than done speculatively.
+  // eslint-disable-next-line playwright/no-wait-for-timeout
   await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
 }
 

--- a/tests/playwright/websocket-async-auth-v2.test.js
+++ b/tests/playwright/websocket-async-auth-v2.test.js
@@ -116,11 +116,34 @@ test.describe('V2 Async/Await Modal Login Authentication', () => {
 
     // Get initial terminal size
     await executeV2Command(page, 'stty size')
-    await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
+    // Wait for the stty output (a "<rows> <cols>" digit pair) to appear
+    await page.waitForFunction(
+      () => {
+        // eslint-disable-next-line no-undef
+        const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
+        const text = rows.map((row) => row.textContent || '').join('\n')
+        // eslint-disable-next-line sonarjs/slow-regex -- digits and whitespace are disjoint character classes, so backtracking stays linear
+        return /\d+\s+\d+/.test(text)
+      },
+      { timeout: TIMEOUTS.CONNECTION }
+    )
 
     // Resize viewport and test async resize handling
+    const screenWidthBeforeResize = await page.evaluate(
+      // eslint-disable-next-line no-undef
+      () => document.querySelector('.xterm-screen')?.clientWidth || 0
+    )
     await page.setViewportSize({ width: 1200, height: 800 })
-    await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
+    // Wait for xterm to actually re-fit to the new viewport dimensions
+    await page.waitForFunction(
+      (previousWidth) => {
+        // eslint-disable-next-line no-undef
+        const width = document.querySelector('.xterm-screen')?.clientWidth || 0
+        return width !== previousWidth
+      },
+      screenWidthBeforeResize,
+      { timeout: TIMEOUTS.MEDIUM_WAIT }
+    )
 
     // Test that terminal still works after resize
     await executeV2Command(page, 'echo "resize test"')

--- a/tests/playwright/websocket-basic.test.js
+++ b/tests/playwright/websocket-basic.test.js
@@ -73,8 +73,13 @@ test.describe('WebSocket Basic Tests', () => {
     // Type exit command
     await executeCommand(page, 'exit')
 
-    // Wait for a disconnection marker: terminal shows logout/exit, or the
-    // status element updates (matches the assertion below)
+    // Wait for a real post-disconnect signal: terminal shows a logout
+    // message, or the status element reports Disconnected. (Deliberately
+    // excludes terminalText.includes('exit') and statusText === '' here —
+    // both are already true the moment 'exit' is echoed back or before the
+    // status element has any text, i.e. before disconnection has actually
+    // happened; they remain valid in the assertion below, which checks the
+    // final state rather than gating the wait.)
     await page.waitForFunction(() => {
       // eslint-disable-next-line no-undef
       const terminalText = document.querySelector('.xterm-screen')?.textContent || ''
@@ -83,9 +88,7 @@ test.describe('WebSocket Basic Tests', () => {
       const statusText = status ? status.textContent || '' : ''
       return (
         terminalText.includes('logout') ||
-        terminalText.includes('exit') ||
-        statusText.includes('Disconnected') ||
-        statusText === ''
+        statusText.includes('Disconnected')
       )
     }, { timeout: TIMEOUTS.CONNECTION })
 

--- a/tests/playwright/websocket-basic.test.js
+++ b/tests/playwright/websocket-basic.test.js
@@ -72,10 +72,23 @@ test.describe('WebSocket Basic Tests', () => {
     
     // Type exit command
     await executeCommand(page, 'exit')
-    
-    // Wait a moment for disconnection to process
-    await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
-    
+
+    // Wait for a disconnection marker: terminal shows logout/exit, or the
+    // status element updates (matches the assertion below)
+    await page.waitForFunction(() => {
+      // eslint-disable-next-line no-undef
+      const terminalText = document.querySelector('.xterm-screen')?.textContent || ''
+      // eslint-disable-next-line no-undef
+      const status = document.querySelector('#status')
+      const statusText = status ? status.textContent || '' : ''
+      return (
+        terminalText.includes('logout') ||
+        terminalText.includes('exit') ||
+        statusText.includes('Disconnected') ||
+        statusText === ''
+      )
+    }, { timeout: TIMEOUTS.CONNECTION })
+
     // Check if the connection status changed or if we see logout/exit message
     // eslint-disable-next-line no-undef
     const terminalContent = await page.evaluate(() => document.querySelector('.xterm-screen')?.textContent || '')

--- a/tests/unit/scripts/host-key-seed.vitest.ts
+++ b/tests/unit/scripts/host-key-seed.vitest.ts
@@ -161,6 +161,13 @@ describe('parseArgs', () => {
     expect(result.port).toBe(2222)
   })
 
+  it('preserves a previously parsed --port when a later --port has no value', () => {
+    const result = parseArgs([
+      'node', 'script', '--host', 'example.com', '--port', '2222', '--port'
+    ])
+    expect(result.port).toBe(2222)
+  })
+
   it('parses --list', () => {
     const result = parseArgs(['node', 'script', '--list'])
     expect(result.command).toBe('list')

--- a/tests/unit/services/telnet/telnet-service.vitest.ts
+++ b/tests/unit/services/telnet/telnet-service.vitest.ts
@@ -25,6 +25,45 @@ const createTestConfig = (
 })
 
 /**
+ * Find the end of a subnegotiation sequence (IAC SB ... IAC SE) starting at
+ * `start`, returning the index just past it (or data.length if unterminated).
+ */
+const skipSubnegotiation = (data: Buffer, start: number): number => {
+  let i = start
+  while (i < data.length) {
+    if (data[i] === IAC && i + 1 < data.length && data[i + 1] === SE) {
+      return i + 2
+    }
+    i++
+  }
+  return i
+}
+
+/**
+ * Filter IAC (telnet command) sequences out of raw socket data, leaving only
+ * the plain data bytes that a real telnet peer would echo back.
+ */
+const filterIacSequences = (data: Buffer): number[] => {
+  const bytes: number[] = []
+  let i = 0
+  while (i < data.length) {
+    if (data[i] === IAC && i + 1 < data.length) {
+      if (data[i + 1] === SB) {
+        // Skip subnegotiation: IAC SB ... IAC SE
+        i = skipSubnegotiation(data, i + 2)
+        continue
+      }
+      // Skip 3-byte commands: IAC WILL/WONT/DO/DONT <option>
+      i += 3
+      continue
+    }
+    bytes.push(data[i])
+    i++
+  }
+  return bytes
+}
+
+/**
  * Wait for a condition with timeout
  */
 const waitFor = (
@@ -62,30 +101,7 @@ describe('TelnetServiceImpl', () => {
     server = net.createServer((socket) => {
       socket.on('data', (data) => {
         // Filter out IAC sequences before echoing
-        const bytes: number[] = []
-        let i = 0
-        while (i < data.length) {
-          if (data[i] === IAC && i + 1 < data.length) {
-            // Skip IAC sequences
-            if (data[i + 1] === SB) {
-              // Skip subnegotiation: IAC SB ... IAC SE
-              i += 2
-              while (i < data.length) {
-                if (data[i] === IAC && i + 1 < data.length && data[i + 1] === SE) {
-                  i += 2
-                  break
-                }
-                i++
-              }
-              continue
-            }
-            // Skip 3-byte commands: IAC WILL/WONT/DO/DONT <option>
-            i += 3
-            continue
-          }
-          bytes.push(data[i])
-          i++
-        }
+        const bytes = filterIacSequences(data)
         if (bytes.length > 0) {
           socket.write(Buffer.from(bytes))
         }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -9,7 +9,8 @@
     "*.config.mjs",
     "tests/**/*.ts",
     "eslint.config.mjs",
-    "playwright.config.ts"
+    "playwright.config.ts",
+    "types/**/*.d.ts"
   ],
   "exclude": [
     "node_modules",

--- a/types/validator-lib.d.ts
+++ b/types/validator-lib.d.ts
@@ -1,0 +1,40 @@
+// Ambient declarations for `validator/lib/<fn>` subpath imports.
+//
+// `validator` ships no types of its own; `@types/validator` only publishes
+// declarations for the package root (`node_modules/@types/validator/index.d.ts`).
+// Under `moduleResolution: NodeNext`, TypeScript does not mirror deep/subpath
+// imports of a runtime package onto a separate `@types/*` package's matching
+// subpath (only the package root gets that fallback), so
+// `import isIP from 'validator/lib/isIP'` fails with TS2307 even though the
+// file exists on disk and resolves fine at runtime. These declarations close
+// that gap for the specific functions this codebase imports by subpath,
+// mirroring the real signatures from `@types/validator`.
+declare module 'validator/lib/isIP' {
+  import type { IsIPOptions, IPVersion } from 'validator'
+
+  export default function isIP(str: string, versionOrOptions?: IPVersion | IsIPOptions): boolean
+}
+
+declare module 'validator/lib/escape' {
+  export default function escape(input: string): string
+}
+
+declare module 'validator/lib/isLength' {
+  import type { IsLengthOptions } from 'validator'
+
+  export default function isLength(str: string, minOrOptions?: number | IsLengthOptions): boolean
+}
+
+declare module 'validator/lib/matches' {
+  export default function matches(str: string, pattern: RegExp | string, modifiers?: string): boolean
+}
+
+declare module 'validator/lib/isInt' {
+  import type { IsIntOptions } from 'validator'
+
+  export default function isInt(str: string, options?: IsIntOptions): boolean
+}
+
+declare module 'validator/lib/isPort' {
+  export default function isPort(str: string): boolean
+}

--- a/types/validator-lib.d.ts
+++ b/types/validator-lib.d.ts
@@ -5,36 +5,50 @@
 // Under `moduleResolution: NodeNext`, TypeScript does not mirror deep/subpath
 // imports of a runtime package onto a separate `@types/*` package's matching
 // subpath (only the package root gets that fallback), so
-// `import isIP from 'validator/lib/isIP'` fails with TS2307 even though the
-// file exists on disk and resolves fine at runtime. These declarations close
-// that gap for the specific functions this codebase imports by subpath,
-// mirroring the real signatures from `@types/validator`.
-declare module 'validator/lib/isIP' {
+// `import isIP from 'validator/lib/isIP.js'` fails with TS2307 even though
+// the file exists on disk and resolves fine at runtime. These declarations
+// close that gap for the specific functions this codebase imports by
+// subpath, mirroring the real signatures from `@types/validator`.
+//
+// IMPORTANT: the module specifiers below are NOT resolution-checked by tsc.
+// A `declare module '<anything>'` block is accepted verbatim whether or not
+// that path actually exists on disk — tsc will happily typecheck an import
+// of a module that doesn't exist at runtime. The `.js` extension on every
+// specifier here is load-bearing and must exactly match the extension used
+// in the corresponding `import` statement: this package is
+// `"type": "module"`, `validator` has no `package.json` `exports` map, and
+// Node's ESM resolver (unlike CommonJS `require`) does not search for
+// extensions on bare/deep specifiers — an extensionless
+// `validator/lib/isIP` import throws `ERR_MODULE_NOT_FOUND` at runtime even
+// though it typechecks fine. If you add another subpath here, verify it
+// actually resolves at runtime (see the runtime import check in
+// task-3-report.md) — tsc will not catch a mismatch for you.
+declare module 'validator/lib/isIP.js' {
   import type { IsIPOptions, IPVersion } from 'validator'
 
   export default function isIP(str: string, versionOrOptions?: IPVersion | IsIPOptions): boolean
 }
 
-declare module 'validator/lib/escape' {
+declare module 'validator/lib/escape.js' {
   export default function escape(input: string): string
 }
 
-declare module 'validator/lib/isLength' {
+declare module 'validator/lib/isLength.js' {
   import type { IsLengthOptions } from 'validator'
 
   export default function isLength(str: string, minOrOptions?: number | IsLengthOptions): boolean
 }
 
-declare module 'validator/lib/matches' {
+declare module 'validator/lib/matches.js' {
   export default function matches(str: string, pattern: RegExp | string, modifiers?: string): boolean
 }
 
-declare module 'validator/lib/isInt' {
+declare module 'validator/lib/isInt.js' {
   import type { IsIntOptions } from 'validator'
 
   export default function isInt(str: string, options?: IsIntOptions): boolean
 }
 
-declare module 'validator/lib/isPort' {
+declare module 'validator/lib/isPort.js' {
   export default function isPort(str: string): boolean
 }


### PR DESCRIPTION
## Summary

Completes the SonarCloud cleanup begun in #557/#559, resolving the remaining **37 findings** across three phases. Executed as 10 reviewed tasks (each implemented, task-reviewed, and re-reviewed after fixes) plus a whole-branch final review.

### Phase 2 — supply-chain / workflow hardening (7 findings)

- `rebuild-release-tags.yml`: `--proto '=https' --proto-redir '=https'` on both Docker Hub curls (S6506 ×2)
- `e2e-ssh.yml`: `npx --no-install` pins playwright to the lockfile install (S6505, S8543) — and fixes the workflow targeting a nonexistent spec filename (pre-existing; found by final review)
- `npm ci --ignore-scripts` with explicit, commented restore steps (`npm rebuild better-sqlite3`, `prepare:runtime` where needed) in `ci.yml`, `Dockerfile`, `examples/Dockerfile`, and the devcontainer (S6505 ×4) — verified via fresh-install experiments and both-arch Docker builds with boot + functional sqlite checks

### Phase 2.5 — validator subpath imports (3 findings)

- `validator/lib/<fn>.js` subpath imports in the three validation modules (S8927 ×3), with a hand-written ambient type shim (`types/validator-lib.d.ts`) since `@types/validator` doesn't cover subpaths under NodeNext
- Import guard: `@typescript-eslint/no-restricted-imports` bans bare `'validator'` (type-only imports allowed)
- Task review caught that extensionless specifiers broke the production ESM build (tsc/vitest are structurally blind to it); fixed with `.js` extensions + runtime import verification of built `dist/` modules

### Phase 3 — test hygiene (21 findings)

- 15 fixed waits replaced with waits on real observable conditions (S2925), each changed spec verified twice against the Docker sshd; review + fix round eliminated two subtle premature-resolution races
- 6 skipped tests documented (S1607) — all were already in the conditional-with-reason form; explicit reason comments added. If SonarCloud doesn't close these, they should be marked accepted in the UI
- Prevention: `eslint-plugin-playwright@2.10.5` (quarantine-compliant) with `no-wait-for-timeout` + `no-skipped-test` (conditional allowed) scoped to `tests/playwright/**`

### Phase 4 — complexity refactors (5 findings + promotion)

- Behavior-preserving decompositions of the five S3776 offenders: `env-mapper` (42→<15), `validateTheme` (45→<15, security semantics audited path-by-path; also clears the repo's only `max-depth` error), `sftp-service`, `host-key-seed`, telnet test helper — tests byte-identical throughout (one allowed test-file restructure)
- `sonarjs/cognitive-complexity` promoted **warn → error** in both lint configs
- One regression the process caught before merge: the host-key-seed refactor dropped the empty-value guard on `--port`; fixed with a regression test

## Known fast-follows (deliberately out of scope)

- `scripts/postinstall.js` inner `npm install --no-save` is unpinned and doesn't pass `--ignore-scripts` (pre-existing)
- Pre-existing bug: `WEBSSH2_SSH_ALGORITHMS_PRESET=constructor` crashes boot via bare prototype lookup in `algorithm-presets.ts:51` — 2-line `Object.hasOwn` fix, worth its own issue
- Port the condition-wait pattern into the shared playwright helpers (`constants.ts`, `v2-helpers.ts`) with live Docker verification (currently documented eslint-disables)
- Post-merge: confirm S1607/S2925 close on SonarCloud; watch for new S5852 on the digit-pair regexes (justified disables added)

## Test plan

- [x] `npm run lint` / `lint:sonar` / `lint:complexity` — 0 errors (max-depth error eliminated)
- [x] `npm run typecheck`
- [x] `npm run test` — 116 files, 1686 tests (one new regression test)
- [x] `npm run build`
- [x] `npm audit` — 0 vulnerabilities
- [x] Changed e2e specs run twice each against Docker sshd; Docker images built and boot-checked on arm64 + amd64