### PR TITLE
fix(config): ignore prototype-member algorithm preset names

### DIFF
--- a/app/config/algorithm-presets.ts
+++ b/app/config/algorithm-presets.ts
@@ -48,6 +48,8 @@ export const ALGORITHM_PRESETS: Record<string, Algorithms> = {
  * @pure
  */
 export function getAlgorithmPreset(presetName: string): Algorithms | undefined {
-  return ALGORITHM_PRESETS[presetName.toLowerCase()]
+  const key = presetName.toLowerCase()
+  // eslint-disable-next-line security/detect-object-injection -- own-key membership verified via Object.hasOwn
+  return Object.hasOwn(ALGORITHM_PRESETS, key) ? ALGORITHM_PRESETS[key] : undefined
 }
 

--- a/tests/unit/config/algorithm-presets.vitest.ts
+++ b/tests/unit/config/algorithm-presets.vitest.ts
@@ -1,0 +1,27 @@
+// tests/unit/config/algorithm-presets.vitest.ts
+// Unit tests for algorithm preset lookup (issue #561: prototype-member names)
+
+import { describe, it, expect } from 'vitest'
+import { ALGORITHM_PRESETS, getAlgorithmPreset } from '../../../app/config/algorithm-presets.js'
+
+describe('getAlgorithmPreset', () => {
+  it.each(['modern', 'legacy', 'strict'])('returns the %s preset', (name) => {
+    // eslint-disable-next-line security/detect-object-injection -- test data uses known preset names only
+    expect(getAlgorithmPreset(name)).toEqual(ALGORITHM_PRESETS[name])
+  })
+
+  it('is case-insensitive', () => {
+    expect(getAlgorithmPreset('MODERN')).toEqual(ALGORITHM_PRESETS['modern'])
+  })
+
+  it('returns undefined for unknown preset names', () => {
+    expect(getAlgorithmPreset('banana')).toBeUndefined()
+  })
+
+  it.each(['constructor', 'toString', 'hasOwnProperty', 'valueOf', '__proto__'])(
+    'returns undefined for prototype-member name %s',
+    (name) => {
+      expect(getAlgorithmPreset(name)).toBeUndefined()
+    }
+  )
+})

--- a/tests/unit/config/env-mapper.vitest.ts
+++ b/tests/unit/config/env-mapper.vitest.ts
@@ -180,6 +180,19 @@ describe('mapEnvironmentVariables', () => {
       expect(result).toEqual({})
     })
 
+    it.each(['constructor', 'toString', 'hasOwnProperty'])(
+      'ignores prototype-member preset name %s without throwing',
+      (name) => {
+        const env = {
+          WEBSSH2_SSH_ALGORITHMS_PRESET: name
+        }
+
+        const result = mapEnvironmentVariables(env)
+
+        expect(result).toEqual({})
+      }
+    )
+
     it('case-insensitive preset names', () => {
       const env = {
         WEBSSH2_SSH_ALGORITHMS_PRESET: 'MODERN'


### PR DESCRIPTION
## Summary

Fixes #561. `WEBSSH2_SSH_ALGORITHMS_PRESET=constructor` (or any `Object.prototype` member name — `toString`, `hasOwnProperty`, …) crashed the server at boot with `TypeError: preset.cipher is not iterable`, because `getAlgorithmPreset` did a bare bracket lookup on a plain object literal and returned the inherited prototype member. Invalid preset names are supposed to be silently ignored with fallback to defaults, like `banana` is.

## Fix

Guard the lookup with `Object.hasOwn` in `app/config/algorithm-presets.ts` so only own keys (`modern`, `legacy`, `strict`) resolve; everything else returns `undefined` and is handled by the existing guard in `collectPresetEntries`.

The other bracket lookup on `ALGORITHM_PRESETS` (`app/services/ssh/algorithm-analyzer.ts` `suggestPreset`) iterates a static literal list and is unreachable from external input — deliberately unchanged.

## Behavior change

Only inputs that previously crashed the boot are affected; they are now ignored. Valid and merely-unknown preset names behave identically to before. Bug fix restoring intended behavior — no config flag needed.

## Tests

- New `tests/unit/config/algorithm-presets.vitest.ts`: valid presets, case-insensitivity, unknown names, and all five prototype-member cases (`constructor`, `toString`, `hasOwnProperty`, `valueOf`, `__proto__`) — RED confirmed before the fix (`constructor` and `__proto__` leaked non-undefined values).
- `tests/unit/config/env-mapper.vitest.ts`: regression cases asserting prototype-member preset names map to `{}` without throwing, same as unknown names.
- Boot repro verified against the built server: `WEBSSH2_SSH_ALGORITHMS_PRESET=constructor` now starts cleanly.
- Full gate: lint (0 errors), typecheck, 1699/1699 tests, build — all pass.