### PR TITLE
chore: client 5.4.2, sonarjs 4.2.0 adoption, issue-102 spec constants (#566, #567, #570)

### DIFF
--- a/app/socket/handlers/exec-safety.ts
+++ b/app/socket/handlers/exec-safety.ts
@@ -13,8 +13,7 @@ export function isCommandSafe(command: string): boolean {
   // Basic safety checks - can be expanded based on requirements
   const dangerousPatterns = [
     /;\s*rm\s+-rf\s+\//i,     // rm -rf /
-    // eslint-disable-next-line sonarjs/slow-regex -- dangerous-command detector; input is already length-bounded upstream
-    /dd\s+.*of=\/dev\//i,     // NOSONAR dd overwriting devices
+    /dd\s[\s\S]*of=\/dev\//i, // dd overwriting devices
     />\s*\/dev\/s[a-z]+/i,    // Redirecting to block devices
   ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "socket.io": "^4.8.1",
         "ssh2": "1.17",
         "validator": "^13.15.35",
-        "webssh2_client": "5.4.1",
+        "webssh2_client": "5.4.2",
         "zod": "^4.1.12"
       },
       "bin": {
@@ -48,7 +48,7 @@
         "eslint-plugin-n": "^18.2.2",
         "eslint-plugin-playwright": "2.10.5",
         "eslint-plugin-security": "^4.0.0",
-        "eslint-plugin-sonarjs": "4.0.3",
+        "eslint-plugin-sonarjs": "4.2.0",
         "eslint-plugin-unicorn": "^71.1.0",
         "supertest": "^7.1.4",
         "tsx": "^4.22.4",
@@ -2948,9 +2948,9 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
-      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz",
+      "integrity": "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
@@ -2958,14 +2958,15 @@
         "builtin-modules": "^3.3.0",
         "bytes": "^3.1.2",
         "functional-red-black-tree": "^1.0.1",
-        "globals": "^17.4.0",
+        "globals": "^17.7.0",
         "jsx-ast-utils-x": "^0.1.0",
         "lodash.merge": "^4.6.2",
         "minimatch": "^10.2.5",
         "scslre": "^0.3.0",
-        "semver": "^7.7.4",
+        "semver": "^7.8.5",
         "ts-api-utils": "^2.5.0",
-        "typescript": ">=5"
+        "typescript": ">=5 <6.1.0",
+        "yaml": "^2.9.0"
       },
       "peerDependencies": {
         "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
@@ -6210,9 +6211,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/webssh2_client": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-5.4.1.tgz",
-      "integrity": "sha512-w5bxsnsXp/RV0skQM8FgcfBk2W6q11YkgoFiGkHRQcklOrIRXoA5XBXTx3ZJ8in0wPRN6lZmycmPelCjZUWg4A==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/webssh2_client/-/webssh2_client-5.4.2.tgz",
+      "integrity": "sha512-WdscgQyo+uOax4W7Si1raKPiClNn9dyTFfPKCNI11TugKWDljotKbW7U6vp/boV83vZZTtcSR/ZFgy0p8EDJtA==",
       "license": "MIT",
       "engines": {
         "node": ">= 22"
@@ -6286,6 +6287,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "socket.io": "^4.8.1",
     "ssh2": "1.17",
     "validator": "^13.15.35",
-    "webssh2_client": "5.4.1",
+    "webssh2_client": "5.4.2",
     "zod": "^4.1.12"
   },
   "scripts": {
@@ -101,7 +101,7 @@
     "eslint-plugin-n": "^18.2.2",
     "eslint-plugin-playwright": "2.10.5",
     "eslint-plugin-security": "^4.0.0",
-    "eslint-plugin-sonarjs": "4.0.3",
+    "eslint-plugin-sonarjs": "4.2.0",
     "eslint-plugin-unicorn": "^71.1.0",
     "supertest": "^7.1.4",
     "tsx": "^4.22.4",

--- a/tests/contracts/socket-negative-auth-exec.vitest.ts
+++ b/tests/contracts/socket-negative-auth-exec.vitest.ts
@@ -84,6 +84,6 @@ describe('Socket.IO Negative: authenticate + exec env', () => {
     // This test verifies that exec request processes without error
     // No ssherror events should be emitted
     const errorEvents = mockSocket.emit.mock.calls.filter((c: unknown[]) => c[0] === 'ssherror')
-    expect(errorEvents.length).toBe(0)
+    expect(errorEvents).toHaveLength(0)
   })
 })

--- a/tests/integration/csp-headers.vitest.ts
+++ b/tests/integration/csp-headers.vitest.ts
@@ -54,7 +54,7 @@ describe('CSP headers', () => {
       )
     )
     const defined = headers.filter((h): h is string => h !== undefined)
-    expect(defined.length).toBe(paths.length)  // every app-handled route carries it
+    expect(defined).toHaveLength(paths.length)  // every app-handled route carries it
     expect(new Set(defined).size).toBe(1)       // value is identical across routes
     expect(scriptSrcOf(defined[0])).toBe("script-src 'self'")
     expect(defined[0]).toContain("base-uri 'none'")

--- a/tests/playwright/csp-enforce.spec.ts
+++ b/tests/playwright/csp-enforce.spec.ts
@@ -91,7 +91,7 @@ test.describe('CSP enforcement — terminal boots from JSON config block (#546)'
       // that CSP enforcement is actually on — zero would mean enforcement
       // silently broke and this spec was passing vacuously. If the legacy
       // inline script is ever removed server-side, update this deliberately.
-      expect(inlineScriptViolations.length).toBe(1)
+      expect(inlineScriptViolations).toHaveLength(1)
 
       // Strong assertion: evaluate in-page that the JSON config block exists
       // and contains a non-null parsed object.  This is the authoritative proof

--- a/tests/playwright/e2e-term-size-replay-v2.spec.ts
+++ b/tests/playwright/e2e-term-size-replay-v2.spec.ts
@@ -138,8 +138,7 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
       () => {
         const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
         const text = rows.map((row) => row.textContent ?? '').join('\n')
-        // eslint-disable-next-line sonarjs/slow-regex -- digits and whitespace are disjoint character classes, so backtracking stays linear
-        return /\d+\s+\d+/.test(text)
+        return /\b\d+\s+\d+\b/.test(text)
       },
       { timeout: TIMEOUTS.CONNECTION },
     )
@@ -152,8 +151,7 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
 
     // Look for any digit pair that looks like terminal dimensions (rows cols)
     // The output might be on a new line after the command
-    // eslint-disable-next-line sonarjs/slow-regex -- digits and whitespace are disjoint character classes, so backtracking stays linear
-    const dimensionMatches = out.matchAll(/(\d+)\s+(\d+)/g) //NOSONAR
+    const dimensionMatches = out.matchAll(/\b(\d+)\s+(\d+)\b/g)
     const matches = Array.from(dimensionMatches)
 
     // Find the match that looks like terminal dimensions (not timestamps or other numbers)
@@ -205,8 +203,7 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
       () => {
         const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
         const text = rows.map((row) => row.textContent ?? '').join('\n')
-        // eslint-disable-next-line sonarjs/slow-regex -- digits and whitespace are disjoint character classes, so backtracking stays linear
-        return /\d+\s+\d+/.test(text)
+        return /\b\d+\s+\d+\b/.test(text)
       },
       { timeout: TIMEOUTS.CONNECTION },
     )
@@ -259,45 +256,25 @@ test.describe('V2 E2E: TERM, size, and replay credentials', () => {
     )
     // The client debounces the resize socket emission (RESIZE_DEBOUNCE_DELAY,
     // 150ms in webssh2_client) before notifying the server, and there is no
-    // client-visible DOM signal for "server applied the new PTY size". This
-    // settle time genuinely has no observable condition to synchronize on
-    // (see task-4 report), so a short fixed wait is kept intentionally.
-    // eslint-disable-next-line playwright/no-wait-for-timeout
-    await page.waitForTimeout(TIMEOUTS.SHORT_WAIT)
-
-    // Check size again (don't clear to preserve history)
-    await executeV2Command(page, 'stty size')
-
-    // Wait for the post-resize stty output to differ from the initial size
-    await page.waitForFunction(
-      (previousSize) => {
-        const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
-        const text = rows.map((row) => row.textContent ?? '').join('\n')
-        const matches = [...text.matchAll(/\b(\d+)\s+(\d+)\b/g)]
-        const last = matches.at(-1)
-        return last !== undefined && last[0] !== previousSize
-      },
-      initialSize,
-      { timeout: TIMEOUTS.CONNECTION },
-    )
-
-    // Get the new content after resize
-    const newOut: string = await getTerminalText()
-
-    // Find all size patterns in the output
-    const newSizeMatches: RegExpMatchArray[] = [...newOut.matchAll(/\b(\d+)\s+(\d+)\b/g)]
-
-    // The last match should be our new size
-    const lastSizeMatch: RegExpMatchArray | undefined = newSizeMatches.at(-1)
-
-    if (lastSizeMatch === undefined) {
-      throw new Error(`No size found after resize. Terminal output: ${newOut.slice(0, 500)}`)
-    }
-
-    const newSize: string = lastSizeMatch[0]
-
-    // Verify it's different from initial
-    expect(newSize).not.toBe(initialSize)
+    // client-visible DOM signal for "server applied the new PTY size". Rather
+    // than sleeping out the debounce, re-run `stty size` until the server
+    // reports a size that differs from the pre-resize one. Iterations that see
+    // no size at all report the initial size so the poll keeps retrying
+    // instead of passing on an empty reading.
+    let newSize: string = initialSize
+    await expect
+      .poll(
+        async () => {
+          // Check size again (don't clear to preserve history)
+          await executeV2Command(page, 'stty size')
+          const currentOut = await getTerminalText()
+          const currentMatches: RegExpMatchArray[] = [...currentOut.matchAll(/\b(\d+)\s+(\d+)\b/g)]
+          newSize = currentMatches.at(-1)?.[0] ?? initialSize
+          return newSize
+        },
+        { timeout: TIMEOUTS.CONNECTION },
+      )
+      .not.toBe(initialSize)
 
     // Verify we got reasonable values (not 0 0)
     expect(newSize).not.toBe('0 0')

--- a/tests/playwright/issue-102-header-smoke.spec.ts
+++ b/tests/playwright/issue-102-header-smoke.spec.ts
@@ -14,9 +14,9 @@
  */
 /* global document */
 import { test, expect, type Page } from '@playwright/test'
-import { BASE_URL } from './constants.js'
+import { BASE_URL, SSH_HOST, SSH_PORT, USERNAME, PASSWORD } from './constants.js'
 
-const SSH_QUERY = 'host=localhost&port=22'
+const SSH_QUERY = `host=${SSH_HOST}&port=${SSH_PORT}`
 
 // The Playwright config template (tests/playwright/assets/config.template.json)
 // sets header.background = "green" by default. When no URL override is applied,
@@ -55,9 +55,7 @@ async function getInjectedConfig(page: Page): Promise<WebSSH2Config | undefined>
 }
 
 function extractConfigFromHtml(html: string): WebSSH2Config {
-  const match = html.match(
-    /<script type="application\/json" id="webssh2-config">(.+?)<\/script>/s
-  )
+  const match = /<script type="application\/json" id="webssh2-config">(.+?)<\/script>/s.exec(html)
   if (match?.[1] === undefined) {
     throw new Error('webssh2-config JSON block not found in response HTML')
   }
@@ -179,23 +177,32 @@ test.describe('Issue #102 — headerStyle/Tailwind injection removal', () => {
     //
     // We assert by reading the POST response HTML — the rendered config
     // reflects what's in the session at the moment the response is produced.
-    const responseHtml = await page.evaluate(async (baseUrl) => {
-      const formData = new URLSearchParams({
-        host: 'localhost',
-        port: '22',
-        username: 'testuser',
-        password: 'testpassword',
-        'header.color': 'blue',
-      })
-      const res = await fetch(`${baseUrl}/ssh`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: formData.toString(),
-        // include cookies (same-origin is default but be explicit)
-        credentials: 'include',
-      })
-      return res.text()
-    }, BASE_URL)
+    const responseHtml = await page.evaluate(
+      async ({ baseUrl, host, port, username, password }) => {
+        const formData = new URLSearchParams({
+          host,
+          port,
+          username,
+          password,
+          'header.color': 'blue',
+        })
+        const res = await fetch(`${baseUrl}/ssh`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: formData.toString(),
+          // include cookies (same-origin is default but be explicit)
+          credentials: 'include',
+        })
+        return res.text()
+      },
+      {
+        baseUrl: BASE_URL,
+        host: SSH_HOST,
+        port: String(SSH_PORT),
+        username: USERNAME,
+        password: PASSWORD,
+      }
+    )
 
     const postResponseCfg = extractConfigFromHtml(responseHtml)
     expect(
@@ -214,22 +221,26 @@ test.describe('Issue #102 — headerStyle/Tailwind injection removal', () => {
     const initialCfg = await getInjectedConfig(page)
     expect(initialCfg?.header).toMatchObject({ text: 'STALE' })
 
-    const responseHtml = await page.evaluate(async (baseUrl) => {
-      const formData = new URLSearchParams({
-        host: 'localhost',
-        port: '22',
-        username: 'testuser',
-        password: 'testpassword',
+    const responseHtml = await page.evaluate(
+      async ({ baseUrl, host, port, username, password }) => {
         // no header.* fields at all
-      })
-      const res = await fetch(`${baseUrl}/ssh`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: formData.toString(),
-        credentials: 'include',
-      })
-      return res.text()
-    }, BASE_URL)
+        const formData = new URLSearchParams({ host, port, username, password })
+        const res = await fetch(`${baseUrl}/ssh`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: formData.toString(),
+          credentials: 'include',
+        })
+        return res.text()
+      },
+      {
+        baseUrl: BASE_URL,
+        host: SSH_HOST,
+        port: String(SSH_PORT),
+        username: USERNAME,
+        password: PASSWORD,
+      }
+    )
 
     const postResponseCfg = extractConfigFromHtml(responseHtml)
     // After clearing the session override, the rendered cfg falls back to the

--- a/tests/playwright/websocket-async-auth-v2.test.js
+++ b/tests/playwright/websocket-async-auth-v2.test.js
@@ -62,6 +62,11 @@ test.describe('V2 Async/Await Modal Login Authentication', () => {
 
     // Verify terminal functionality with async operations
     await verifyV2TerminalFunctionality(page, TEST_CONFIG.validUsername)
+
+    // The helper runs `whoami` and an echo; assert both landed in the session
+    const content = await getTerminalContent(page)
+    expect(content).toContain(TEST_CONFIG.validUsername)
+    expect(content).toContain('V2 test successful')
   })
 
   test('should handle async authentication error properly (V2)', async ({ page }) => {
@@ -122,8 +127,7 @@ test.describe('V2 Async/Await Modal Login Authentication', () => {
         // eslint-disable-next-line no-undef
         const rows = Array.from(document.querySelectorAll('.xterm-rows > div'))
         const text = rows.map((row) => row.textContent || '').join('\n')
-        // eslint-disable-next-line sonarjs/slow-regex -- digits and whitespace are disjoint character classes, so backtracking stays linear
-        return /\d+\s+\d+/.test(text)
+        return /\b\d+\s+\d+\b/.test(text)
       },
       { timeout: TIMEOUTS.CONNECTION }
     )
@@ -181,6 +185,11 @@ test.describe('V2 Async/Await HTTP Basic Authentication', () => {
 
     // Verify terminal functionality
     await verifyV2TerminalFunctionality(page, TEST_CONFIG.validUsername)
+
+    // The helper runs `whoami` and an echo; assert both landed in the session
+    const content = await getTerminalContent(page)
+    expect(content).toContain(TEST_CONFIG.validUsername)
+    expect(content).toContain('V2 test successful')
   })
 
   test('should show async auth error modal with invalid Basic Auth (V2)', async ({ page }) => {

--- a/tests/playwright/websocket-auth-v2.test.js
+++ b/tests/playwright/websocket-auth-v2.test.js
@@ -18,6 +18,7 @@ import {
   executeAndVerifyCommand,
   connectAndWaitForTerminal,
   fillFormDirectly,
+  getTerminalContent,
   validCredentials,
   invalidCredentials,
   credentialsWithPort
@@ -34,6 +35,9 @@ test.describe('V2 WebSocket Interactive Authentication', () => {
 
     // Verify terminal is functional
     await executeAndVerifyCommand(page, 'whoami', TEST_CONFIG.validUsername)
+
+    const content = await getTerminalContent(page)
+    expect(content).toContain(TEST_CONFIG.validUsername)
   })
 
   test('should show error with invalid credentials', async ({ page }) => {
@@ -93,6 +97,9 @@ test.describe('V2 WebSocket Basic Authentication', () => {
     // Verify terminal is functional
     await waitForV2Prompt(page)
     await executeAndVerifyCommand(page, 'echo "V2 Basic Auth works!"', 'V2 Basic Auth works!')
+
+    const content = await getTerminalContent(page)
+    expect(content).toContain('V2 Basic Auth works!')
   })
 
   test('should show auth error modal for invalid Basic Auth credentials', async ({ page }) => {
@@ -130,9 +137,14 @@ test.describe('V2 WebSocket Basic Authentication', () => {
     await waitForV2Prompt(page)
 
     // Execute multiple commands
-    await executeAndVerifyCommand(page, 'pwd', '/home/testuser')
+    await executeAndVerifyCommand(page, 'pwd', `/home/${TEST_CONFIG.validUsername}`)
     await executeAndVerifyCommand(page, 'ls -la', '.ssh')
     await executeAndVerifyCommand(page, 'uname -a', 'Linux')
+
+    // The last command's output is still on screen, proving the session
+    // survived all three commands rather than dropping partway through
+    const content = await getTerminalContent(page)
+    expect(content).toContain('Linux')
   })
 })
 
@@ -156,5 +168,9 @@ test.describe('V2 WebSocket Connection Resilience', () => {
     // Clean up
     await executeV2Command(page, `rm ${testFile}`)
     await executeAndVerifyCommand(page, `ls ${testFile}`, 'No such file')
+
+    // The file is gone at the end of the session it was created in
+    const content = await getTerminalContent(page)
+    expect(content).toContain('No such file')
   })
 })

--- a/tests/unit/auth/credential-processor.vitest.ts
+++ b/tests/unit/auth/credential-processor.vitest.ts
@@ -50,10 +50,10 @@ describe('extractPostCredentials', () => {
   })
   
   it('should return null for missing credentials', () => {
-    expect(extractPostCredentials({})).toBe(null)
-    expect(extractPostCredentials({ username: 'user' })).toBe(null)
-    expect(extractPostCredentials({ password: TEST_PASSWORDS.basic })).toBe(null)
-    expect(extractPostCredentials({ username: '', password: TEST_PASSWORDS.basic })).toBe(null)
+    expect(extractPostCredentials({})).toBeNull()
+    expect(extractPostCredentials({ username: 'user' })).toBeNull()
+    expect(extractPostCredentials({ password: TEST_PASSWORDS.basic })).toBeNull()
+    expect(extractPostCredentials({ username: '', password: TEST_PASSWORDS.basic })).toBeNull()
   })
   
   it('should convert string port to number', () => {
@@ -77,7 +77,7 @@ describe('extractPostCredentials', () => {
     
     const result = extractPostCredentials(body)
     
-    expect(result?.term).toBe(null)
+    expect(result?.term).toBeNull()
   })
 })
 
@@ -236,9 +236,9 @@ describe('extractReadyTimeout', () => {
   })
   
   it('should return null for invalid values', () => {
-    expect(extractReadyTimeout({})).toBe(null)
-    expect(extractReadyTimeout({ readyTimeout: 'invalid' })).toBe(null)
-    expect(extractReadyTimeout({ readyTimeout: -1000 })).toBe(null)
-    expect(extractReadyTimeout({ readyTimeout: 0 })).toBe(null)
+    expect(extractReadyTimeout({})).toBeNull()
+    expect(extractReadyTimeout({ readyTimeout: 'invalid' })).toBeNull()
+    expect(extractReadyTimeout({ readyTimeout: -1000 })).toBeNull()
+    expect(extractReadyTimeout({ readyTimeout: 0 })).toBeNull()
   })
 })

--- a/tests/unit/auth/header-processor.vitest.ts
+++ b/tests/unit/auth/header-processor.vitest.ts
@@ -47,11 +47,11 @@ describe('validateHeaderValue', () => {
   })
   
   it('should return null for invalid values', () => {
-    expect(validateHeaderValue(null)).toBe(null)
-    expect(validateHeaderValue(undefined)).toBe(null)
-    expect(validateHeaderValue('')).toBe(null)
-    expect(validateHeaderValue(123)).toBe(null)
-    expect(validateHeaderValue({})).toBe(null)
+    expect(validateHeaderValue(null)).toBeNull()
+    expect(validateHeaderValue(undefined)).toBeNull()
+    expect(validateHeaderValue('')).toBeNull()
+    expect(validateHeaderValue(123)).toBeNull()
+    expect(validateHeaderValue({})).toBeNull()
   })
   
   it('should remove control characters', () => {
@@ -126,7 +126,7 @@ describe('createHeaderOverride', () => {
 
     const result = createHeaderOverride(values, SourceType.POST)
 
-    expect(result).toBe(null)
+    expect(result).toBeNull()
   })
 
   it('should include only valid fields', () => {
@@ -199,9 +199,9 @@ describe('processHeaderParams', () => {
   })
   
   it('should return null for no valid params', () => {
-    expect(processHeaderParams(undefined)).toBe(null)
-    expect(processHeaderParams({})).toBe(null)
-    expect(processHeaderParams({ other: 'value' })).toBe(null)
+    expect(processHeaderParams(undefined)).toBeNull()
+    expect(processHeaderParams({})).toBeNull()
+    expect(processHeaderParams({ other: 'value' })).toBeNull()
   })
   
   it('should process POST parameters (no color extraction)', () => {
@@ -219,11 +219,11 @@ describe('processHeaderParams', () => {
   })
 
   it('returns null for legacy-only sources', () => {
-    expect(processHeaderParams({ headerStyle: 'bold' })).toBe(null)
-    expect(processHeaderParams({ 'header.color': 'red' })).toBe(null)
+    expect(processHeaderParams({ headerStyle: 'bold' })).toBeNull()
+    expect(processHeaderParams({ 'header.color': 'red' })).toBeNull()
     expect(
       processHeaderParams({ headerStyle: 'bold', 'header.color': 'red' })
-    ).toBe(null)
+    ).toBeNull()
   })
 })
 

--- a/tests/unit/auth/privatekey-authentication.vitest.ts
+++ b/tests/unit/auth/privatekey-authentication.vitest.ts
@@ -91,7 +91,7 @@ describe('Private Key Authentication - Issue #441', () => {
       // This is what BasicAuthProvider.getCredentials() does
       const credentials = convertToAuthCredentials(sshCreds)
 
-      expect(credentials).not.toBe(null)
+      expect(credentials).not.toBeNull()
       expect(credentials?.username).toBe(TEST_USERNAME)
       expect(credentials?.host).toBe(TEST_SSH.HOST)
       expect(credentials?.port).toBe(TEST_SSH.PORT)
@@ -107,7 +107,7 @@ describe('Private Key Authentication - Issue #441', () => {
       }
 
       const credentials = convertToAuthCredentials(sessionCreds)
-      expect(credentials).toBe(null)
+      expect(credentials).toBeNull()
     })
 
     it('should default to port 22 when port is missing from session credentials', () => {
@@ -119,7 +119,7 @@ describe('Private Key Authentication - Issue #441', () => {
       }
 
       const credentials = convertToAuthCredentials(sessionCreds)
-      expect(credentials).not.toBe(null)
+      expect(credentials).not.toBeNull()
       expect(credentials?.port).toBe(22)
     })
   })
@@ -129,7 +129,7 @@ describe('Private Key Authentication - Issue #441', () => {
       const config = createTestConfig()
       const extracted = extractConfigCredentials(config)
 
-      expect(extracted).not.toBe(null)
+      expect(extracted).not.toBeNull()
       expect(extracted?.username).toBe(TEST_USERNAME)
       expect(extracted?.privateKey).toBe(TEST_SSH_PRIVATE_KEY_VALID)
     })
@@ -138,7 +138,7 @@ describe('Private Key Authentication - Issue #441', () => {
       const config = createTestConfig({ passphrase: TEST_PASSPHRASE })
       const extracted = extractConfigCredentials(config)
 
-      expect(extracted).not.toBe(null)
+      expect(extracted).not.toBeNull()
       expect(extracted?.privateKey).toBe(TEST_SSH_PRIVATE_KEY_VALID)
       expect(extracted?.passphrase).toBe(TEST_PASSPHRASE)
     })
@@ -181,7 +181,7 @@ describe('Private Key Authentication - Issue #441', () => {
 
       // Step 4: Convert credentials (simulates BasicAuthProvider)
       const credentials = convertToAuthCredentials(sshCreds)
-      expect(credentials).not.toBe(null)
+      expect(credentials).not.toBeNull()
       expect(credentials?.privateKey).toBe(TEST_SSH_PRIVATE_KEY_VALID)
     })
 
@@ -228,7 +228,7 @@ describe('Private Key Authentication - Issue #441', () => {
       }
 
       const credentials = convertToAuthCredentials(sessionCreds)
-      expect(credentials).toBe(null)
+      expect(credentials).toBeNull()
     })
 
     it('should handle custom SSH port with privateKey', () => {
@@ -259,7 +259,7 @@ describe('Private Key Authentication - Issue #441', () => {
 
       // Bug was: credentials === null
       // Fix: credentials should be valid
-      expect(credentials).not.toBe(null)
+      expect(credentials).not.toBeNull()
       expect(credentials?.username).toBe('keyuser')
       expect(credentials?.privateKey).toBeTruthy()
     })

--- a/tests/unit/config-enhanced.vitest.ts
+++ b/tests/unit/config-enhanced.vitest.ts
@@ -345,9 +345,9 @@ describe('Enhanced Config - Validation Functions', () => {
     it('should validate SSH hosts correctly', () => {
       expect(validateSshHost('example.com')).toBe('example.com')
       expect(validateSshHost(TEST_IPS.PRIVATE_192)).toBe(TEST_IPS.PRIVATE_192)
-      expect(validateSshHost(null)).toBe(null)
-      expect(validateSshHost(undefined)).toBe(null)
-      expect(validateSshHost('')).toBe(null)
+      expect(validateSshHost(null)).toBeNull()
+      expect(validateSshHost(undefined)).toBeNull()
+      expect(validateSshHost('')).toBeNull()
       expect(() => validateSshHost('invalid host')).toThrow('contains spaces')
     })
   })

--- a/tests/unit/config/config-processor.vitest.ts
+++ b/tests/unit/config/config-processor.vitest.ts
@@ -23,7 +23,7 @@ describe('createDefaultConfig', () => {
     expect(config.ssh.term).toBe('xterm-256color')
     // Should auto-generate a secure secret (64 hex chars = 32 bytes)
     expect(config.session.secret).toBeDefined()
-    expect(config.session.secret.length).toBe(64)
+    expect(config.session.secret).toHaveLength(64)
     expect(config.session.name).toBe('webssh2.sid')
     expect(config.logging?.minimumLevel).toBe('info')
     expect(config.logging?.stdout?.enabled).toBe(true)

--- a/tests/unit/config/host-key-config.vitest.ts
+++ b/tests/unit/config/host-key-config.vitest.ts
@@ -27,29 +27,20 @@ function buildHostKeyConfig(
 }
 
 describe('resolveHostKeyMode', () => {
-  it('should set serverStore=true, clientStore=false for mode "server"', () => {
-    const config = buildHostKeyConfig({ mode: 'server' })
-    const result = resolveHostKeyMode(config)
+  it.each([
+    { mode: 'server', expectedServer: true, expectedClient: false },
+    { mode: 'client', expectedServer: false, expectedClient: true },
+    { mode: 'hybrid', expectedServer: true, expectedClient: true }
+  ] as const)(
+    'should set serverStore=$expectedServer, clientStore=$expectedClient for mode $mode',
+    ({ mode, expectedServer, expectedClient }) => {
+      const config = buildHostKeyConfig({ mode })
+      const result = resolveHostKeyMode(config)
 
-    expect(result.serverStore.enabled).toBe(true)
-    expect(result.clientStore.enabled).toBe(false)
-  })
-
-  it('should set serverStore=false, clientStore=true for mode "client"', () => {
-    const config = buildHostKeyConfig({ mode: 'client' })
-    const result = resolveHostKeyMode(config)
-
-    expect(result.serverStore.enabled).toBe(false)
-    expect(result.clientStore.enabled).toBe(true)
-  })
-
-  it('should set both stores true for mode "hybrid"', () => {
-    const config = buildHostKeyConfig({ mode: 'hybrid' })
-    const result = resolveHostKeyMode(config)
-
-    expect(result.serverStore.enabled).toBe(true)
-    expect(result.clientStore.enabled).toBe(true)
-  })
+      expect(result.serverStore.enabled).toBe(expectedServer)
+      expect(result.clientStore.enabled).toBe(expectedClient)
+    }
+  )
 
   it('should allow explicit flags to override mode defaults', () => {
     // mode=server normally sets clientStore=false, but explicit flag overrides

--- a/tests/unit/connection/ssh-validator.vitest.ts
+++ b/tests/unit/connection/ssh-validator.vitest.ts
@@ -227,7 +227,7 @@ describe('enhanceErrorMessage', () => {
     // Should truncate to 253 characters (max DNS label length)
     expect(result).toContain('DNS resolution failed')
     const match = /DNS resolution failed for '([^']+)'/.exec(result)
-    expect(match).not.toBe(null)
+    expect(match).not.toBeNull()
     if (match !== null) {
       expect(match[1]?.length).toBeLessThanOrEqual(253)
     }

--- a/tests/unit/routes/telnet-routes.vitest.ts
+++ b/tests/unit/routes/telnet-routes.vitest.ts
@@ -188,6 +188,6 @@ describe('telnet route handler protocol injection', () => {
     const routePaths = extractRoutes(router)
 
     // Should have: GET /, GET /config, GET /host/:host, POST /, POST /host/:host
-    expect(routePaths.length).toBe(5)
+    expect(routePaths).toHaveLength(5)
   })
 })

--- a/tests/unit/security/csp-report.vitest.ts
+++ b/tests/unit/security/csp-report.vitest.ts
@@ -35,12 +35,12 @@ describe('extractCspReport', () => {
   it('truncates over-long fields', () => {
     const long = 'x'.repeat(2000)
     const r = extractCspReport({ 'csp-report': { 'document-uri': long } })
-    expect(r.documentUri!.length).toBe(512)
+    expect(r.documentUri!).toHaveLength(512)
   })
 
   it('truncates script-sample to 80 chars', () => {
     const r = extractCspReport({ 'csp-report': { 'script-sample': 'y'.repeat(500) } })
-    expect(r.scriptSample!.length).toBe(80)
+    expect(r.scriptSample!).toHaveLength(80)
   })
 
   it('ignores non-string fields', () => {

--- a/tests/unit/services/sftp/security-fuzzing.vitest.ts
+++ b/tests/unit/services/sftp/security-fuzzing.vitest.ts
@@ -370,16 +370,6 @@ describe('defense-in-depth: validator + escaping chain', () => {
       }
     })
 
-    it('blocks traversal out of allowed path', () => {
-      const result = validatePath('/home/user/../../etc/passwd', restrictedOptions)
-      expect(result.ok).toBe(false)
-    })
-
-    it('blocks blocked extension within allowed path', () => {
-      const result = validatePath('/home/user/malware.exe', restrictedOptions)
-      expect(result.ok).toBe(false)
-    })
-
     it('allows file with shell chars in allowed path', () => {
       const result = validatePath("/home/user/my 'special' file.txt", restrictedOptions)
       expect(result.ok).toBe(true)
@@ -388,8 +378,12 @@ describe('defense-in-depth: validator + escaping chain', () => {
       }
     })
 
-    it('rejects injection attempt that tries to escape allowed path', () => {
-      const result = validatePath("/home/user/../admin/'; rm -rf /", restrictedOptions)
+    it.each([
+      ['blocks traversal out of allowed path', '/home/user/../../etc/passwd'],
+      ['blocks blocked extension within allowed path', '/home/user/malware.exe'],
+      ['rejects injection attempt that tries to escape allowed path', "/home/user/../admin/'; rm -rf /"]
+    ])('%s', (_scenario, path) => {
+      const result = validatePath(path, restrictedOptions)
       expect(result.ok).toBe(false)
     })
   })

--- a/tests/unit/services/sftp/transfer-manager.vitest.ts
+++ b/tests/unit/services/sftp/transfer-manager.vitest.ts
@@ -605,7 +605,7 @@ describe('transfer-manager', () => {
       // TypeScript ensures this is a TransferId - if it compiles, it's correct
       // Just verify it's a string at runtime
       expect(typeof id).toBe('string')
-      expect(id.length).toBe(36) // UUID length
+      expect(id).toHaveLength(36) // UUID length
     })
   })
 })

--- a/tests/unit/socket-v2-exec-edge-cases.vitest.ts
+++ b/tests/unit/socket-v2-exec-edge-cases.vitest.ts
@@ -37,15 +37,12 @@ describe('Socket V2 Exec Edge Cases', () => {
     // The command is coerced to string "123" and processed (no error emitted)
     // Note: service-socket-terminal.ts uses String() coercion for robustness
     const ssherrorEmits = emittedEvents.filter(e => e.event === 'ssherror')
-    expect(ssherrorEmits.length).toBe(0)
+    expect(ssherrorEmits).toHaveLength(0)
   })
 
   it('exec: processes exec requests through service layer', async () => {
     await setupAuthenticatedSocket(io, mockSocket)
-
-    // With services, exec requests are processed differently
-    // This test just verifies the socket handler accepts exec events
-    // without crashing (detailed exec testing is in exec-handler unit tests)
+    const emittedEvents = trackEmittedEvents(mockSocket)
 
     // Send exec request
     EventEmitter.prototype.emit.call(mockSocket, 'exec', {
@@ -57,7 +54,8 @@ describe('Socket V2 Exec Edge Cases', () => {
 
     await waitForAsync(3)
 
-    // Test passes if no exceptions were thrown
-    expect(true).toBe(true)
+    // The service layer streams the command output back without erroring
+    expect(emittedEvents.map(e => e.event)).not.toContain('ssherror')
+    expect(emittedEvents.map(e => e.event)).toContain('data')
   })
 })

--- a/tests/unit/socket-v2-exec.vitest.ts
+++ b/tests/unit/socket-v2-exec.vitest.ts
@@ -65,7 +65,7 @@ describe('Socket V2 Exec Handler', () => {
 
     // With services, exec is processed without emitting errors
     const errorEvents = mockSocket.emit.mock.calls.filter((c: unknown[]) => c[0] === 'ssherror')
-    expect(errorEvents.length).toBe(0)
+    expect(errorEvents).toHaveLength(0)
   })
 
   it('should emit error when exec payload is invalid', () => {

--- a/tests/unit/socket-v2-terminal-control.vitest.ts
+++ b/tests/unit/socket-v2-terminal-control.vitest.ts
@@ -58,7 +58,7 @@ describe('Socket V2 Terminal and Control', () => {
 
     // V2 should silently ignore invalid resize values without emitting errors
     const errorEvents = filterEventsByType(emittedEvents, 'ssherror')
-    expect(errorEvents.length).toBe(0)
+    expect(errorEvents).toHaveLength(0)
   })
 
   it('control: silently ignores invalid control commands (V2 improvement)', async () => {

--- a/tests/unit/socket/handlers/prompt-validator.vitest.ts
+++ b/tests/unit/socket/handlers/prompt-validator.vitest.ts
@@ -211,20 +211,12 @@ describe('Prompt Validator', () => {
       { action: 'cancel', label: 'Cancel' }
     ]
 
-    it('should accept valid button action', () => {
-      const result = validateResponseAction('submit', buttons)
-
-      expect(result.ok).toBe(true)
-    })
-
-    it('should accept dismissed action', () => {
-      const result = validateResponseAction('dismissed', buttons)
-
-      expect(result.ok).toBe(true)
-    })
-
-    it('should accept timeout action', () => {
-      const result = validateResponseAction('timeout', buttons)
+    it.each([
+      ['valid button action', 'submit'],
+      ['dismissed action', 'dismissed'],
+      ['timeout action', 'timeout']
+    ])('should accept %s', (_description, action) => {
+      const result = validateResponseAction(action, buttons)
 
       expect(result.ok).toBe(true)
     })

--- a/tests/unit/types/result.vitest.ts
+++ b/tests/unit/types/result.vitest.ts
@@ -154,7 +154,7 @@ describe('Result type', () => {
     
     it('returns null on error', () => {
       const result = err('error')
-      expect(toNullable(result)).toBe(null)
+      expect(toNullable(result)).toBeNull()
     })
   })
   

--- a/tests/unit/utils-parse-env-vars.vitest.ts
+++ b/tests/unit/utils-parse-env-vars.vitest.ts
@@ -12,19 +12,13 @@ describe('parseEnvVars', () => {
     expect(result).toEqual({ FOO: 'bar', BAR: 'baz' })
   })
 
-  it('rejects invalid keys overall (no valid pairs)', () => {
-    const result: Record<string, string> | null = parseEnvVars('foo:bar,A-B:1,1X:2')
-    expect(result).toEqual(null)
-  })
-
-  it('rejects dangerous values overall (no valid pairs)', () => {
-    const result: Record<string, string> | null = parseEnvVars('FOO:bar;rm -rf /,BAR:baz|whoami')
-    expect(result).toEqual(null)
-  })
-
-  it('ignores malformed entries', () => {
-    const result: Record<string, string> | null = parseEnvVars('A,A:, :B,A:B:C')
-    expect(result).toEqual(null)
+  it.each([
+    ['rejects invalid keys overall (no valid pairs)', 'foo:bar,A-B:1,1X:2'],
+    ['rejects dangerous values overall (no valid pairs)', 'FOO:bar;rm -rf /,BAR:baz|whoami'],
+    ['ignores malformed entries', 'A,A:, :B,A:B:C']
+  ])('%s', (_scenario, input) => {
+    const result: Record<string, string> | null = parseEnvVars(input)
+    expect(result).toBeNull()
   })
 
   it('applies key/value length caps and pair cap', () => {
@@ -39,7 +33,7 @@ describe('parseEnvVars', () => {
     const out: Record<string, string> | null = parseEnvVars(many)
     expect(out).not.toBeNull()
     if (out !== null) {
-      expect(Object.keys(out).length).toBe(50)
+      expect(Object.keys(out)).toHaveLength(50)
       expect(out['K0']).toBe('v0')
       expect(out['K49']).toBe('v49')
       expect(out['K59']).toBeUndefined()

--- a/tests/unit/utils/html-transformer.vitest.ts
+++ b/tests/unit/utils/html-transformer.vitest.ts
@@ -74,12 +74,13 @@ describe('transformHtml', () => {
   it('should be pure - not mutate inputs', () => {
     const html = '<link href="styles.css">'
     const config = { test: 'value' }
-    const originalHtml = html
     const originalConfig = { ...config }
 
-    transformHtml(html, config)
+    const result = transformHtml(html, config)
 
-    expect(html).toBe(originalHtml)
+    // Strings are immutable, so purity here means a new value is returned and
+    // the caller's config object is left untouched
+    expect(result).toBe('<link href="/ssh/assets/styles.css">')
     expect(config).toEqual(originalConfig)
   })
 })

--- a/tests/unit/validation-credentials.vitest.ts
+++ b/tests/unit/validation-credentials.vitest.ts
@@ -80,7 +80,7 @@ describe('Credential Validation Functions', () => {
         password: TEST_PASSWORDS.secret
       })
       expect(result.valid).toBe(true)
-      expect(result.errors.length).toBe(0)
+      expect(result.errors).toHaveLength(0)
     })
 
     it('should detect missing username', () => {
@@ -159,7 +159,7 @@ describe('Credential Validation Functions', () => {
         privateKey: 'key'
       })
       expect(result.valid).toBe(true)
-      expect(result.errors.length).toBe(0)
+      expect(result.errors).toHaveLength(0)
     })
   })
 })

--- a/tests/unit/validation-ssh.vitest.ts
+++ b/tests/unit/validation-ssh.vitest.ts
@@ -66,12 +66,12 @@ describe('SSH Validation Functions', () => {
     })
 
     it('should reject invalid terminal types', () => {
-      expect(validateTerm('')).toBe(null)
-      expect(validateTerm()).toBe(null)
-      expect(validateTerm('xterm; rm -rf /')).toBe(null)
-      expect(validateTerm('a'.repeat(31))).toBe(null) // Too long
-      expect(validateTerm('xterm$')).toBe(null) // Invalid char
-      expect(validateTerm('xterm&')).toBe(null) // Invalid char
+      expect(validateTerm('')).toBeNull()
+      expect(validateTerm()).toBeNull()
+      expect(validateTerm('xterm; rm -rf /')).toBeNull()
+      expect(validateTerm('a'.repeat(31))).toBeNull() // Too long
+      expect(validateTerm('xterm$')).toBeNull() // Invalid char
+      expect(validateTerm('xterm&')).toBeNull() // Invalid char
     })
   })
 

--- a/tests/unit/validation/socket-messages.vitest.ts
+++ b/tests/unit/validation/socket-messages.vitest.ts
@@ -470,7 +470,7 @@ describe('Socket Message Validation', () => {
 
       expect(result.ok).toBe(true)
       if (result.ok && result.value.env !== undefined) {
-        expect(Object.keys(result.value.env).length).toBe(50)
+        expect(Object.keys(result.value.env)).toHaveLength(50)
       }
     })
 


### PR DESCRIPTION
## Summary

Batches three ready-to-land maintenance items into one PR:

1. **Pin webssh2_client 5.4.2** — picks up the SFTP pre-transfer rejection fix
   (billchurch/webssh2_client#148 / webssh2_client#147), turning the last red
   Playwright spec (`e2e-sftp.spec.ts` blocked-extension upload) green.
   Bundle verified via `npm run security:verify-bundle` (provenance + checksums).
2. **De-hardcode issue-102 smoke spec** — `issue-102-header-smoke.spec.ts` now
   imports `SSH_HOST` / `SSH_PORT` / `USERNAME` / `PASSWORD` from
   `tests/playwright/constants.js` and passes them into the S6/S7
   `page.evaluate` bodies as arguments (browser context cannot close over Node
   imports). Also swaps `html.match()` for `RegExp.exec()`
   (sonarjs/prefer-regexp-exec).
3. **Adopt eslint-plugin-sonarjs 4.2.0** — un-pins from exact 4.0.3 (pinned in
   #565 to keep #550 scoped; 4.2.0 published 2026-07-14, 14-day quarantine
   satisfied) and fixes all findings instead of disabling rules:
   - `prefer-specific-assertions` (58) — rewritten to `toHaveLength` /
     `toBeInstanceOf` / `toContain` / `toHaveProperty` etc.
   - `super-linear-regex` (5) — backtracking-ambiguous regexes rewritten,
     including the `dd ... of=/dev/` detector in
     `app/socket/handlers/exec-safety.ts`; stale
     `eslint-disable sonarjs/slow-regex` directives removed
   - `assertions-in-tests` (6), `parameterized-tests` (4),
     `no-trivial-assertions` (2), `no-fixed-wait-in-tests` (1)

## Gates

- `npm run lint` — 0 errors, warnings at/below the pre-existing baseline
- `npm run typecheck` — clean
- `npm run test` — all Vitest tests pass
- `CONTAINER_RUNTIME=docker ENABLE_E2E_SSH=1 npx playwright test` — 64/64
- `npm run security:verify-bundle` — webssh2_client@5.4.2 verified

Fixes #566
Fixes #567
Fixes #570
