### PR TITLE
test(e2e): restore Playwright baseline (#567)

### DIFF
--- a/tests/playwright/csp-enforce.spec.ts
+++ b/tests/playwright/csp-enforce.spec.ts
@@ -74,11 +74,19 @@ test.describe('CSP enforcement — terminal boots from JSON config block (#546)'
       await expect(page.locator('.xterm-screen')).toBeVisible({ timeout: TIMEOUTS.CONNECTION })
 
       // Assert no app-breaking CSP violations.
-      // The one benign/expected violation is the blocked legacy
-      // `window.webssh2Config = null;` inline script — filter it out so we
-      // only fail on genuine regressions in app-controlled code.
-      const appViolations = cspMessages.filter((m) => !/webssh2Config/i.test(m))
-      expect(appViolations).toEqual([])
+      // The one benign/expected violation is the blocked legacy inline
+      // `window.webssh2Config = ...` script. Chromium's violation message
+      // never includes script source (only a per-content sha256), so the
+      // legacy script can't be matched by name: instead allow at most ONE
+      // blocked-inline-script violation and require zero of any other kind.
+      const inlineScriptViolations = cspMessages.filter((m) =>
+        /Executing inline script/i.test(m)
+      )
+      const otherViolations = cspMessages.filter(
+        (m) => !/Executing inline script/i.test(m)
+      )
+      expect(otherViolations).toEqual([])
+      expect(inlineScriptViolations.length).toBeLessThanOrEqual(1)
 
       // Strong assertion: evaluate in-page that the JSON config block exists
       // and contains a non-null parsed object.  This is the authoritative proof

--- a/tests/playwright/csp-enforce.spec.ts
+++ b/tests/playwright/csp-enforce.spec.ts
@@ -10,9 +10,10 @@
  *      as the other E2E SSH specs.
  *   3. Asserts the xterm terminal renders — proving the client read runtime
  *      config from the inert JSON block rather than the blocked inline script.
- *   4. Asserts no app-originated CSP violations occurred (the one expected
+ *   4. Asserts no app-originated CSP violations occurred. The one expected
  *      violation — the blocked legacy `window.webssh2Config = null;` inline
- *      script — is intentionally filtered out).
+ *      script — is counted structurally: exactly one blocked-inline-script
+ *      violation is required; any other violation kind fails the spec.
  *   5. (Strong) Evaluates in-page that the JSON config block is populated with
  *      a non-null object, confirming the JSON-block injection path works.
  *
@@ -86,7 +87,11 @@ test.describe('CSP enforcement — terminal boots from JSON config block (#546)'
         (m) => !/Executing inline script/i.test(m)
       )
       expect(otherViolations).toEqual([])
-      expect(inlineScriptViolations.length).toBeLessThanOrEqual(1)
+      // Exactly one: the blocked legacy inline script is a free positive proof
+      // that CSP enforcement is actually on — zero would mean enforcement
+      // silently broke and this spec was passing vacuously. If the legacy
+      // inline script is ever removed server-side, update this deliberately.
+      expect(inlineScriptViolations.length).toBe(1)
 
       // Strong assertion: evaluate in-page that the JSON config block exists
       // and contains a non-null parsed object.  This is the authoritative proof

--- a/tests/playwright/issue-102-header-smoke.spec.ts
+++ b/tests/playwright/issue-102-header-smoke.spec.ts
@@ -42,12 +42,12 @@ interface WebSSH2Config {
 async function getInjectedConfig(page: Page): Promise<WebSSH2Config | undefined> {
   return page.evaluate(() => {
     const el = document.getElementById('webssh2-config')
-    const content = el?.textContent
-    if (content === undefined || content === '') {
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain, @typescript-eslint/no-unnecessary-condition, sonarjs/different-types-comparison
+    if (el === null || el.textContent === null || el.textContent === '') {
       return undefined
     }
     try {
-      return JSON.parse(content) as WebSSH2Config
+      return JSON.parse(el.textContent) as WebSSH2Config
     } catch {
       return undefined
     }

--- a/tests/playwright/issue-102-header-smoke.spec.ts
+++ b/tests/playwright/issue-102-header-smoke.spec.ts
@@ -9,10 +9,10 @@
  * requests via hasAnyHeaderKey) and the client (validates background via
  * `validateHeaderBackground`, renders default `#000` fallback on rejection).
  *
- * No SSH connection is required — the smokes assert on the rendered page's
- * `window.webssh2Config` object and the header `<div>`'s styling.
+ * No SSH connection is required — the smokes assert on the injected JSON config
+ * block and the header `<div>`'s styling.
  */
-/* global window */
+/* global document */
 import { test, expect, type Page } from '@playwright/test'
 import { BASE_URL } from './constants.js'
 
@@ -39,20 +39,27 @@ interface WebSSH2Config {
   [key: string]: unknown
 }
 
-declare global {
-  interface Window {
-    webssh2Config?: WebSSH2Config
-  }
-}
-
 async function getInjectedConfig(page: Page): Promise<WebSSH2Config | undefined> {
-  return page.evaluate(() => window.webssh2Config)
+  return page.evaluate(() => {
+    const el = document.getElementById('webssh2-config')
+    const content = el?.textContent
+    if (content === undefined || content === '') {
+      return undefined
+    }
+    try {
+      return JSON.parse(content) as WebSSH2Config
+    } catch {
+      return undefined
+    }
+  })
 }
 
 function extractConfigFromHtml(html: string): WebSSH2Config {
-  const match = html.match(/window\.webssh2Config = (\{.+?\});/s)
+  const match = html.match(
+    /<script type="application\/json" id="webssh2-config">(.+?)<\/script>/s
+  )
   if (match?.[1] === undefined) {
-    throw new Error('window.webssh2Config not found in response HTML')
+    throw new Error('webssh2-config JSON block not found in response HTML')
   }
   return JSON.parse(match[1]) as WebSSH2Config
 }

--- a/tests/playwright/post-auth.test.js
+++ b/tests/playwright/post-auth.test.js
@@ -43,7 +43,9 @@ test.describe('HTTP POST Authentication', () => {
     // Verify response contains client HTML
     const body = await response.text()
     expect(body).toContain('<!DOCTYPE html>')
-    expect(body).toContain('webssh2.bundle.js')
+    // Since the #109 contract the client bundle is content-hashed
+    // (webssh2-<hash>.js); never assert a specific hash.
+    expect(body).toMatch(/webssh2-[0-9a-f]+\.js/)
   })
 
   test('should connect with all parameters in body', async ({ request }) => {
@@ -62,7 +64,9 @@ test.describe('HTTP POST Authentication', () => {
     // Verify response contains client HTML
     const body = await response.text()
     expect(body).toContain('<!DOCTYPE html>')
-    expect(body).toContain('webssh2.bundle.js')
+    // Since the #109 contract the client bundle is content-hashed
+    // (webssh2-<hash>.js); never assert a specific hash.
+    expect(body).toMatch(/webssh2-[0-9a-f]+\.js/)
   })
 
   test('should connect with hostname alias in query params', async ({ request }) => {

--- a/tests/playwright/theming.spec.ts
+++ b/tests/playwright/theming.spec.ts
@@ -110,21 +110,36 @@ test.describe('Terminal Theming', () => {
       )
     })
 
-    // Rewrite the served HTML's JSON config block (the source the client
-    // actually boots from under enforced CSP, #546) so theming is disabled
-    // regardless of server config.
-    await page.route('**/ssh/host/**', async (route) => {
-      const response = await route.fetch()
-      const body = await response.text()
-      const patched = body.replace(
-        /<script type="application\/json" id="webssh2-config">(.+?)<\/script>/s,
-        (_m, json: string) => {
-          const cfg = JSON.parse(json) as Record<string, unknown>
-          cfg['theming'] = { enabled: false }
-          return `<script type="application/json" id="webssh2-config">${JSON.stringify(cfg)}</script>`
+    // Patch the served JSON config block (the source the client boots from
+    // under enforced CSP, #546) so theming is disabled regardless of server
+    // config. Route interception is NOT usable here: a route.fulfill()'d
+    // document loses its local address-space attribution and Chromium's
+    // Local Network Access checks then block the ws://localhost socket.
+    // Instead, rewrite the inert block's text before the (deferred) module
+    // script executes — init scripts run ahead of all page scripts.
+    await page.addInitScript(() => {
+      /* global document, MutationObserver */
+      const observer = new MutationObserver(() => {
+        const el = document.getElementById('webssh2-config')
+        // eslint-disable-next-line @typescript-eslint/prefer-optional-chain, @typescript-eslint/no-unnecessary-condition, sonarjs/different-types-comparison
+        if (el === null || el.textContent === null || el.textContent === '') {
+          return
         }
-      )
-      await route.fulfill({ response, body: patched })
+        try {
+          const cfg = JSON.parse(el.textContent) as Record<string, unknown>
+          cfg['theming'] = { enabled: false }
+          el.textContent = JSON.stringify(cfg)
+          observer.disconnect()
+        } catch {
+          // JSON text still streaming in — keep observing until it parses
+        }
+      })
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      observer.observe(document.documentElement ?? document, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      })
     })
 
     await page.goto(

--- a/tests/playwright/theming.spec.ts
+++ b/tests/playwright/theming.spec.ts
@@ -102,30 +102,29 @@ test.describe('Terminal Theming', () => {
     })
     const page = await context.newPage()
 
-    // Override window.webssh2Config before the inline script runs so that the
-    // client sees theming as disabled regardless of the server config.
-    await page.addInitScript(() => {
-      let _cfg: unknown = null
-      Object.defineProperty(window, 'webssh2Config', {
-        configurable: true,
-        get() {
-          return _cfg
-        },
-        set(v) {
-          _cfg = {
-            ...(v as Record<string, unknown>),
-            theming: { enabled: false },
-          }
-        },
-      })
-    })
-
     // Pre-seed stale localStorage with a Dracula theming entry
     await page.addInitScript(() => {
       localStorage.setItem(
         'webssh2.theming',
         JSON.stringify({ themeName: 'Dracula' })
       )
+    })
+
+    // Rewrite the served HTML's JSON config block (the source the client
+    // actually boots from under enforced CSP, #546) so theming is disabled
+    // regardless of server config.
+    await page.route('**/ssh/host/**', async (route) => {
+      const response = await route.fetch()
+      const body = await response.text()
+      const patched = body.replace(
+        /<script type="application\/json" id="webssh2-config">(.+?)<\/script>/s,
+        (_m, json: string) => {
+          const cfg = JSON.parse(json) as Record<string, unknown>
+          cfg['theming'] = { enabled: false }
+          return `<script type="application/json" id="webssh2-config">${JSON.stringify(cfg)}</script>`
+        }
+      )
+      await route.fulfill({ response, body: patched })
     })
 
     await page.goto(


### PR DESCRIPTION
## Summary

Part of #567. Restores the Playwright E2E baseline after the #546 CSP-enforce
+ JSON-config-block change made ten specs assert dead code (the old
`window.webssh2Config` global / literal bundle filename / `defineProperty`
overrides), rather than the actual behavior. Full suite goes from the
pre-existing failures described in #567 to **63/64**, with one remaining
failure that is a documented, tracked **client** bug (not fixable from this
repo) — see notes below.

## Root cause (single, for 9 of 10 failures)

The suite runs under `WEBSSH2_CSP_MODE=enforce`. Under enforced CSP the
legacy inline config script is blocked outright, and the client now boots
from the `#webssh2-config` JSON script block (#546) instead of
`window.webssh2Config`. Every failing spec was asserting the old,
now-dead mechanism.

## Per-task fixes

- **post-auth** (`bef31e9`): assert the hashed client bundle filename via
  regex instead of the stale literal `webssh2.bundle.js` — 11/11.
- **issue-102 header smokes** (`00d258d`, `2cf9b03`): helpers now read the
  `#webssh2-config` JSON block instead of the nonexistent
  `window.webssh2Config` — 7/7.
- **theming** (`eb7796a`, `58d07ea`): the "theming disabled" override now
  patches the JSON block via an init-script `MutationObserver`, replacing a
  `defineProperty` override on the dead legacy global — 2/2. Note: the
  original #567 hypothesis of stale-`localStorage` leakage between runs was
  **incorrect** — the test deliberately seeds `localStorage`; the real cause
  was the CSP-blocked override mechanism. Route interception
  (`route.fulfill()`) was tried first and doesn't work here: a fulfilled
  document loses local address-space attribution, and Chromium's Local
  Network Access checks then block `ws://localhost`
  (`ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS`).
- **csp-enforce** (`975d142`): the benign-violation filter is now structural
  (at most one `Executing inline script` violation, zero others) instead of
  a `/webssh2Config/` substring match — Chromium violation messages carry
  only a sha256 hash, never script source, so the old filter could never
  match — 1/1.

## Remaining failure (out of scope for this branch)

`e2e-sftp.spec.ts › should block upload of files with blocked extensions`
stays red. Root-caused to a **client** bug, not server or test: the server
emits a well-formed `sftp-error` event with a `transferId`
(`SFTP_EXTENSION_BLOCKED`, "File extension .exe is not allowed"), but the
client's `sftp-service.ts` `handleError()` never rejects the
`pendingUploadReady` FIFO entry, so the upload sits at "Waiting..." until a
generic ~30s timeout instead of surfacing the error. Filed as
[webssh2_client#147](https://github.com/billchurch/webssh2_client/issues/147).
This spec will stay red until that client fix ships.

## Full-suite result

```text
63 passed, 1 failed (e2e-sftp.spec.ts > should block upload of files with blocked extensions)
```

## Gates

- `npm run lint`: 0 errors (37 pre-existing warnings, unrelated to this
  branch)
- `npm run typecheck`: clean
- `npm run test`: 1731/1731 Vitest tests passed (123 files)

## Notes

- Findings posted to #567:
  https://github.com/billchurch/webssh2/issues/567#issuecomment-5130639620
- Minor deferred items from review, not blocking: the three-rule
  `eslint-disable-next-line` comments in the issue-102/theming helpers exist
  because the mandated explicit null-check pattern trips auto-fixable lint
  rules; a `/* global */` comment placement nit in `theming.spec.ts`.
