### PR TITLE
chore(deps): bump webssh2_client to 5.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "socket.io": "^4.8.1",
         "ssh2": "1.17",
         "validator": "^13.15.35",
-        "webssh2_client": "5.4.0",
+        "webssh2_client": "5.4.1",
         "zod": "^4.1.12"
       },
       "bin": {
@@ -1138,19 +1138,6 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
-      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -6223,15 +6210,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/webssh2_client": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-5.4.0.tgz",
-      "integrity": "sha512-WQTwiYGbKmOH0lZKr5K7PaV2x2a/Ux2SdKGfGfqOipi+hg3Gz+LmLGNtvH094+CtrL568FNFhtPGNeQRPkZWNg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-5.4.1.tgz",
+      "integrity": "sha512-w5bxsnsXp/RV0skQM8FgcfBk2W6q11YkgoFiGkHRQcklOrIRXoA5XBXTx3ZJ8in0wPRN6lZmycmPelCjZUWg4A==",
       "license": "MIT",
       "engines": {
         "node": ">= 22"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.53.3"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "socket.io": "^4.8.1",
     "ssh2": "1.17",
     "validator": "^13.15.35",
-    "webssh2_client": "5.4.0",
+    "webssh2_client": "5.4.1",
     "zod": "^4.1.12"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps `webssh2_client` from 5.4.0 to 5.4.1.

This release removes the orphaned `@rollup/rollup-linux-x64-gnu` optionalDependency from the dependency tree (closes [webssh2_client#143](https://github.com/billchurch/webssh2_client/issues/143), implemented in [webssh2_client#144](https://github.com/billchurch/webssh2_client pull/144)). The bundle is verified against published release checksums.

## Verification

| Gate | Result | Evidence |
| --- | --- | --- |
| Security Bundle Verification | PASS | `npm run security:verify-bundle` ✓ webssh2_client@5.4.1 bundle verified (provenance + checksums) |
| Linting | PASS | `npm run lint` — 0 errors / 37 pre-existing warnings |
| Type Checking | PASS | `npm run typecheck` — exit 0 |
| Unit Tests | PASS | `npm run test` — 1731/1731 tests passing across 123 files |
| Security Audit | PASS | `npm audit --audit-level=high` — 0 vulnerabilities |
| E2E Tests | PASS | `npm run test:e2e` — 54/64 (identical failure set to issue #567 baseline) |

All changes are confined to `package.json` and `package-lock.json`. Exact pin: `"5.4.1"`.
