### PR TITLE
chore: pin client 5.3.0 + transport fallback E2E (#549)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "socket.io": "^4.8.1",
         "ssh2": "1.17",
         "validator": "^13.15.35",
-        "webssh2_client": "5.2.0",
+        "webssh2_client": "5.3.0",
         "zod": "^4.1.12"
       },
       "bin": {
@@ -6067,9 +6067,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/webssh2_client": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-5.2.0.tgz",
-      "integrity": "sha512-dFh6bvHtnH4zYyxNhYq+M+pguRtpSOiZXvEx2sufjh8a8O/afx6D2QhhT+8e2swKIIQKdzcwmVVt/EFxtZOYow==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-5.3.0.tgz",
+      "integrity": "sha512-BH8YfyEyEdrRdoxlPiwZnmjdzw3USmMIogPjC43lwT6qZNrYv6q309J1YqXaAalC5zBmKySlTAXzOVbM1XQO3Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 22"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "socket.io": "^4.8.1",
     "ssh2": "1.17",
     "validator": "^13.15.35",
-    "webssh2_client": "5.2.0",
+    "webssh2_client": "5.3.0",
     "zod": "^4.1.12"
   },
   "scripts": {

--- a/tests/playwright/transport-fallback.spec.ts
+++ b/tests/playwright/transport-fallback.spec.ts
@@ -1,0 +1,164 @@
+/* global window */
+/**
+ * E2E proof of operator-forced Socket.IO transport fallback (#549 / #131).
+ *
+ * The shared Playwright webServer (see playwright.config.ts) starts a single
+ * gateway with fixed env for the whole run, but this spec needs a different
+ * WEBSSH2_OPTIONS_TRANSPORT per scenario. So each test spins up its own
+ * short-lived gateway (`node dist/index.js`) on a dedicated port and tears
+ * it down afterward, following the spawn/teardown shape used by
+ * scripts/start-server.ts.
+ */
+import { spawn, type ChildProcess } from 'node:child_process'
+import { test, expect, type Page } from '@playwright/test'
+import { TEST_CONFIG } from './constants.js'
+import { connectWithBasicAuth } from './v2-helpers.js'
+
+const E2E_ENABLED = process.env.ENABLE_E2E_SSH === '1'
+
+const GATEWAY_STARTUP_TIMEOUT = 15_000
+const TRANSPORT_UPGRADE_TIMEOUT = 15_000
+
+// Dedicated ports for this spec's private gateways. Distinct from the shared
+// webServer port (4444 by default) and the E2E SSH container port, so runs
+// never collide with the rest of the suite.
+const POLLING_ONLY_PORT = 4301
+const POLLING_UPGRADE_PORT = 4302
+const DEFAULT_TRANSPORT_PORT = 4303
+
+interface Gateway {
+  readonly proc: ChildProcess
+  readonly baseUrl: string
+}
+
+async function startGateway(port: number, env: Record<string, string>): Promise<Gateway> {
+  const proc = spawn(process.execPath, ['dist/index.js'], {
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      WEBSSH2_LISTEN_PORT: String(port),
+      WEBSSH2_SESSION_SECRET: 'e2e-transport-fallback-test-secret-32chars',
+      ...env,
+    },
+  })
+
+  let stderrOutput = ''
+  proc.stderr.on('data', (chunk: Buffer) => {
+    stderrOutput += chunk.toString()
+  })
+
+  const baseUrl = `http://localhost:${port}`
+  try {
+    await expect
+      .poll(
+        async () => {
+          try {
+            const res = await fetch(`${baseUrl}/ssh`)
+            return res.status
+          } catch {
+            return 0
+          }
+        },
+        { timeout: GATEWAY_STARTUP_TIMEOUT }
+      )
+      .toBeGreaterThan(0)
+  } catch (error) {
+    proc.kill()
+    throw new Error(`Gateway on port ${port} failed to start: ${stderrOutput}`, { cause: error })
+  }
+  return { proc, baseUrl }
+}
+
+function stopGateway(gateway: Gateway): void {
+  gateway.proc.kill()
+}
+
+async function activeTransport(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const socket = (
+      window as unknown as {
+        webssh2Socket?: { io: { engine: { transport: { name: string } } } }
+      }
+    ).webssh2Socket
+    if (socket === undefined) {
+      throw new Error('webssh2Socket not present on window')
+    }
+    return socket.io.engine.transport.name
+  })
+}
+
+test.describe('operator-forced Socket.IO transport (#549/#131)', () => {
+  // Reason: requires a live Docker SSH test server; opt-in only via ENABLE_E2E_SSH=1.
+  test.skip(!E2E_ENABLED, 'Set ENABLE_E2E_SSH=1 to run this test')
+
+  test('transport=polling connects via long-polling and never upgrades', async ({ page }) => {
+    const gateway = await startGateway(POLLING_ONLY_PORT, {
+      WEBSSH2_OPTIONS_TRANSPORT: 'polling',
+    })
+    try {
+      const socketIoWsConnections: string[] = []
+      page.on('websocket', (ws) => {
+        if (ws.url().includes('/ssh/socket.io')) {
+          socketIoWsConnections.push(ws.url())
+        }
+      })
+
+      await connectWithBasicAuth(
+        page,
+        gateway.baseUrl,
+        TEST_CONFIG.validUsername,
+        TEST_CONFIG.validPassword,
+        TEST_CONFIG.sshHost,
+        TEST_CONFIG.sshPort
+      )
+
+      await expect.poll(() => activeTransport(page)).toBe('polling')
+      // With only 'polling' advertised server-side, engine.io's handshake
+      // never lists 'websocket' as an available upgrade, so the client has
+      // nothing to attempt — no timing race to guard against here.
+      expect(socketIoWsConnections).toHaveLength(0)
+    } finally {
+      stopGateway(gateway)
+    }
+  })
+
+  test('transport=polling,websocket starts polling then upgrades', async ({ page }) => {
+    const gateway = await startGateway(POLLING_UPGRADE_PORT, {
+      WEBSSH2_OPTIONS_TRANSPORT: 'polling,websocket',
+    })
+    try {
+      await connectWithBasicAuth(
+        page,
+        gateway.baseUrl,
+        TEST_CONFIG.validUsername,
+        TEST_CONFIG.validPassword,
+        TEST_CONFIG.sshHost,
+        TEST_CONFIG.sshPort
+      )
+
+      await expect
+        .poll(() => activeTransport(page), { timeout: TRANSPORT_UPGRADE_TIMEOUT })
+        .toBe('websocket')
+    } finally {
+      stopGateway(gateway)
+    }
+  })
+
+  test('no transport config keeps websocket-first default', async ({ page }) => {
+    const gateway = await startGateway(DEFAULT_TRANSPORT_PORT, {})
+    try {
+      await connectWithBasicAuth(
+        page,
+        gateway.baseUrl,
+        TEST_CONFIG.validUsername,
+        TEST_CONFIG.validPassword,
+        TEST_CONFIG.sshHost,
+        TEST_CONFIG.sshPort
+      )
+
+      await expect.poll(() => activeTransport(page)).toBe('websocket')
+    } finally {
+      stopGateway(gateway)
+    }
+  })
+})

--- a/tests/playwright/transport-fallback.spec.ts
+++ b/tests/playwright/transport-fallback.spec.ts
@@ -13,6 +13,7 @@ import { spawn, type ChildProcess } from 'node:child_process'
 import { test, expect, type Page } from '@playwright/test'
 import { TEST_CONFIG } from './constants.js'
 import { connectWithBasicAuth } from './v2-helpers.js'
+import { TEST_SESSION_SECRET_VALID } from '../test-constants.js'
 
 const E2E_ENABLED = process.env.ENABLE_E2E_SSH === '1'
 
@@ -32,12 +33,18 @@ interface Gateway {
 }
 
 async function startGateway(port: number, env: Record<string, string>): Promise<Gateway> {
+  // Strip any ambient WEBSSH2_OPTIONS_TRANSPORT before applying per-scenario
+  // overrides, so a scenario that omits it (testing the "unset" default) is
+  // hermetic regardless of what the enclosing shell/CI happens to export.
+  const baseEnv = { ...process.env }
+  delete baseEnv.WEBSSH2_OPTIONS_TRANSPORT
+
   const proc = spawn(process.execPath, ['dist/index.js'], {
     stdio: 'pipe',
     env: {
-      ...process.env,
+      ...baseEnv,
       WEBSSH2_LISTEN_PORT: String(port),
-      WEBSSH2_SESSION_SECRET: 'e2e-transport-fallback-test-secret-32chars',
+      WEBSSH2_SESSION_SECRET: TEST_SESSION_SECRET_VALID,
       ...env,
     },
   })


### PR DESCRIPTION
## Summary

Wave-1 gate for the cross-repo transport-fallback feature: pins
webssh2_client **5.3.0** (the release that honors injected
`socket.transports`, billchurch/webssh2_client#138) and adds the Playwright
E2E proof that the feature works end-to-end through a real browser.

With this merged, #549 and billchurch/webssh2_client#131 are complete and
can be closed.

## Changes

- `chore:` pin `webssh2_client` at exact `5.3.0` (was 5.2.0).
- `test:` new `tests/playwright/transport-fallback.spec.ts` — spawns
  short-lived gateways with per-scenario env (ports 4301–4303, distinct from
  the shared webServer) and proves:
  1. `WEBSSH2_OPTIONS_TRANSPORT=polling` → client connects via long-polling
     only; `page.on('websocket')` (registered before navigation) records
     **zero** WebSocket connections to `/ssh/socket.io`.
  2. `polling,websocket` → starts on polling, upgrades to websocket.
  3. No transport config → websocket-first default, unchanged.
- Hermeticity: ambient `WEBSSH2_OPTIONS_TRANSPORT` is stripped from the
  spawned env so scenario 3 is immune to shell/CI leakage; session secret
  comes from `tests/test-constants.ts`; gateways are torn down in `finally`
  (no leaked processes, including on boot failure).

## Testing

- Full unit/integration suite against the 5.3.0 bundle: 1731/1731.
- `ENABLE_E2E_SSH=1 npx playwright test tests/playwright/transport-fallback.spec.ts`:
  3/3, run repeatedly for flake-resistance.
- Review trail: task reviews + adversarial gate review (verified the
  no-WebSocket assertion is falsifiable — a server ignoring the env var
  would fail it — plus teardown-on-failure and port-collision checks), one
  fix round (secret constant, env hermeticity), scoped re-review clean.

Closes #549. Companion client issue: billchurch/webssh2_client#131.
